### PR TITLE
Dynamic model list per AI engine

### DIFF
--- a/app/src/main/java/io/apicurio/axiom/app/rest/SystemResourceImpl.java
+++ b/app/src/main/java/io/apicurio/axiom/app/rest/SystemResourceImpl.java
@@ -89,13 +89,14 @@ public class SystemResourceImpl implements SystemResource {
     /**
      * {@inheritDoc}
      *
-     * Returns the available models for the active AI engine. For Claude Code,
-     * returns the static list from config. For OpenCode, returns models in
-     * provider/model format.
+     * Returns the available models for the specified engine, or the default
+     * engine if not specified. Claude Code returns short model names;
+     * OpenCode returns provider/model format.
      */
     @Override
-    public List<String> listModels() {
-        String models = "opencode".equals(aiEngine.getType())
+    public List<String> listModels(String engine) {
+        String engineType = (engine != null && !engine.isBlank()) ? engine : aiEngine.getType();
+        String models = "opencode".equals(engineType)
                 ? openCodeAvailableModels
                 : claudeAvailableModels;
 

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -63,8 +63,16 @@
       "get": {
         "tags": ["System"],
         "summary": "List available AI models",
-        "description": "Returns the list of AI models that can be used for action type configuration.",
+        "description": "Returns the list of AI models available for the specified engine, or the default engine if not specified.",
         "operationId": "listModels",
+        "parameters": [
+          {
+            "name": "engine",
+            "in": "query",
+            "description": "Engine type to list models for (e.g. opencode, claude-code). Defaults to the active engine.",
+            "schema": { "type": "string" }
+          }
+        ],
         "responses": {
           "200": {
             "content": {

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -116,8 +116,9 @@ export async function fetchSystemConfig(): Promise<SystemConfig> {
     return response.json();
 }
 
-export async function fetchModels(): Promise<string[]> {
-    const response = await fetch(`${API}/system/models`);
+export async function fetchModels(engine?: string): Promise<string[]> {
+    const params = engine ? `?engine=${encodeURIComponent(engine)}` : "";
+    const response = await fetch(`${API}/system/models${params}`);
     if (!response.ok) throw new Error(`Failed to fetch models: ${response.status}`);
     return response.json();
 }

--- a/ui/src/pages/ActionTypeDetailPage.tsx
+++ b/ui/src/pages/ActionTypeDetailPage.tsx
@@ -85,11 +85,19 @@ export function ActionTypeDetailPage() {
 
     useEffect(() => { loadData(); }, [loadData]);
     useEffect(() => {
-        fetchModels().then(setAvailableModels).catch(console.error);
         fetchEngines().then(setAvailableEngines).catch(console.error);
     }, []);
 
+    // Refetch models when the selected engine changes
+    useEffect(() => {
+        fetchModels(form.engine).then(setAvailableModels).catch(console.error);
+    }, [form.engine]);
+
     const updateForm = (updates: Partial<NewActionType>) => {
+        // Clear the model when the engine changes (models differ per engine)
+        if (updates.engine !== undefined && updates.engine !== form.engine) {
+            updates = { ...updates, model: undefined };
+        }
         setForm((prev) => ({ ...prev, ...updates }));
         setDirty(true);
     };


### PR DESCRIPTION
## Summary

When switching the AI engine on an action type, the model dropdown now refreshes to show models for the selected engine instead of always showing the global default's models.

## Changes

### API
- `GET /system/models` now accepts an optional `?engine=` query parameter
  - `?engine=opencode` returns `anthropic/claude-sonnet-4-6`, `openai/gpt-4o`, etc.
  - `?engine=claude-code` returns `claude-sonnet-4-6`, `opus`, etc.
  - No parameter returns models for the global default engine
- OpenAPI spec updated with the `engine` query parameter

### UI
- `fetchModels(engine?)` API function passes the engine parameter
- ActionTypeDetailPage refetches models when the engine dropdown changes
- Model selection is cleared when switching engines (since models differ between engines)

## How it works

1. Go to an **Action Type** detail page
2. Change the **AI Engine** dropdown to a different engine
3. The **Model** dropdown automatically refreshes with that engine's models
4. Previously selected model is cleared (it may not exist in the new engine)