### PR TITLE
Add IBM Bob as an alternate AI engine

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -47,6 +47,10 @@
         </dependency>
         <dependency>
             <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-axiom-engine-bob</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.apicurio</groupId>
             <artifactId>apicurio-axiom-actors-human</artifactId>
         </dependency>
         <dependency>

--- a/app/src/main/java/io/apicurio/axiom/app/rest/SystemResourceImpl.java
+++ b/app/src/main/java/io/apicurio/axiom/app/rest/SystemResourceImpl.java
@@ -89,13 +89,14 @@ public class SystemResourceImpl implements SystemResource {
     /**
      * {@inheritDoc}
      *
-     * Returns the available models for the active AI engine. For Claude Code,
-     * returns the static list from config. For OpenCode, returns models in
-     * provider/model format.
+     * Returns the available models for the specified engine, or the default
+     * engine if not specified. Claude Code returns short model names;
+     * OpenCode returns provider/model format.
      */
     @Override
-    public List<String> listModels() {
-        String models = "opencode".equals(aiEngine.getType())
+    public List<String> listModels(String engine) {
+        String engineType = (engine != null && !engine.isBlank()) ? engine : aiEngine.getType();
+        String models = "opencode".equals(engineType)
                 ? openCodeAvailableModels
                 : claudeAvailableModels;
 

--- a/app/src/main/java/io/apicurio/axiom/app/rest/SystemResourceImpl.java
+++ b/app/src/main/java/io/apicurio/axiom/app/rest/SystemResourceImpl.java
@@ -36,6 +36,10 @@ public class SystemResourceImpl implements SystemResource {
             defaultValue = "anthropic/claude-sonnet-4-6,anthropic/claude-opus-4-6,anthropic/claude-haiku-4-5-20251001,openai/gpt-4o,openai/o3-mini")
     String openCodeAvailableModels;
 
+    @ConfigProperty(name = "axiom.bob.available-models",
+            defaultValue = "granite,llama,mistral")
+    String bobAvailableModels;
+
     @Inject
     AiEngine aiEngine;
 
@@ -96,9 +100,14 @@ public class SystemResourceImpl implements SystemResource {
     @Override
     public List<String> listModels(String engine) {
         String engineType = (engine != null && !engine.isBlank()) ? engine : aiEngine.getType();
-        String models = "opencode".equals(engineType)
-                ? openCodeAvailableModels
-                : claudeAvailableModels;
+        String models;
+        if ("opencode".equals(engineType)) {
+            models = openCodeAvailableModels;
+        } else if ("bob".equals(engineType)) {
+            models = bobAvailableModels;
+        } else {
+            models = claudeAvailableModels;
+        }
 
         return Arrays.stream(models.split(","))
                 .map(String::trim)

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -73,6 +73,12 @@ axiom.opencode.max-steps=50
 # HTTP request timeout in seconds
 axiom.opencode.timeout-seconds=600
 
+# --- IBM Bob ---
+# Available models for the UI model picker (comma-separated)
+axiom.bob.available-models=granite,llama,mistral
+# Subprocess timeout in seconds
+axiom.bob.timeout-seconds=600
+
 # --- Workspaces ---
 # Root directory for project git clones
 axiom.workspace.root=${user.home}/.axiom/workspaces

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -63,8 +63,16 @@
       "get": {
         "tags": ["System"],
         "summary": "List available AI models",
-        "description": "Returns the list of AI models that can be used for action type configuration.",
+        "description": "Returns the list of AI models available for the specified engine, or the default engine if not specified.",
         "operationId": "listModels",
+        "parameters": [
+          {
+            "name": "engine",
+            "in": "query",
+            "description": "Engine type to list models for (e.g. opencode, claude-code). Defaults to the active engine.",
+            "schema": { "type": "string" }
+          }
+        ],
         "responses": {
           "200": {
             "content": {

--- a/engine/bob/pom.xml
+++ b/engine/bob/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.apicurio</groupId>
+        <artifactId>apicurio-axiom</artifactId>
+        <version>2.0.1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>apicurio-axiom-engine-bob</artifactId>
+    <name>Apicurio Axiom - Engine - IBM Bob</name>
+    <description>IBM Bob AI engine implementation</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-axiom-engine-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-axiom-actors-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/engine/bob/src/main/java/io/apicurio/axiom/engine/bob/BobActor.java
+++ b/engine/bob/src/main/java/io/apicurio/axiom/engine/bob/BobActor.java
@@ -1,0 +1,108 @@
+package io.apicurio.axiom.engine.bob;
+
+import io.apicurio.axiom.actors.spi.Actor;
+import io.apicurio.axiom.actors.spi.ActorContext;
+import io.apicurio.axiom.actors.spi.TaskResult;
+import io.apicurio.axiom.core.entities.TaskEntity;
+import io.apicurio.axiom.engine.spi.AiEngineConfig;
+import io.apicurio.axiom.engine.spi.AiEngineResult;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Actor implementation that executes tasks via IBM Bob Shell.
+ */
+@ApplicationScoped
+public class BobActor implements Actor {
+
+    private static final Logger LOG = Logger.getLogger(BobActor.class);
+
+    @Inject
+    BobEngine engine;
+
+    @ConfigProperty(name = "axiom.bob.timeout-seconds", defaultValue = "600")
+    int timeoutSeconds;
+
+    private final Map<Long, BobSubprocess> runningProcesses = new ConcurrentHashMap<>();
+
+    @Override
+    public String getType() {
+        return "bob";
+    }
+
+    @Override
+    public CompletableFuture<TaskResult> execute(TaskEntity task, ActorContext context) {
+        LOG.infof("Executing task %d (action: %s) via IBM Bob", task.id, task.actionType);
+
+        String prompt = buildPrompt(task, context);
+
+        AiEngineConfig engineConfig = AiEngineConfig.builder()
+                .systemPrompt(context.getSystemPrompt())
+                .allowedTools(context.getAllowedTools())
+                .disallowedTools(context.getDisallowedTools())
+                .workingDirectory(context.getWorkingDirectory())
+                .environment(context.getEnvironment() != null ? context.getEnvironment() : Map.of())
+                .timeoutSeconds(timeoutSeconds)
+                .build();
+
+        return engine.prompt(engineConfig, prompt)
+                .thenApply(result -> {
+                    runningProcesses.remove(task.id);
+                    return toTaskResult(result);
+                })
+                .exceptionally(throwable -> {
+                    runningProcesses.remove(task.id);
+                    LOG.errorf(throwable, "Task %d execution failed", task.id);
+                    return TaskResult.failure("Execution error: " + throwable.getMessage()).build();
+                });
+    }
+
+    @Override
+    public void cancel(TaskEntity task) {
+        BobSubprocess subprocess = runningProcesses.remove(task.id);
+        if (subprocess != null) {
+            LOG.infof("Cancelling task %d", task.id);
+            subprocess.kill();
+        }
+    }
+
+    private String buildPrompt(TaskEntity task, ActorContext context) {
+        String template = context.getPromptTemplate();
+        if (template != null && !template.isBlank()) {
+            return template;
+        }
+
+        StringBuilder prompt = new StringBuilder();
+        prompt.append("You are performing the following action: ").append(task.actionType).append("\n\n");
+        if (task.input != null && !task.input.isEmpty()) {
+            prompt.append("Task context:\n").append(task.input).append("\n");
+        }
+        return prompt.toString();
+    }
+
+    private TaskResult toTaskResult(AiEngineResult result) {
+        if (result.success()) {
+            return TaskResult.success(result.result())
+                    .sessionId(result.sessionId())
+                    .costUsd(result.costUsd())
+                    .inputTokens(result.inputTokens())
+                    .outputTokens(result.outputTokens())
+                    .executionLog(result.executionLog())
+                    .build();
+        } else {
+            return TaskResult.failure(result.result())
+                    .sessionId(result.sessionId())
+                    .costUsd(result.costUsd())
+                    .inputTokens(result.inputTokens())
+                    .outputTokens(result.outputTokens())
+                    .executionLog(result.executionLog())
+                    .build();
+        }
+    }
+}

--- a/engine/bob/src/main/java/io/apicurio/axiom/engine/bob/BobCommandBuilder.java
+++ b/engine/bob/src/main/java/io/apicurio/axiom/engine/bob/BobCommandBuilder.java
@@ -1,0 +1,57 @@
+package io.apicurio.axiom.engine.bob;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Builds the command line for launching an IBM Bob CLI subprocess
+ * in non-interactive mode.
+ */
+public class BobCommandBuilder {
+
+    private String prompt;
+    private String systemPrompt;
+    private boolean yolo = true;
+
+    public static BobCommandBuilder create(String prompt) {
+        BobCommandBuilder builder = new BobCommandBuilder();
+        builder.prompt = prompt;
+        return builder;
+    }
+
+    public BobCommandBuilder systemPrompt(String systemPrompt) {
+        this.systemPrompt = systemPrompt;
+        return this;
+    }
+
+    public BobCommandBuilder yolo(boolean yolo) {
+        this.yolo = yolo;
+        return this;
+    }
+
+    public List<String> build() {
+        List<String> cmd = new ArrayList<>();
+        cmd.add("bob");
+
+        // Bob uses API key auth in non-interactive mode
+        cmd.add("--auth-method");
+        cmd.add("api-key");
+
+        // Build the full prompt (system prompt prepended if present)
+        String fullPrompt;
+        if (systemPrompt != null && !systemPrompt.isBlank()) {
+            fullPrompt = systemPrompt + "\n\n---\n\n" + prompt;
+        } else {
+            fullPrompt = prompt;
+        }
+
+        cmd.add("-p");
+        cmd.add(fullPrompt);
+
+        if (yolo) {
+            cmd.add("--yolo");
+        }
+
+        return cmd;
+    }
+}

--- a/engine/bob/src/main/java/io/apicurio/axiom/engine/bob/BobCommandBuilder.java
+++ b/engine/bob/src/main/java/io/apicurio/axiom/engine/bob/BobCommandBuilder.java
@@ -33,7 +33,8 @@ public class BobCommandBuilder {
         List<String> cmd = new ArrayList<>();
         cmd.add("bob");
 
-        // Bob uses API key auth in non-interactive mode
+        // Accept license non-interactively and use API key auth
+        cmd.add("--accept-license");
         cmd.add("--auth-method");
         cmd.add("api-key");
 

--- a/engine/bob/src/main/java/io/apicurio/axiom/engine/bob/BobEngine.java
+++ b/engine/bob/src/main/java/io/apicurio/axiom/engine/bob/BobEngine.java
@@ -1,0 +1,148 @@
+package io.apicurio.axiom.engine.bob;
+
+import io.apicurio.axiom.engine.spi.AiEngine;
+import io.apicurio.axiom.engine.spi.AiEngineCheckResult;
+import io.apicurio.axiom.engine.spi.AiEngineConfig;
+import io.apicurio.axiom.engine.spi.AiEngineProvider;
+import io.apicurio.axiom.engine.spi.AiEngineResult;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Typed;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * IBM Bob CLI implementation of the {@link AiEngine} SPI. Wraps the Bob Shell
+ * CLI to provide engine-agnostic prompt execution.
+ *
+ * <p>Bob Shell runs in non-interactive mode via {@code bob -p "<prompt>"} and
+ * uses {@code BOBSHELL_API_KEY} for authentication.</p>
+ */
+@ApplicationScoped
+@Typed({BobEngine.class, AiEngineProvider.class})
+public class BobEngine implements AiEngine, AiEngineProvider {
+
+    @Override
+    public String getType() {
+        return "bob";
+    }
+
+    @Override
+    public CompletableFuture<AiEngineResult> prompt(AiEngineConfig config, String prompt) {
+        return executeInternal(config, prompt, null);
+    }
+
+    @Override
+    public CompletableFuture<AiEngineResult> promptWithSchema(AiEngineConfig config,
+                                                               String prompt,
+                                                               String jsonSchema) {
+        return executeInternal(config, prompt, jsonSchema);
+    }
+
+    @Override
+    public List<AiEngineCheckResult> healthCheck() {
+        List<AiEngineCheckResult> results = new ArrayList<>();
+
+        try {
+            ProcessBuilder pb = new ProcessBuilder("bob", "--auth-method", "api-key",
+                    "-p", "Reply with exactly: AXIOM_OK");
+            pb.redirectErrorStream(true);
+            Process process = pb.start();
+
+            boolean completed = process.waitFor(30, TimeUnit.SECONDS);
+            if (!completed) {
+                process.destroyForcibly();
+                results.add(new AiEngineCheckResult(
+                        "IBM Bob CLI",
+                        "error",
+                        "IBM Bob CLI check timed out after 30 seconds. "
+                                + "Ensure that the 'bob' command is on your PATH and that "
+                                + "BOBSHELL_API_KEY is set in your environment."
+                ));
+                return results;
+            }
+
+            String output = new String(process.getInputStream().readAllBytes());
+            int exitCode = process.exitValue();
+
+            if (exitCode == 0 && output.contains("AXIOM_OK")) {
+                results.add(new AiEngineCheckResult(
+                        "IBM Bob CLI",
+                        "ok",
+                        "IBM Bob CLI is available and working."
+                ));
+            } else {
+                results.add(new AiEngineCheckResult(
+                        "IBM Bob CLI",
+                        "error",
+                        "IBM Bob CLI returned exit code " + exitCode + ". "
+                                + "Ensure that the 'bob' command is installed, on your PATH, "
+                                + "and that BOBSHELL_API_KEY is set. "
+                                + "Install Bob Shell: curl -fsSL https://bob.ibm.com/download/bobshell.sh | bash"
+                ));
+            }
+        } catch (Exception e) {
+            results.add(new AiEngineCheckResult(
+                    "IBM Bob CLI",
+                    "error",
+                    "IBM Bob CLI is not available: " + e.getMessage() + ". "
+                            + "Install Bob Shell: curl -fsSL https://bob.ibm.com/download/bobshell.sh | bash"
+            ));
+        }
+
+        return results;
+    }
+
+    private CompletableFuture<AiEngineResult> executeInternal(AiEngineConfig config,
+                                                               String prompt,
+                                                               String jsonSchema) {
+        // If structured output is requested, inject schema instructions into the prompt
+        String effectivePrompt = prompt;
+        if (jsonSchema != null) {
+            effectivePrompt = prompt + "\n\nYou MUST respond with valid JSON conforming to "
+                    + "this schema:\n" + jsonSchema
+                    + "\n\nRespond ONLY with the JSON object, no other text.";
+        }
+
+        BobCommandBuilder cmdBuilder = BobCommandBuilder.create(effectivePrompt)
+                .systemPrompt(config.getSystemPrompt())
+                .yolo(true);
+
+        List<String> command = cmdBuilder.build();
+
+        java.io.File workDir = config.getWorkingDirectory() != null
+                ? config.getWorkingDirectory().toFile()
+                : null;
+
+        BobSubprocess subprocess = new BobSubprocess(
+                command, workDir,
+                config.getEnvironment() != null ? config.getEnvironment() : Map.of(),
+                Duration.ofSeconds(config.getTimeoutSeconds())
+        );
+
+        return subprocess.execute().thenApply(BobEngine::toEngineResult);
+    }
+
+    private static AiEngineResult toEngineResult(BobResult result) {
+        return new AiEngineResult(
+                result.result(),
+                null,
+                null,
+                null,
+                null,
+                result.isSuccess(),
+                null
+        );
+    }
+
+    // --- AiEngineProvider ---
+
+    @Override
+    public AiEngine getEngine() {
+        return this;
+    }
+}

--- a/engine/bob/src/main/java/io/apicurio/axiom/engine/bob/BobEngine.java
+++ b/engine/bob/src/main/java/io/apicurio/axiom/engine/bob/BobEngine.java
@@ -48,8 +48,8 @@ public class BobEngine implements AiEngine, AiEngineProvider {
         List<AiEngineCheckResult> results = new ArrayList<>();
 
         try {
-            ProcessBuilder pb = new ProcessBuilder("bob", "--auth-method", "api-key",
-                    "-p", "Reply with exactly: AXIOM_OK");
+            ProcessBuilder pb = new ProcessBuilder("bob", "--accept-license",
+                    "--auth-method", "api-key", "-p", "Reply with exactly: AXIOM_OK");
             pb.redirectErrorStream(true);
             Process process = pb.start();
 

--- a/engine/bob/src/main/java/io/apicurio/axiom/engine/bob/BobResult.java
+++ b/engine/bob/src/main/java/io/apicurio/axiom/engine/bob/BobResult.java
@@ -1,0 +1,18 @@
+package io.apicurio.axiom.engine.bob;
+
+/**
+ * Parsed result from an IBM Bob CLI invocation.
+ */
+public record BobResult(
+        String result,
+        int exitCode
+) {
+
+    public static BobResult failed(String errorMessage, int exitCode) {
+        return new BobResult(errorMessage, exitCode);
+    }
+
+    public boolean isSuccess() {
+        return exitCode == 0;
+    }
+}

--- a/engine/bob/src/main/java/io/apicurio/axiom/engine/bob/BobSubprocess.java
+++ b/engine/bob/src/main/java/io/apicurio/axiom/engine/bob/BobSubprocess.java
@@ -1,0 +1,130 @@
+package io.apicurio.axiom.engine.bob;
+
+import org.jboss.logging.Logger;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Manages an IBM Bob CLI subprocess. Handles launching the process,
+ * reading plain-text output, and enforcing timeouts.
+ */
+public class BobSubprocess {
+
+    private static final Logger LOG = Logger.getLogger(BobSubprocess.class);
+
+    private final List<String> command;
+    private final java.io.File workingDirectory;
+    private final Map<String, String> environment;
+    private final Duration timeout;
+
+    private Process process;
+
+    public BobSubprocess(List<String> command, java.io.File workingDirectory,
+                         Map<String, String> environment, Duration timeout) {
+        this.command = command;
+        this.workingDirectory = workingDirectory;
+        this.environment = environment;
+        this.timeout = timeout;
+    }
+
+    public CompletableFuture<BobResult> execute() {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                return doExecute();
+            } catch (Exception e) {
+                LOG.errorf(e, "Bob subprocess failed");
+                return BobResult.failed("Subprocess error: " + e.getMessage(), -1);
+            }
+        });
+    }
+
+    public void kill() {
+        if (process != null && process.isAlive()) {
+            LOG.warn("Killing Bob subprocess");
+            process.destroyForcibly();
+        }
+    }
+
+    private BobResult doExecute() throws IOException, InterruptedException {
+        LOG.infof("Launching Bob: %s", String.join(" ",
+                command.subList(0, Math.min(command.size(), 5))) + "...");
+
+        ProcessBuilder pb = new ProcessBuilder(command);
+        pb.redirectErrorStream(false);
+        pb.redirectInput(ProcessBuilder.Redirect.from(new java.io.File("/dev/null")));
+
+        if (workingDirectory != null) {
+            pb.directory(workingDirectory);
+        }
+
+        if (environment != null) {
+            pb.environment().putAll(environment);
+        }
+
+        process = pb.start();
+
+        StringBuilder stdoutContent = new StringBuilder();
+        StringBuilder stderrContent = new StringBuilder();
+
+        CompletableFuture<Void> stdoutFuture = CompletableFuture.runAsync(() -> {
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    if (!stdoutContent.isEmpty()) stdoutContent.append("\n");
+                    stdoutContent.append(line);
+                }
+            } catch (IOException e) {
+                LOG.warnf("Error reading Bob stdout: %s", e.getMessage());
+            }
+        });
+
+        CompletableFuture<Void> stderrFuture = CompletableFuture.runAsync(() -> {
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(process.getErrorStream(), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    stderrContent.append(line).append("\n");
+                    LOG.debugf("Bob stderr: %s", line);
+                }
+            } catch (IOException e) {
+                LOG.warnf("Error reading Bob stderr: %s", e.getMessage());
+            }
+        });
+
+        boolean completed = process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS);
+        if (!completed) {
+            LOG.warnf("Bob subprocess timed out after %s", timeout);
+            process.destroyForcibly();
+            process.waitFor(5, TimeUnit.SECONDS);
+            return new BobResult("Process timed out after " + timeout, 124);
+        }
+
+        stdoutFuture.join();
+        stderrFuture.join();
+
+        int exitCode = process.exitValue();
+        LOG.infof("Bob subprocess exited with code %d", exitCode);
+
+        if (exitCode != 0) {
+            String error = stderrContent.toString().trim();
+            if (error.isEmpty()) {
+                error = stdoutContent.toString().trim();
+            }
+            if (error.isEmpty()) {
+                error = "Process exited with code " + exitCode;
+            }
+            return new BobResult(error, exitCode);
+        }
+
+        return new BobResult(stdoutContent.toString(), exitCode);
+    }
+}

--- a/engine/bob/src/test/java/io/apicurio/axiom/engine/bob/BobCommandBuilderTest.java
+++ b/engine/bob/src/test/java/io/apicurio/axiom/engine/bob/BobCommandBuilderTest.java
@@ -13,6 +13,7 @@ class BobCommandBuilderTest {
         List<String> cmd = BobCommandBuilder.create("Hello").build();
 
         assertTrue(cmd.contains("bob"));
+        assertTrue(cmd.contains("--accept-license"));
         assertTrue(cmd.contains("--auth-method"));
         assertTrue(cmd.contains("api-key"));
         assertTrue(cmd.contains("-p"));

--- a/engine/bob/src/test/java/io/apicurio/axiom/engine/bob/BobCommandBuilderTest.java
+++ b/engine/bob/src/test/java/io/apicurio/axiom/engine/bob/BobCommandBuilderTest.java
@@ -1,0 +1,63 @@
+package io.apicurio.axiom.engine.bob;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BobCommandBuilderTest {
+
+    @Test
+    void testMinimalCommand() {
+        List<String> cmd = BobCommandBuilder.create("Hello").build();
+
+        assertTrue(cmd.contains("bob"));
+        assertTrue(cmd.contains("--auth-method"));
+        assertTrue(cmd.contains("api-key"));
+        assertTrue(cmd.contains("-p"));
+        assertTrue(cmd.contains("Hello"));
+        assertTrue(cmd.contains("--yolo"));
+    }
+
+    @Test
+    void testSystemPromptPrepended() {
+        List<String> cmd = BobCommandBuilder.create("Do the thing")
+                .systemPrompt("You are a helpful assistant")
+                .build();
+
+        int promptIndex = cmd.indexOf("-p");
+        String fullPrompt = cmd.get(promptIndex + 1);
+        assertTrue(fullPrompt.startsWith("You are a helpful assistant"),
+                "System prompt should be at the start");
+        assertTrue(fullPrompt.contains("---"),
+                "Should have separator between system prompt and user prompt");
+        assertTrue(fullPrompt.contains("Do the thing"),
+                "User prompt should be present");
+    }
+
+    @Test
+    void testNoSystemPrompt() {
+        List<String> cmd = BobCommandBuilder.create("Just a prompt").build();
+
+        int promptIndex = cmd.indexOf("-p");
+        String fullPrompt = cmd.get(promptIndex + 1);
+        assertEquals("Just a prompt", fullPrompt);
+    }
+
+    @Test
+    void testYoloDisabled() {
+        List<String> cmd = BobCommandBuilder.create("Read only task")
+                .yolo(false)
+                .build();
+
+        assertFalse(cmd.contains("--yolo"));
+    }
+
+    @Test
+    void testYoloEnabledByDefault() {
+        List<String> cmd = BobCommandBuilder.create("Write task").build();
+
+        assertTrue(cmd.contains("--yolo"));
+    }
+}

--- a/engine/bob/src/test/java/io/apicurio/axiom/engine/bob/BobEngineTest.java
+++ b/engine/bob/src/test/java/io/apicurio/axiom/engine/bob/BobEngineTest.java
@@ -1,0 +1,51 @@
+package io.apicurio.axiom.engine.bob;
+
+import io.apicurio.axiom.engine.spi.AiEngineCheckResult;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BobEngineTest {
+
+    @Test
+    void testGetType() {
+        BobEngine engine = new BobEngine();
+        assertEquals("bob", engine.getType());
+    }
+
+    @Test
+    void testGetActorTypeDefaultsToType() {
+        BobEngine engine = new BobEngine();
+        assertEquals("bob", engine.getActorType());
+    }
+
+    @Test
+    void testProviderReturnsItself() {
+        BobEngine engine = new BobEngine();
+        assertSame(engine, engine.getEngine());
+    }
+
+    @Test
+    void testProviderTypeMatchesEngineType() {
+        BobEngine engine = new BobEngine();
+        assertEquals(engine.getType(), engine.getType());
+    }
+
+    @Test
+    void testHealthCheckReturnsResults() {
+        BobEngine engine = new BobEngine();
+        List<AiEngineCheckResult> results = engine.healthCheck();
+
+        assertNotNull(results);
+        assertFalse(results.isEmpty());
+
+        AiEngineCheckResult cliCheck = results.stream()
+                .filter(r -> r.name().contains("IBM Bob"))
+                .findFirst()
+                .orElse(null);
+        assertNotNull(cliCheck, "Should have an IBM Bob CLI check result");
+        assertTrue("ok".equals(cliCheck.status()) || "error".equals(cliCheck.status()));
+    }
+}

--- a/engine/bob/src/test/java/io/apicurio/axiom/engine/bob/BobResultTest.java
+++ b/engine/bob/src/test/java/io/apicurio/axiom/engine/bob/BobResultTest.java
@@ -1,0 +1,34 @@
+package io.apicurio.axiom.engine.bob;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BobResultTest {
+
+    @Test
+    void testSuccessfulResult() {
+        BobResult result = new BobResult("Analysis complete", 0);
+
+        assertTrue(result.isSuccess());
+        assertEquals("Analysis complete", result.result());
+        assertEquals(0, result.exitCode());
+    }
+
+    @Test
+    void testFailedResult() {
+        BobResult result = BobResult.failed("Process crashed", 1);
+
+        assertFalse(result.isSuccess());
+        assertEquals("Process crashed", result.result());
+        assertEquals(1, result.exitCode());
+    }
+
+    @Test
+    void testTimeoutResult() {
+        BobResult result = BobResult.failed("Timed out", 124);
+
+        assertFalse(result.isSuccess());
+        assertEquals(124, result.exitCode());
+    }
+}

--- a/engine/bob/src/test/java/io/apicurio/axiom/engine/bob/BobSubprocessTest.java
+++ b/engine/bob/src/test/java/io/apicurio/axiom/engine/bob/BobSubprocessTest.java
@@ -1,0 +1,92 @@
+package io.apicurio.axiom.engine.bob;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests that actually launch the IBM Bob CLI.
+ *
+ * <p>These tests are <strong>disabled by default</strong>. To enable them, set the
+ * environment variable {@code AXIOM_BOB_TESTS=true} before running:</p>
+ *
+ * <pre>
+ * AXIOM_BOB_TESTS=true mvn test -pl engine/bob
+ * </pre>
+ *
+ * <p>Requirements:</p>
+ * <ul>
+ *   <li>The {@code bob} CLI must be installed and on the PATH</li>
+ *   <li>A valid {@code BOBSHELL_API_KEY} must be set in the environment</li>
+ * </ul>
+ */
+@EnabledIfEnvironmentVariable(named = "AXIOM_BOB_TESTS", matches = "true")
+class BobSubprocessTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void testSimplePrompt() throws ExecutionException, InterruptedException, TimeoutException {
+        List<String> cmd = BobCommandBuilder.create("Reply with exactly: HELLO AXIOM")
+                .yolo(false)
+                .build();
+
+        BobSubprocess subprocess = new BobSubprocess(
+                cmd, tempDir.toFile(), Map.of(), Duration.ofSeconds(60));
+
+        BobResult result = subprocess.execute()
+                .get(90, TimeUnit.SECONDS);
+
+        assertTrue(result.isSuccess(), "Expected success but got exit code " + result.exitCode());
+        assertNotNull(result.result(), "Result text should not be null");
+        assertTrue(result.result().contains("HELLO AXIOM"),
+                "Expected result to contain 'HELLO AXIOM' but got: " + result.result());
+    }
+
+    @Test
+    void testTimeoutEnforcement() throws ExecutionException, InterruptedException, TimeoutException {
+        List<String> cmd = BobCommandBuilder
+                .create("Write a 5000 word essay about the history of computing")
+                .yolo(false)
+                .build();
+
+        BobSubprocess subprocess = new BobSubprocess(
+                cmd, tempDir.toFile(), Map.of(), Duration.ofSeconds(5));
+
+        BobResult result = subprocess.execute()
+                .get(30, TimeUnit.SECONDS);
+
+        assertFalse(result.isSuccess(), "Should have timed out");
+        assertEquals(124, result.exitCode(), "Timeout exit code should be 124");
+    }
+
+    @Test
+    void testCancellation() throws InterruptedException {
+        List<String> cmd = BobCommandBuilder
+                .create("Write a very long essay about every programming language ever created")
+                .yolo(false)
+                .build();
+
+        BobSubprocess subprocess = new BobSubprocess(
+                cmd, tempDir.toFile(), Map.of(), Duration.ofSeconds(120));
+
+        var future = subprocess.execute();
+
+        Thread.sleep(3000);
+        subprocess.kill();
+
+        BobResult result = future.join();
+        assertFalse(result.isSuccess(), "Cancelled task should not be successful");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <module>core</module>
         <module>engine/spi</module>
         <module>engine/opencode</module>
+        <module>engine/bob</module>
         <module>manager</module>
         <module>actors/spi</module>
         <module>actors/claude-code</module>
@@ -92,6 +93,11 @@
             <dependency>
                 <groupId>io.apicurio</groupId>
                 <artifactId>apicurio-axiom-engine-opencode</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.apicurio</groupId>
+                <artifactId>apicurio-axiom-engine-bob</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -116,8 +116,9 @@ export async function fetchSystemConfig(): Promise<SystemConfig> {
     return response.json();
 }
 
-export async function fetchModels(): Promise<string[]> {
-    const response = await fetch(`${API}/system/models`);
+export async function fetchModels(engine?: string): Promise<string[]> {
+    const params = engine ? `?engine=${encodeURIComponent(engine)}` : "";
+    const response = await fetch(`${API}/system/models${params}`);
     if (!response.ok) throw new Error(`Failed to fetch models: ${response.status}`);
     return response.json();
 }

--- a/ui/src/pages/ActionTypeDetailPage.tsx
+++ b/ui/src/pages/ActionTypeDetailPage.tsx
@@ -85,11 +85,19 @@ export function ActionTypeDetailPage() {
 
     useEffect(() => { loadData(); }, [loadData]);
     useEffect(() => {
-        fetchModels().then(setAvailableModels).catch(console.error);
         fetchEngines().then(setAvailableEngines).catch(console.error);
     }, []);
 
+    // Refetch models when the selected engine changes
+    useEffect(() => {
+        fetchModels(form.engine).then(setAvailableModels).catch(console.error);
+    }, [form.engine]);
+
     const updateForm = (updates: Partial<NewActionType>) => {
+        // Clear the model when the engine changes (models differ per engine)
+        if (updates.engine !== undefined && updates.engine !== form.engine) {
+            updates = { ...updates, model: undefined };
+        }
         setForm((prev) => ({ ...prev, ...updates }));
         setDirty(true);
     };

--- a/ui/src/pages/EngineSettingsPage.tsx
+++ b/ui/src/pages/EngineSettingsPage.tsx
@@ -60,7 +60,7 @@ export function EngineSettingsPage() {
     }
 
     const engineName = config.engine || "unknown";
-    const engineLabel = engineName === "opencode" ? "OpenCode" : engineName === "claude-code" ? "Claude Code" : engineName;
+    const engineLabel = engineName === "opencode" ? "OpenCode" : engineName === "claude-code" ? "Claude Code" : engineName === "bob" ? "IBM Bob" : engineName;
     const engineChecks = (config.checks || []).filter(
         (c) => !["GitHub API Token", "Node.js"].includes(c.name)
     );


### PR DESCRIPTION
## Summary

- Adds IBM Bob Shell as a third AI engine alongside Claude Code and OpenCode
- New `engine/bob` Maven module with `BobEngine`, `BobActor`, `BobCommandBuilder`, `BobSubprocess`, and `BobResult`
- Bob runs in non-interactive CLI mode (`bob -p`) with API key auth (`BOBSHELL_API_KEY`)
- Wired into root pom, app module, application.properties, SystemResourceImpl, and UI engine label

## Test plan

- [x] Unit tests pass (13 tests): `BobResultTest`, `BobCommandBuilderTest`, `BobEngineTest`
- [x] Integration tests gated by `AXIOM_BOB_TESTS=true` (3 tests skipped when Bob not installed)
- [x] Full app module tests pass (93 tests)
- [x] Manual: set `axiom.ai-engine=bob` and verify engine appears in UI settings page
- [ ] Manual: with Bob CLI installed, verify health check returns "ok"

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)