### PR TITLE
Add configurable claude CLI executable path

### DIFF
--- a/actors/claude-code/src/main/java/io/apitomy/axiom/actors/claudecode/ClaudeCodeCommandBuilder.java
+++ b/actors/claude-code/src/main/java/io/apitomy/axiom/actors/claudecode/ClaudeCodeCommandBuilder.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
  */
 public class ClaudeCodeCommandBuilder {
 
+    private String executable = "claude";
     private String prompt;
     private Path workingDirectory;
     private String model;
@@ -41,6 +42,11 @@ public class ClaudeCodeCommandBuilder {
         builder.systemPrompt = context.getSystemPrompt();
         builder.mcpConfigFile = context.getMcpConfigFile();
         return builder;
+    }
+
+    public ClaudeCodeCommandBuilder executable(String executable) {
+        this.executable = executable;
+        return this;
     }
 
     public ClaudeCodeCommandBuilder model(String model) {
@@ -85,7 +91,7 @@ public class ClaudeCodeCommandBuilder {
      */
     public List<String> build() {
         List<String> cmd = new ArrayList<>();
-        cmd.add("claude");
+        cmd.add(executable);
         cmd.add("-p");
         cmd.add(prompt);
 

--- a/actors/claude-code/src/main/java/io/apitomy/axiom/actors/claudecode/ClaudeCodeEngine.java
+++ b/actors/claude-code/src/main/java/io/apitomy/axiom/actors/claudecode/ClaudeCodeEngine.java
@@ -10,6 +10,7 @@ import io.apitomy.axiom.engine.spi.AiEngineResult;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Typed;
 import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -31,6 +32,9 @@ import java.util.concurrent.TimeUnit;
 @ApplicationScoped
 @Typed({ClaudeCodeEngine.class, AiEngineProvider.class})
 public class ClaudeCodeEngine implements AiEngine, AiEngineProvider {
+
+    @ConfigProperty(name = "axiom.claude-code.executable", defaultValue = "claude")
+    String executable;
 
     @Inject
     ClaudeCodeMcpManager mcpManager;
@@ -57,7 +61,7 @@ public class ClaudeCodeEngine implements AiEngine, AiEngineProvider {
         List<AiEngineCheckResult> results = new ArrayList<>();
 
         try {
-            ProcessBuilder pb = new ProcessBuilder("claude", "-p", "Reply with exactly: AXIOM_OK",
+            ProcessBuilder pb = new ProcessBuilder(executable, "-p", "Reply with exactly: AXIOM_OK",
                     "--bare", "--output-format", "text", "--max-turns", "1");
             pb.redirectErrorStream(true);
             Process process = pb.start();
@@ -130,6 +134,7 @@ public class ClaudeCodeEngine implements AiEngine, AiEngineProvider {
         // Build command
         ClaudeCodeCommandBuilder cmdBuilder = ClaudeCodeCommandBuilder
                 .fromContext(prompt, actorContext)
+                .executable(executable)
                 .streamJson(true)
                 .maxTurns(config.getMaxSteps());
 

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -49,6 +49,8 @@ axiom.manager.max-turns=5
 # axiom.manager.model=claude-sonnet-4-6
 
 # --- Claude Code ---
+# Path to the claude CLI executable (defaults to "claude" on PATH)
+# axiom.claude-code.executable=/usr/local/bin/claude
 # Model to use (optional, defaults to Claude Code's default)
 # axiom.claude-code.model=claude-sonnet-4-6
 # Available models for the UI model picker (comma-separated)


### PR DESCRIPTION
## Summary

- Add `axiom.claude-code.executable` config property (default: `"claude"`) so users can specify the full path to the Claude Code CLI binary when it is not on the Java process's PATH
- Replaces hardcoded `"claude"` in `ClaudeCodeCommandBuilder.build()` and `ClaudeCodeEngine.healthCheck()`

Fixes #7

## Test plan
- [ ] Start Axiom with default config — verify Claude Code works as before (uses `claude` from PATH)
- [ ] Set `axiom.claude-code.executable=/full/path/to/claude` in application.properties — verify subprocess uses the configured path
- [ ] Verify health check uses the configured executable path

🤖 Generated with [Claude Code](https://claude.com/claude-code)