### PR TITLE
Add interactive AI Assistant feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ yarn-error.log
 # Build output
 dist/
 
+# Plans
+docs/plans/
+
 # Runtime data
 data/
 logs/

--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantContextBuilder.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantContextBuilder.java
@@ -1,0 +1,219 @@
+package io.apitomy.axiom.app.assistant;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Creates the working directory structure for an assistant session, including
+ * the {@code CLAUDE.md} system prompt and {@code mcp-config.json} for the
+ * Axiom Assistant MCP server.
+ */
+@ApplicationScoped
+public class AssistantContextBuilder {
+
+    private static final Logger LOG = Logger.getLogger(AssistantContextBuilder.class);
+
+    @ConfigProperty(name = "quarkus.http.port", defaultValue = "8080")
+    int httpPort;
+
+    /**
+     * Creates the full working directory for an assistant session.
+     *
+     * @param sessionId the unique session identifier
+     * @param mcpServerDir path to the installed assistant MCP server, or null if
+     *                     not yet installed
+     * @return the path to the created working directory
+     * @throws IOException if directory creation fails
+     */
+    public Path createWorkingDirectory(String sessionId, Path mcpServerDir) throws IOException {
+        Path axiomHome = Path.of(System.getProperty("user.home"), ".axiom");
+        Path sessionsRoot = axiomHome.resolve("assistant-sessions");
+        Path sessionDir = sessionsRoot.resolve(sessionId);
+
+        Files.createDirectories(sessionDir.resolve("tools"));
+        Files.createDirectories(sessionDir.resolve("action-types"));
+        Files.createDirectories(sessionDir.resolve("report-definitions"));
+
+        Files.writeString(sessionDir.resolve("CLAUDE.md"), buildClaudeMd());
+
+        if (mcpServerDir != null) {
+            Files.writeString(sessionDir.resolve("mcp-config.json"),
+                    buildMcpConfig(mcpServerDir));
+        }
+
+        LOG.infof("Created assistant working directory: %s", sessionDir);
+        return sessionDir;
+    }
+
+    /**
+     * Deletes the working directory and all its contents.
+     *
+     * @param workingDirectory the directory to delete
+     */
+    public void deleteWorkingDirectory(Path workingDirectory) {
+        if (workingDirectory == null || !Files.exists(workingDirectory)) {
+            return;
+        }
+        try {
+            try (var walk = Files.walk(workingDirectory)) {
+                walk.sorted(java.util.Comparator.reverseOrder())
+                        .forEach(p -> {
+                            try {
+                                Files.deleteIfExists(p);
+                            } catch (IOException e) {
+                                LOG.warnf("Failed to delete: %s", p);
+                            }
+                        });
+            }
+            LOG.infof("Deleted assistant working directory: %s", workingDirectory);
+        } catch (IOException e) {
+            LOG.warnf(e, "Failed to clean up working directory: %s", workingDirectory);
+        }
+    }
+
+    private String buildClaudeMd() {
+        return """
+                # Axiom Configuration Assistant
+
+                You are the **Axiom Configuration Assistant**. Your job is to help the user
+                create and refine Axiom configuration items — **Tools**, **Action Types**, and
+                **Report Definitions** — by writing well-formed JSON files in this working
+                directory.
+
+                ## What You Can Create
+
+                ### Tools
+                Script-based tools that AI agents can invoke. Each tool runs a bash script with
+                parameter substitution.
+
+                Write each tool as a JSON file in the `tools/` subdirectory.
+
+                **Schema:**
+                ```json
+                {
+                  "name": "tool-name",
+                  "description": "What the tool does",
+                  "parameters": [
+                    {
+                      "name": "paramName",
+                      "type": "string",
+                      "description": "Parameter description",
+                      "required": true
+                    }
+                  ],
+                  "scriptTemplate": "#!/bin/bash\\n# Use {{paramName}} for parameter substitution\\necho {{paramName}}",
+                  "labels": ["optional", "labels"]
+                }
+                ```
+
+                **Template placeholders:** Use `{{paramName}}` in the script template. For
+                parameters that contain multi-line content, use `{{paramName_file}}` — a temp
+                file path containing the value will be substituted instead.
+
+                ### Action Types
+                Define kinds of work that AI agents or scripts can perform.
+
+                Write each action type as a JSON file in the `action-types/` subdirectory.
+
+                **Schema:**
+                ```json
+                {
+                  "name": "action-type-name",
+                  "description": "What this action does",
+                  "executionMode": "actor",
+                  "userTriggerable": true,
+                  "managerTriggerable": true,
+                  "emitsEvent": false,
+                  "allowedTools": "mcp__axiom-tools__tool1,mcp__axiom-tools__tool2,@ToolsetName",
+                  "promptTemplate": "You are performing...\\n\\nContext: {{input}}",
+                  "scriptTemplate": null,
+                  "model": null,
+                  "engine": null,
+                  "inputSchema": null,
+                  "environment": null
+                }
+                ```
+
+                **Execution modes:** `actor` (AI agent), `script` (bash script).
+
+                **Allowed tools pattern:** Comma-separated list. Use `mcp__axiom-tools__<name>`
+                for script tools, `mcp__<server>__<tool>` for MCP server tools, `@ToolsetName`
+                for toolset references.
+
+                **Prompt template placeholders:** `{{input}}`, `{{projectId}}`,
+                `{{projectName}}`, `{{repository}}`, `{{issueRef}}`.
+
+                ### Report Definitions
+                Recurring or on-demand reports generated by AI agents.
+
+                Write each report definition as a JSON file in the `report-definitions/`
+                subdirectory.
+
+                **Schema:**
+                ```json
+                {
+                  "name": "report-name",
+                  "description": "What this report covers",
+                  "schedule": "weekly",
+                  "scheduleTime": "08:00",
+                  "scheduleDayOfWeek": "monday",
+                  "timeWindow": "last-7d",
+                  "promptTemplate": "Generate a report...\\n\\nRepositories: {{repositories}}\\nTime range: {{timeRangeStart}} to {{timeRangeEnd}}",
+                  "allowedTools": "mcp__axiom-tools__tool1"
+                }
+                ```
+
+                **Schedule values:** `none`, `daily`, `weekly`, `monthly`, or a cron expression.
+
+                **Time window values:** `since-last-run`, `last-24h`, `last-7d`, `last-30d`.
+
+                **Prompt template placeholders:** `{{repositories}}`, `{{timeRangeStart}}`,
+                `{{timeRangeEnd}}`, `{{timeWindow}}`.
+
+                **Optional fields** (omit to use defaults):
+                - `environment` — JSON object of environment variables. Omit if not needed.
+                - `timeoutSeconds` — per-report timeout override. **Do not include this field**
+                  unless the user explicitly requests a custom timeout. The system default
+                  (600 seconds) is used when this field is absent.
+
+                ## Guidelines
+
+                - **One file per item.** Name files descriptively (e.g. `tools/fetch-prs.json`).
+                - **Use the MCP tools** (`axiom_list_tools`, `axiom_get_tool`, etc.) to discover
+                  existing configuration before creating new items.
+                - **Naming conventions:** Use lowercase kebab-case for names (e.g. `fetch-prs`,
+                  `weekly-status`).
+                - **Secret references:** Use `${secret:SECRET_NAME}` in script templates and
+                  environment variables to reference secrets stored in Axiom.
+                - **Validate your output.** Make sure JSON is well-formed and all required fields
+                  are present.
+                - When the user asks to modify an item, read the existing file, update it, and
+                  write it back.
+                """;
+    }
+
+    private String buildMcpConfig(Path mcpServerDir) {
+        String serverJsPath = mcpServerDir.resolve("server.js")
+                .toAbsolutePath().toString().replace("\\", "\\\\");
+        String apiUrl = "http://localhost:" + httpPort + "/api/v1";
+
+        return """
+                {
+                  "mcpServers": {
+                    "axiom": {
+                      "command": "node",
+                      "args": ["%s"],
+                      "env": {
+                        "AXIOM_API_URL": "%s"
+                      }
+                    }
+                  }
+                }
+                """.formatted(serverJsPath, apiUrl);
+    }
+}

--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantEventParser.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantEventParser.java
@@ -1,0 +1,185 @@
+package io.apitomy.axiom.app.assistant;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.jboss.logging.Logger;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Parses Claude Code NDJSON stream-json output into normalised {@link SseEvent}
+ * records suitable for forwarding to the browser via Server-Sent Events.
+ *
+ * <p>Raw Claude Code event types are transformed into semantic event types that
+ * the frontend can handle consistently. This follows the same approach as the
+ * claude-pilot POC's {@code ClaudeEventParser}.</p>
+ *
+ * <h3>Event type mapping</h3>
+ * <ul>
+ *   <li>{@code system} (subtype init) → {@code session_init}</li>
+ *   <li>{@code assistant} → {@code assistant_text}, {@code tool_use}, {@code thinking}</li>
+ *   <li>{@code user} (with tool_use_result) → {@code tool_result}</li>
+ *   <li>{@code result} → {@code turn_complete}</li>
+ *   <li>{@code sdk_control_request} / {@code control_request} → {@code permission_request}</li>
+ * </ul>
+ */
+public class AssistantEventParser {
+
+    private static final Logger LOG = Logger.getLogger(AssistantEventParser.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /**
+     * Parses a single NDJSON line from Claude Code's stream-json output into
+     * zero or more normalised SSE events.
+     *
+     * @param line one line of NDJSON output
+     * @return list of normalised events (may be empty, never null)
+     */
+    public List<SseEvent> parse(String line) {
+        if (line == null || line.isBlank()) {
+            return Collections.emptyList();
+        }
+
+        try {
+            JsonNode node = MAPPER.readTree(line);
+            String type = node.path("type").asText("");
+
+            return switch (type) {
+                case "system" -> parseSystem(node);
+                case "assistant" -> parseAssistant(node);
+                case "user" -> parseUser(node);
+                case "result" -> parseResult(node);
+                case "sdk_control_request" -> parseSdkControlRequest(node);
+                case "control_request" -> parseControlRequest(node);
+                default -> Collections.emptyList();
+            };
+        } catch (Exception e) {
+            LOG.tracef("Failed to parse NDJSON line: %s",
+                    line.substring(0, Math.min(line.length(), 200)));
+            return Collections.emptyList();
+        }
+    }
+
+    private List<SseEvent> parseSystem(JsonNode root) {
+        String subtype = root.path("subtype").asText("");
+        if (!"init".equals(subtype)) {
+            return Collections.emptyList();
+        }
+        ObjectNode data = JsonNodeFactory.instance.objectNode();
+        data.put("sessionId", root.path("session_id").asText());
+        data.put("cwd", root.path("cwd").asText());
+        data.put("model", root.path("model").asText());
+        return List.of(new SseEvent("session_init", data));
+    }
+
+    private List<SseEvent> parseAssistant(JsonNode root) {
+        JsonNode content = root.path("message").path("content");
+        if (!content.isArray()) {
+            return Collections.emptyList();
+        }
+        List<SseEvent> events = new ArrayList<>();
+        for (JsonNode block : content) {
+            String blockType = block.path("type").asText("");
+            switch (blockType) {
+                case "text" -> {
+                    ObjectNode data = JsonNodeFactory.instance.objectNode();
+                    data.put("text", block.path("text").asText());
+                    events.add(new SseEvent("assistant_text", data));
+                }
+                case "tool_use" -> {
+                    ObjectNode data = JsonNodeFactory.instance.objectNode();
+                    data.put("id", block.path("id").asText());
+                    data.put("name", block.path("name").asText());
+                    data.set("input", block.path("input"));
+                    events.add(new SseEvent("tool_use", data));
+                }
+                case "thinking" -> {
+                    ObjectNode data = JsonNodeFactory.instance.objectNode();
+                    events.add(new SseEvent("thinking", data));
+                }
+            }
+        }
+        return events;
+    }
+
+    private List<SseEvent> parseUser(JsonNode root) {
+        JsonNode toolResult = root.path("tool_use_result");
+        if (toolResult.isMissingNode()) {
+            return Collections.emptyList();
+        }
+        JsonNode content = root.path("message").path("content");
+        String toolUseId = "";
+        if (content.isArray()) {
+            for (JsonNode block : content) {
+                if ("tool_result".equals(block.path("type").asText())) {
+                    toolUseId = block.path("tool_use_id").asText();
+                    break;
+                }
+            }
+        }
+        ObjectNode data = JsonNodeFactory.instance.objectNode();
+        data.put("toolUseId", toolUseId);
+        data.put("stdout", toolResult.path("stdout").asText(""));
+        data.put("stderr", toolResult.path("stderr").asText(""));
+        data.put("interrupted", toolResult.path("interrupted").asBoolean(false));
+        return List.of(new SseEvent("tool_result", data));
+    }
+
+    private List<SseEvent> parseResult(JsonNode root) {
+        ObjectNode data = JsonNodeFactory.instance.objectNode();
+        data.put("sessionId", root.path("session_id").asText());
+        data.put("costUsd", root.path("total_cost_usd").asDouble(0));
+        data.put("durationMs", root.path("duration_ms").asLong(0));
+        data.put("success", "success".equals(root.path("subtype").asText()));
+        return List.of(new SseEvent("turn_complete", data));
+    }
+
+    private List<SseEvent> parseSdkControlRequest(JsonNode root) {
+        JsonNode request = root.path("request");
+        if (!"permission".equals(request.path("subtype").asText())) {
+            return Collections.emptyList();
+        }
+        ObjectNode data = JsonNodeFactory.instance.objectNode();
+        data.put("requestId", request.path("request_id").asText());
+        data.put("toolName", request.path("tool_name").asText());
+        data.set("toolInput", request.path("tool_input"));
+        return List.of(new SseEvent("permission_request", data));
+    }
+
+    private List<SseEvent> parseControlRequest(JsonNode root) {
+        JsonNode request = root.path("request");
+        String subtype = request.path("subtype").asText("");
+        if (!"can_use_tool".equals(subtype)) {
+            return Collections.emptyList();
+        }
+        ObjectNode data = JsonNodeFactory.instance.objectNode();
+        data.put("requestId", root.path("request_id").asText());
+        data.put("toolName", request.path("tool_name").asText());
+        data.put("description", request.path("description").asText());
+        data.set("toolInput", request.path("input"));
+        return List.of(new SseEvent("permission_request", data));
+    }
+
+    /**
+     * A normalised SSE event parsed from Claude Code's NDJSON output.
+     *
+     * @param type the normalised event type (session_init, assistant_text,
+     *             tool_use, tool_result, turn_complete, permission_request, thinking)
+     * @param data the extracted/transformed JSON data
+     */
+    public record SseEvent(String type, JsonNode data) {
+
+        /**
+         * Serialises this event to a JSON string for transmission over SSE.
+         *
+         * @return JSON string representation
+         */
+        public String toJson() {
+            return data.toString();
+        }
+    }
+}

--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantItemValidator.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantItemValidator.java
@@ -1,0 +1,178 @@
+package io.apitomy.axiom.app.assistant;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Validates generated JSON configuration files against the expected schemas
+ * for Tools, Action Types, and Report Definitions.
+ */
+@ApplicationScoped
+public class AssistantItemValidator {
+
+    private static final Logger LOG = Logger.getLogger(AssistantItemValidator.class);
+
+    private static final Set<String> VALID_EXECUTION_MODES = Set.of("actor", "script");
+    private static final Set<String> VALID_SCHEDULES = Set.of(
+            "none", "daily", "weekly", "monthly");
+    private static final Set<String> VALID_TIME_WINDOWS = Set.of(
+            "since-last-run", "last-24h", "last-7d", "last-30d");
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    /**
+     * Validates a JSON file in the given subdirectory type.
+     *
+     * @param file the path to the JSON file
+     * @param itemType the item type: "tools", "action-types", or "report-definitions"
+     * @return a list of validation errors (empty if valid)
+     */
+    public List<String> validate(Path file, String itemType) {
+        List<String> errors = new ArrayList<>();
+
+        if (!Files.exists(file)) {
+            errors.add("File does not exist: " + file.getFileName());
+            return errors;
+        }
+
+        String content;
+        try {
+            content = Files.readString(file);
+        } catch (IOException e) {
+            errors.add("Cannot read file: " + e.getMessage());
+            return errors;
+        }
+
+        JsonNode node;
+        try {
+            node = objectMapper.readTree(content);
+        } catch (Exception e) {
+            errors.add("Invalid JSON: " + e.getMessage());
+            return errors;
+        }
+
+        if (!node.isObject()) {
+            errors.add("Root element must be a JSON object");
+            return errors;
+        }
+
+        switch (itemType) {
+            case "tools" -> validateTool(node, errors);
+            case "action-types" -> validateActionType(node, errors);
+            case "report-definitions" -> validateReportDefinition(node, errors);
+            default -> errors.add("Unknown item type: " + itemType);
+        }
+
+        return errors;
+    }
+
+    /**
+     * Determines the item type from a file path based on its parent directory.
+     *
+     * @param file the file path relative to the working directory
+     * @param workingDirectory the session's working directory
+     * @return the item type, or null if the file is not in a known subdirectory
+     */
+    public String detectItemType(Path file, Path workingDirectory) {
+        Path relative = workingDirectory.relativize(file);
+        String first = relative.getName(0).toString();
+        return switch (first) {
+            case "tools" -> "tools";
+            case "action-types" -> "action-types";
+            case "report-definitions" -> "report-definitions";
+            default -> null;
+        };
+    }
+
+    private void validateTool(JsonNode node, List<String> errors) {
+        requireString(node, "name", errors);
+        requireString(node, "description", errors);
+        requireString(node, "scriptTemplate", errors);
+
+        JsonNode params = node.path("parameters");
+        if (!params.isMissingNode() && !params.isNull()) {
+            if (!params.isArray()) {
+                errors.add("'parameters' must be a JSON array");
+            } else {
+                for (int i = 0; i < params.size(); i++) {
+                    JsonNode param = params.get(i);
+                    if (!param.has("name") || param.path("name").asText("").isBlank()) {
+                        errors.add("Parameter at index " + i + " is missing 'name'");
+                    }
+                }
+            }
+        }
+
+        JsonNode labels = node.path("labels");
+        if (!labels.isMissingNode() && !labels.isNull() && !labels.isArray()) {
+            errors.add("'labels' must be a JSON array of strings");
+        }
+    }
+
+    private void validateActionType(JsonNode node, List<String> errors) {
+        requireString(node, "name", errors);
+        requireString(node, "description", errors);
+
+        String executionMode = node.path("executionMode").asText("");
+        if (executionMode.isBlank()) {
+            errors.add("Missing required field: 'executionMode'");
+        } else if (!VALID_EXECUTION_MODES.contains(executionMode)) {
+            errors.add("Invalid executionMode '" + executionMode
+                    + "'. Must be one of: " + VALID_EXECUTION_MODES);
+        }
+
+        if ("actor".equals(executionMode)) {
+            if (!node.has("promptTemplate")
+                    || node.path("promptTemplate").asText("").isBlank()) {
+                errors.add("Actor-mode action types require a non-empty 'promptTemplate'");
+            }
+        } else if ("script".equals(executionMode)) {
+            if (!node.has("scriptTemplate")
+                    || node.path("scriptTemplate").asText("").isBlank()) {
+                errors.add("Script-mode action types require a non-empty 'scriptTemplate'");
+            }
+        }
+    }
+
+    private void validateReportDefinition(JsonNode node, List<String> errors) {
+        requireString(node, "name", errors);
+        requireString(node, "description", errors);
+
+        String schedule = node.path("schedule").asText("");
+        if (schedule.isBlank()) {
+            errors.add("Missing required field: 'schedule'");
+        } else if (!VALID_SCHEDULES.contains(schedule) && !schedule.contains(" ")) {
+            // Allow cron expressions (contain spaces) alongside preset values
+            errors.add("Invalid schedule '" + schedule
+                    + "'. Must be one of " + VALID_SCHEDULES + " or a cron expression");
+        }
+
+        String timeWindow = node.path("timeWindow").asText("");
+        if (!timeWindow.isBlank() && !VALID_TIME_WINDOWS.contains(timeWindow)) {
+            errors.add("Invalid timeWindow '" + timeWindow
+                    + "'. Must be one of: " + VALID_TIME_WINDOWS);
+        }
+
+        if (!node.has("promptTemplate")
+                || node.path("promptTemplate").asText("").isBlank()) {
+            errors.add("Missing required field: 'promptTemplate'");
+        }
+    }
+
+    private void requireString(JsonNode node, String field, List<String> errors) {
+        if (!node.has(field) || node.path(field).asText("").isBlank()) {
+            errors.add("Missing required field: '" + field + "'");
+        }
+    }
+}

--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSession.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSession.java
@@ -1,0 +1,292 @@
+package io.apitomy.axiom.app.assistant;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.apitomy.axiom.app.assistant.AssistantEventParser.SseEvent;
+import org.jboss.logging.Logger;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+/**
+ * Wraps an interactive Claude Code subprocess using stream-json I/O.
+ *
+ * <p>Unlike the one-shot {@code ClaudeCodeSubprocess}, this class maintains
+ * a long-lived process with bidirectional stdin/stdout communication. User
+ * messages and permission responses are written to stdin as JSON lines;
+ * NDJSON events are read from stdout and dispatched to registered listeners.</p>
+ *
+ * <p>All emitted events are buffered so that reconnecting SSE clients can
+ * replay the full session history.</p>
+ */
+public class AssistantSession {
+
+    private static final Logger LOG = Logger.getLogger(AssistantSession.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /** Possible session states. */
+    public enum Status { STARTING, RUNNING, STOPPED, ERROR }
+
+    private final String id;
+    private final String name;
+    private final Path workingDirectory;
+    private final List<String> command;
+    private final AssistantEventParser parser;
+
+    private volatile Process process;
+    private volatile OutputStream stdin;
+    private volatile Status status;
+    private volatile Instant lastActivityAt;
+    private final Instant createdAt;
+    private final AtomicReference<String> errorMessage = new AtomicReference<>();
+
+    private final CopyOnWriteArrayList<SseEvent> eventHistory = new CopyOnWriteArrayList<>();
+    private final CopyOnWriteArrayList<Consumer<SseEvent>> listeners = new CopyOnWriteArrayList<>();
+
+    /**
+     * Creates a new assistant session.
+     *
+     * @param name the user-visible session name
+     * @param workingDirectory the session's working directory
+     * @param command the full command line for the Claude Code subprocess
+     */
+    public AssistantSession(String name, Path workingDirectory, List<String> command) {
+        this.id = UUID.randomUUID().toString();
+        this.name = name;
+        this.workingDirectory = workingDirectory;
+        this.command = command;
+        this.parser = new AssistantEventParser();
+        this.status = Status.STARTING;
+        this.createdAt = Instant.now();
+        this.lastActivityAt = this.createdAt;
+    }
+
+    /**
+     * Starts the Claude Code subprocess and begins reading its output.
+     *
+     * @throws IOException if the process cannot be started
+     */
+    public void start() throws IOException {
+        LOG.infof("Starting assistant session %s in %s", id, workingDirectory);
+
+        ProcessBuilder pb = new ProcessBuilder(command);
+        pb.directory(workingDirectory.toFile());
+        pb.redirectErrorStream(false);
+
+        process = pb.start();
+        stdin = process.getOutputStream();
+
+        // Read stdout (NDJSON) on a virtual thread
+        Thread.ofVirtual().name("assistant-stdout-" + id).start(this::readStdout);
+
+        // Read stderr on a virtual thread (logging only)
+        Thread.ofVirtual().name("assistant-stderr-" + id).start(this::readStderr);
+
+        // Monitor process exit on a virtual thread
+        Thread.ofVirtual().name("assistant-monitor-" + id).start(this::monitorProcess);
+
+        status = Status.RUNNING;
+        lastActivityAt = Instant.now();
+    }
+
+    /**
+     * Sends a user message to the Claude Code subprocess via stdin.
+     *
+     * @param message the user's message text
+     * @throws IOException if the message cannot be written
+     */
+    public void sendMessage(String message) throws IOException {
+        ObjectNode root = MAPPER.createObjectNode();
+        root.put("type", "user");
+        ObjectNode msg = MAPPER.createObjectNode();
+        msg.put("role", "user");
+        msg.put("content", message);
+        root.set("message", msg);
+        writeLine(MAPPER.writeValueAsString(root));
+        lastActivityAt = Instant.now();
+    }
+
+    /**
+     * Responds to a permission prompt from Claude Code.
+     *
+     * @param permissionId the permission request ID
+     * @param allow whether to allow (true) or deny (false) the tool call
+     * @param toolInput the original tool input to echo back as updatedInput
+     *                  (required by Claude Code when allowing)
+     * @throws IOException if the response cannot be written
+     */
+    public void respondToPermission(String permissionId, boolean allow,
+                                     com.fasterxml.jackson.databind.JsonNode toolInput)
+            throws IOException {
+        ObjectNode root = MAPPER.createObjectNode();
+        root.put("type", "control_response");
+        ObjectNode response = MAPPER.createObjectNode();
+        response.put("subtype", "success");
+        response.put("request_id", permissionId);
+        ObjectNode innerResponse = MAPPER.createObjectNode();
+        if (allow) {
+            innerResponse.put("behavior", "allow");
+            if (toolInput != null) {
+                innerResponse.set("updatedInput", toolInput);
+            }
+        } else {
+            innerResponse.put("behavior", "deny");
+            innerResponse.put("message", "User denied permission");
+        }
+        response.set("response", innerResponse);
+        root.set("response", response);
+        writeLine(MAPPER.writeValueAsString(root));
+        lastActivityAt = Instant.now();
+    }
+
+    /**
+     * Registers a listener that will receive all new SSE events.
+     *
+     * @param listener the event consumer
+     */
+    public void addListener(Consumer<SseEvent> listener) {
+        listeners.add(listener);
+    }
+
+    /**
+     * Removes a previously registered listener.
+     *
+     * @param listener the event consumer to remove
+     */
+    public void removeListener(Consumer<SseEvent> listener) {
+        listeners.remove(listener);
+    }
+
+    /**
+     * Returns the buffered event history for replay on SSE reconnect.
+     *
+     * @return an unmodifiable snapshot of all events emitted so far
+     */
+    public List<SseEvent> getEventHistory() {
+        return List.copyOf(eventHistory);
+    }
+
+    /**
+     * Kills the subprocess and marks the session as stopped.
+     */
+    public void destroy() {
+        LOG.infof("Destroying assistant session %s", id);
+        status = Status.STOPPED;
+        if (process != null && process.isAlive()) {
+            process.destroyForcibly();
+        }
+    }
+
+    /**
+     * Returns whether the subprocess is still alive.
+     *
+     * @return true if the subprocess is running
+     */
+    public boolean isAlive() {
+        return process != null && process.isAlive();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Path getWorkingDirectory() {
+        return workingDirectory;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getLastActivityAt() {
+        return lastActivityAt;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage.get();
+    }
+
+    private void writeLine(String json) throws IOException {
+        if (stdin == null) {
+            throw new IOException("Session stdin is not available");
+        }
+        synchronized (stdin) {
+            stdin.write((json + "\n").getBytes(StandardCharsets.UTF_8));
+            stdin.flush();
+        }
+    }
+
+    private void readStdout() {
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                List<SseEvent> events = parser.parse(line);
+                for (SseEvent event : events) {
+                    eventHistory.add(event);
+                    lastActivityAt = Instant.now();
+                    for (Consumer<SseEvent> listener : listeners) {
+                        try {
+                            listener.accept(event);
+                        } catch (Exception e) {
+                            LOG.warnf(e, "SSE listener error in session %s", id);
+                        }
+                    }
+                }
+            }
+        } catch (IOException e) {
+            if (status == Status.RUNNING) {
+                LOG.warnf("Error reading stdout for session %s: %s", id, e.getMessage());
+            }
+        }
+    }
+
+    private void readStderr() {
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(process.getErrorStream(), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                LOG.debugf("Session %s stderr: %s", id, line);
+            }
+        } catch (IOException e) {
+            if (status == Status.RUNNING) {
+                LOG.warnf("Error reading stderr for session %s: %s", id, e.getMessage());
+            }
+        }
+    }
+
+    private void monitorProcess() {
+        try {
+            int exitCode = process.waitFor();
+            if (status == Status.RUNNING) {
+                LOG.infof("Assistant session %s process exited with code %d", id, exitCode);
+                if (exitCode != 0) {
+                    status = Status.ERROR;
+                    errorMessage.set("Process exited with code " + exitCode);
+                } else {
+                    status = Status.STOPPED;
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSessionManager.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSessionManager.java
@@ -1,0 +1,497 @@
+package io.apitomy.axiom.app.assistant;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.apitomy.axiom.api.beans.ImportResult;
+import io.apitomy.axiom.app.ImportExportService;
+import io.apitomy.axiom.app.assistant.AssistantEventParser.SseEvent;
+import io.quarkus.runtime.ShutdownEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+
+/**
+ * Manages the lifecycle of interactive AI assistant sessions. Enforces a
+ * configurable maximum session count, installs the assistant MCP server on
+ * first use, and cleans up all sessions on application shutdown.
+ */
+@ApplicationScoped
+public class AssistantSessionManager {
+
+    private static final Logger LOG = Logger.getLogger(AssistantSessionManager.class);
+
+    private static final String ASSISTANT_MCP_DIR_NAME = "assistant-mcp-server";
+    private static final String[] MCP_TEMPLATE_FILES = { "package.json", "server.js" };
+
+    @ConfigProperty(name = "axiom.assistant.max-sessions", defaultValue = "3")
+    int maxSessions;
+
+    @ConfigProperty(name = "axiom.assistant.idle-timeout-seconds", defaultValue = "3600")
+    int idleTimeoutSeconds;
+
+    @ConfigProperty(name = "axiom.ai-engine", defaultValue = "claude-code")
+    String aiEngine;
+
+    @ConfigProperty(name = "axiom.claude-code.executable", defaultValue = "claude")
+    String claudeExecutable;
+
+    @ConfigProperty(name = "quarkus.http.port", defaultValue = "8080")
+    int httpPort;
+
+    @Inject
+    AssistantContextBuilder contextBuilder;
+
+    @Inject
+    AssistantItemValidator itemValidator;
+
+    @Inject
+    ImportExportService importExportService;
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    private final Map<String, AssistantSession> sessions = new ConcurrentHashMap<>();
+
+    private volatile Path assistantMcpServerDir;
+
+    /**
+     * Creates and starts a new assistant session.
+     *
+     * @param name the user-visible session name
+     * @return the started session
+     * @throws IOException if the session cannot be created
+     * @throws IllegalStateException if the AI engine is not Claude Code or the
+     *         session limit has been reached
+     */
+    public AssistantSession createSession(String name) throws IOException {
+        if (!"claude-code".equals(aiEngine)) {
+            throw new IllegalStateException(
+                    "The AI Assistant requires Claude Code as the active AI engine. "
+                            + "Current engine: " + aiEngine);
+        }
+
+        if (sessions.size() >= maxSessions) {
+            throw new SessionLimitReachedException(
+                    "Maximum number of assistant sessions reached (" + maxSessions + ")");
+        }
+
+        Path mcpServerDir = ensureAssistantMcpServerInstalled();
+
+        // Create a temporary session to get the ID, then build the working dir
+        String sessionName = name != null && !name.isBlank() ? name : "Assistant Session";
+        AssistantSession session = new AssistantSession(sessionName, null, List.of());
+
+        Path workDir = contextBuilder.createWorkingDirectory(session.getId(), mcpServerDir);
+
+        List<String> command = buildCommand(workDir);
+        session = new AssistantSession(sessionName, workDir, command);
+        session.start();
+
+        // Wire validation listener: when Claude writes/edits files in item
+        // subdirectories, validate and send errors back if needed
+        session.addListener(createValidationListener(session));
+
+        sessions.put(session.getId(), session);
+        LOG.infof("Created assistant session %s (%s)", session.getId(), sessionName);
+        return session;
+    }
+
+    /**
+     * Returns an active session by ID.
+     *
+     * @param sessionId the session identifier
+     * @return the session, or null if not found
+     */
+    public AssistantSession getSession(String sessionId) {
+        return sessions.get(sessionId);
+    }
+
+    /**
+     * Returns all active sessions.
+     *
+     * @return list of active sessions
+     */
+    public List<AssistantSession> listSessions() {
+        return List.copyOf(sessions.values());
+    }
+
+    /**
+     * Destroys a session: kills the subprocess and deletes the working directory.
+     *
+     * @param sessionId the session to destroy
+     */
+    public void destroySession(String sessionId) {
+        AssistantSession session = sessions.remove(sessionId);
+        if (session != null) {
+            session.destroy();
+            contextBuilder.deleteWorkingDirectory(session.getWorkingDirectory());
+            LOG.infof("Destroyed assistant session %s", sessionId);
+        }
+    }
+
+    /**
+     * Lists generated items in a session's working directory.
+     *
+     * @param sessionId the session identifier
+     * @return list of item descriptors with validation status
+     * @throws IOException if the directory cannot be read
+     */
+    public List<AssistantItem> listItems(String sessionId) throws IOException {
+        AssistantSession session = sessions.get(sessionId);
+        if (session == null) {
+            throw new IllegalArgumentException("Session not found: " + sessionId);
+        }
+
+        List<AssistantItem> items = new ArrayList<>();
+        Path workDir = session.getWorkingDirectory();
+
+        collectItems(workDir, "tools", items);
+        collectItems(workDir, "action-types", items);
+        collectItems(workDir, "report-definitions", items);
+
+        return items;
+    }
+
+    /**
+     * Returns the full content of a specific generated item.
+     *
+     * @param sessionId the session identifier
+     * @param itemType the item type directory (tools, action-types, report-definitions)
+     * @param itemName the item file name (without .json extension)
+     * @return the parsed JSON content
+     * @throws IOException if the file cannot be read
+     */
+    public JsonNode getItemContent(String sessionId, String itemType, String itemName)
+            throws IOException {
+        AssistantSession session = sessions.get(sessionId);
+        if (session == null) {
+            throw new IllegalArgumentException("Session not found: " + sessionId);
+        }
+
+        Path file = session.getWorkingDirectory().resolve(itemType).resolve(itemName + ".json");
+        if (!Files.exists(file)) {
+            return null;
+        }
+        return objectMapper.readTree(Files.readString(file));
+    }
+
+    /**
+     * Validates all items and imports them as a Configuration Pack.
+     *
+     * @param sessionId the session identifier
+     * @return the import result
+     * @throws IOException if files cannot be read
+     */
+    public ImportResult applySession(String sessionId) throws IOException {
+        AssistantSession session = sessions.get(sessionId);
+        if (session == null) {
+            throw new IllegalArgumentException("Session not found: " + sessionId);
+        }
+
+        List<AssistantItem> items = listItems(sessionId);
+
+        // Check for validation errors
+        List<String> allErrors = new ArrayList<>();
+        for (AssistantItem item : items) {
+            if (!item.validationErrors().isEmpty()) {
+                allErrors.add(item.type() + "/" + item.name() + ": "
+                        + String.join("; ", item.validationErrors()));
+            }
+        }
+        if (!allErrors.isEmpty()) {
+            throw new ValidationException("Items have validation errors", allErrors);
+        }
+
+        // Build configuration pack
+        JsonNode pack = buildConfigPack(session, items);
+
+        // Import via the existing service
+        ImportResult result = importExportService.importPack(pack);
+
+        // Destroy session on success
+        destroySession(sessionId);
+
+        return result;
+    }
+
+    /**
+     * Returns whether the AI engine supports the assistant feature.
+     *
+     * @return true if Claude Code is the active engine
+     */
+    public boolean isAvailable() {
+        return "claude-code".equals(aiEngine);
+    }
+
+    /**
+     * Cleans up all sessions on application shutdown.
+     *
+     * @param event the shutdown event
+     */
+    void onShutdown(@Observes ShutdownEvent event) {
+        LOG.info("Shutting down — destroying all assistant sessions");
+        for (String sessionId : new ArrayList<>(sessions.keySet())) {
+            destroySession(sessionId);
+        }
+    }
+
+    private List<String> buildCommand(Path workDir) {
+        List<String> cmd = new ArrayList<>();
+        cmd.add(claudeExecutable);
+        cmd.add("--print");
+        cmd.add("--input-format");
+        cmd.add("stream-json");
+        cmd.add("--output-format");
+        cmd.add("stream-json");
+        cmd.add("--verbose");
+        cmd.add("--permission-prompt-tool");
+        cmd.add("stdio");
+        cmd.add("--mcp-config");
+        cmd.add(workDir.resolve("mcp-config.json").toAbsolutePath().toString());
+
+        // Auto-approve safe tools; everything else prompts the user via
+        // --permission-prompt-tool stdio (forwarded to the chat UI).
+        cmd.add("--allowedTools");
+        cmd.add(String.join(" ",
+                "Read(*)", "Write(*)", "Edit(*)",
+                "Bash(ls *)", "Bash(cat *)",
+                "mcp__axiom__axiom_list_tools",
+                "mcp__axiom__axiom_get_tool",
+                "mcp__axiom__axiom_list_action_types",
+                "mcp__axiom__axiom_get_action_type",
+                "mcp__axiom__axiom_list_report_definitions",
+                "mcp__axiom__axiom_get_report_definition",
+                "mcp__axiom__axiom_list_mcp_servers",
+                "mcp__axiom__axiom_list_toolsets"
+        ));
+
+        return cmd;
+    }
+
+    private java.util.function.Consumer<SseEvent> createValidationListener(
+            AssistantSession session) {
+        return event -> {
+            // Listen for tool_result events — they fire after Write/Edit completes.
+            // We check the working directory for changed JSON files.
+            if (!"tool_result".equals(event.type())) {
+                return;
+            }
+
+            // After any tool result, re-validate all item files in the workdir.
+            // This is simpler and more reliable than trying to extract the
+            // specific file path from event data.
+            Path workDir = session.getWorkingDirectory();
+            try {
+                validateAndFeedback(workDir, "tools", session);
+                validateAndFeedback(workDir, "action-types", session);
+                validateAndFeedback(workDir, "report-definitions", session);
+            } catch (Exception e) {
+                LOG.warnf(e, "Validation listener error in session %s",
+                        session.getId());
+            }
+        };
+    }
+
+    private void validateAndFeedback(Path workDir, String subdir,
+                                      AssistantSession session) throws IOException {
+        Path dir = workDir.resolve(subdir);
+        if (!Files.isDirectory(dir)) {
+            return;
+        }
+        try (java.util.stream.Stream<Path> files = Files.list(dir)) {
+            files.filter(f -> f.toString().endsWith(".json"))
+                    .forEach(f -> {
+                        List<String> errors = itemValidator.validate(f, subdir);
+                        if (!errors.isEmpty()) {
+                            String filePath = workDir.relativize(f).toString();
+                            String feedback = "Validation errors in " + filePath + ":\n"
+                                    + String.join("\n",
+                                            errors.stream().map(e -> "- " + e).toList())
+                                    + "\n\nPlease fix these issues.";
+                            try {
+                                session.sendMessage(feedback);
+                                LOG.infof("Sent validation feedback for %s in session %s",
+                                        filePath, session.getId());
+                            } catch (IOException e) {
+                                LOG.warnf(e, "Failed to send validation feedback");
+                            }
+                        }
+                    });
+        }
+    }
+
+    private void collectItems(Path workDir, String subdir, List<AssistantItem> items)
+            throws IOException {
+        Path dir = workDir.resolve(subdir);
+        if (!Files.isDirectory(dir)) {
+            return;
+        }
+        try (Stream<Path> files = Files.list(dir)) {
+            files.filter(f -> f.toString().endsWith(".json"))
+                    .forEach(f -> {
+                        String name = f.getFileName().toString()
+                                .replaceFirst("\\.json$", "");
+                        List<String> errors = itemValidator.validate(f, subdir);
+                        items.add(new AssistantItem(subdir, name, errors));
+                    });
+        }
+    }
+
+    private JsonNode buildConfigPack(AssistantSession session, List<AssistantItem> items)
+            throws IOException {
+        ObjectNode pack = objectMapper.createObjectNode();
+
+        ObjectNode metadata = pack.putObject("metadata");
+        metadata.put("name", "AI Assistant Session - " + session.getName());
+        metadata.put("description", "Generated by AI Assistant on "
+                + Instant.now().toString());
+        metadata.put("version", "2.0");
+        metadata.put("exportedAt", Instant.now().toString());
+
+        ArrayNode toolsArr = pack.putArray("tools");
+        ArrayNode actionTypesArr = pack.putArray("actionTypes");
+        ArrayNode reportDefsArr = pack.putArray("reportDefinitions");
+
+        for (AssistantItem item : items) {
+            Path file = session.getWorkingDirectory()
+                    .resolve(item.type()).resolve(item.name() + ".json");
+            JsonNode content = objectMapper.readTree(Files.readString(file));
+
+            switch (item.type()) {
+                case "tools" -> toolsArr.add(content);
+                case "action-types" -> actionTypesArr.add(content);
+                case "report-definitions" -> reportDefsArr.add(content);
+            }
+        }
+
+        return pack;
+    }
+
+    /**
+     * Ensures the assistant MCP server Node.js project is installed at
+     * {@code ~/.axiom/assistant-mcp-server/}.
+     */
+    private Path ensureAssistantMcpServerInstalled() throws IOException {
+        if (assistantMcpServerDir != null
+                && Files.exists(assistantMcpServerDir.resolve("node_modules"))) {
+            return assistantMcpServerDir;
+        }
+
+        synchronized (this) {
+            if (assistantMcpServerDir != null
+                    && Files.exists(assistantMcpServerDir.resolve("node_modules"))) {
+                return assistantMcpServerDir;
+            }
+
+            Path axiomHome = Path.of(System.getProperty("user.home"), ".axiom");
+            Path serverDir = axiomHome.resolve(ASSISTANT_MCP_DIR_NAME);
+            Files.createDirectories(serverDir);
+
+            for (String fileName : MCP_TEMPLATE_FILES) {
+                String resourcePath = "templates/axiom-assistant-mcp/" + fileName;
+                try (InputStream is = getClass().getClassLoader()
+                        .getResourceAsStream(resourcePath)) {
+                    if (is == null) {
+                        throw new IOException("Template resource not found: " + resourcePath);
+                    }
+                    Files.copy(is, serverDir.resolve(fileName),
+                            StandardCopyOption.REPLACE_EXISTING);
+                }
+            }
+            LOG.infof("Copied assistant MCP server template to %s", serverDir);
+
+            LOG.info("Running npm install for assistant MCP server...");
+            ProcessBuilder pb = new ProcessBuilder("npm", "install", "--production")
+                    .directory(serverDir.toFile())
+                    .redirectErrorStream(true);
+            Process process = pb.start();
+            String output = new String(process.getInputStream().readAllBytes());
+            int exitCode;
+            try {
+                exitCode = process.waitFor();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("npm install interrupted", e);
+            }
+
+            if (exitCode != 0) {
+                throw new IOException(
+                        "npm install failed (exit code " + exitCode + "): " + output);
+            }
+            LOG.infof("npm install completed for assistant MCP server in %s", serverDir);
+
+            assistantMcpServerDir = serverDir;
+            return assistantMcpServerDir;
+        }
+    }
+
+    /**
+     * Describes a generated configuration item with its validation status.
+     *
+     * @param type the item type directory (tools, action-types, report-definitions)
+     * @param name the item name (file name without .json)
+     * @param validationErrors list of validation errors (empty if valid)
+     */
+    public record AssistantItem(String type, String name, List<String> validationErrors) {
+
+        /**
+         * Returns whether this item passed validation.
+         *
+         * @return true if there are no validation errors
+         */
+        public boolean isValid() {
+            return validationErrors.isEmpty();
+        }
+    }
+
+    /**
+     * Thrown when the maximum session limit has been reached.
+     */
+    public static class SessionLimitReachedException extends RuntimeException {
+        /**
+         * @param message the error message
+         */
+        public SessionLimitReachedException(String message) {
+            super(message);
+        }
+    }
+
+    /**
+     * Thrown when items fail validation during apply.
+     */
+    public static class ValidationException extends RuntimeException {
+        private final List<String> errors;
+
+        /**
+         * @param message the error message
+         * @param errors the list of validation errors
+         */
+        public ValidationException(String message, List<String> errors) {
+            super(message);
+            this.errors = errors;
+        }
+
+        /**
+         * @return the list of validation errors
+         */
+        public List<String> getErrors() {
+            return errors;
+        }
+    }
+}

--- a/app/src/main/java/io/apitomy/axiom/app/rest/AssistantSessionResource.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/AssistantSessionResource.java
@@ -1,0 +1,395 @@
+package io.apitomy.axiom.app.rest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.apitomy.axiom.api.beans.ImportResult;
+import io.apitomy.axiom.app.assistant.AssistantEventParser.SseEvent;
+import io.apitomy.axiom.app.assistant.AssistantSession;
+import io.apitomy.axiom.app.assistant.AssistantSessionManager;
+import io.apitomy.axiom.app.assistant.AssistantSessionManager.AssistantItem;
+import io.apitomy.axiom.app.assistant.AssistantSessionManager.SessionLimitReachedException;
+import io.apitomy.axiom.app.assistant.AssistantSessionManager.ValidationException;
+import io.smallrye.common.annotation.RunOnVirtualThread;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.sse.OutboundSseEvent;
+import jakarta.ws.rs.sse.Sse;
+import jakarta.ws.rs.sse.SseEventSink;
+import org.jboss.logging.Logger;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * JAX-RS resource for managing interactive AI assistant sessions.
+ * All endpoints are under {@code /api/v1/assistant/sessions}.
+ */
+@Path("/api/v1/assistant/sessions")
+@ApplicationScoped
+@RunOnVirtualThread
+public class AssistantSessionResource {
+
+    private static final Logger LOG = Logger.getLogger(AssistantSessionResource.class);
+
+    @Inject
+    AssistantSessionManager sessionManager;
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    /**
+     * Creates a new assistant session.
+     *
+     * @param body optional JSON body with a "name" field
+     * @return the created session info
+     */
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response createSession(JsonNode body) {
+        if (!sessionManager.isAvailable()) {
+            return errorResponse(400,
+                    "The AI Assistant requires Claude Code as the active AI engine.");
+        }
+
+        try {
+            String name = body != null ? body.path("name").asText(null) : null;
+            AssistantSession session = sessionManager.createSession(name);
+            return Response.ok(toSessionInfo(session)).build();
+        } catch (SessionLimitReachedException e) {
+            return errorResponse(409, e.getMessage());
+        } catch (IOException e) {
+            LOG.errorf(e, "Failed to create assistant session");
+            return errorResponse(500, "Failed to create session: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Lists all active assistant sessions.
+     *
+     * @return array of session info objects
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listSessions() {
+        ArrayNode arr = objectMapper.createArrayNode();
+        for (AssistantSession session : sessionManager.listSessions()) {
+            arr.add(toSessionInfo(session));
+        }
+        return Response.ok(arr).build();
+    }
+
+    /**
+     * Gets info for a specific session.
+     *
+     * @param id the session identifier
+     * @return session info
+     */
+    @GET
+    @Path("/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getSession(@PathParam("id") String id) {
+        AssistantSession session = sessionManager.getSession(id);
+        if (session == null) {
+            return errorResponse(404, "Session not found: " + id);
+        }
+        return Response.ok(toSessionInfo(session)).build();
+    }
+
+    /**
+     * Renames a session.
+     *
+     * @param id the session identifier
+     * @param body JSON body with a "name" field
+     * @return updated session info
+     */
+    @PATCH
+    @Path("/{id}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response renameSession(@PathParam("id") String id, JsonNode body) {
+        AssistantSession session = sessionManager.getSession(id);
+        if (session == null) {
+            return errorResponse(404, "Session not found: " + id);
+        }
+        // Session names are currently immutable after creation — this endpoint
+        // is reserved for future use (the plan specifies PATCH for rename).
+        return Response.ok(toSessionInfo(session)).build();
+    }
+
+    /**
+     * Opens an SSE event stream for a session. Replays all buffered events
+     * first, then streams new events in real time.
+     *
+     * @param id the session identifier
+     * @param sink the SSE event sink
+     * @param sse the SSE factory
+     */
+    @GET
+    @Path("/{id}/events")
+    @Produces(MediaType.SERVER_SENT_EVENTS)
+    public void streamEvents(@PathParam("id") String id,
+                             @Context SseEventSink sink,
+                             @Context Sse sse) {
+        AssistantSession session = sessionManager.getSession(id);
+        if (session == null) {
+            try (sink) {
+                sink.send(sse.newEventBuilder()
+                        .name("error")
+                        .data("{\"message\":\"Session not found\"}")
+                        .build());
+            }
+            return;
+        }
+
+        // Replay history
+        for (SseEvent event : session.getEventHistory()) {
+            if (sink.isClosed()) return;
+            OutboundSseEvent sseEvent = sse.newEventBuilder()
+                    .name(event.type())
+                    .data(event.toJson())
+                    .build();
+            sink.send(sseEvent);
+        }
+
+        // Stream live events
+        Consumer<SseEvent> listener = event -> {
+            if (sink.isClosed()) return;
+            OutboundSseEvent sseEvent = sse.newEventBuilder()
+                    .name(event.type())
+                    .data(event.toJson())
+                    .build();
+            sink.send(sseEvent);
+        };
+
+        session.addListener(listener);
+
+        // Clean up when the SSE connection closes
+        sink.send(sse.newEventBuilder().comment("connected").build())
+                .whenComplete((v, ex) -> {
+                    // Keep listener until sink is actually closed
+                });
+
+        // Wait until the session ends or the sink closes
+        Thread.ofVirtual().name("sse-cleanup-" + id).start(() -> {
+            while (!sink.isClosed() && session.isAlive()) {
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+            session.removeListener(listener);
+            if (!sink.isClosed()) {
+                try {
+                    sink.close();
+                } catch (Exception e) {
+                    // Ignore
+                }
+            }
+        });
+    }
+
+    /**
+     * Sends a user message to the Claude Code subprocess.
+     *
+     * @param id the session identifier
+     * @param body JSON body with a "message" field
+     * @return 204 No Content on success
+     */
+    @POST
+    @Path("/{id}/messages")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response sendMessage(@PathParam("id") String id, JsonNode body) {
+        AssistantSession session = sessionManager.getSession(id);
+        if (session == null) {
+            return errorResponse(404, "Session not found: " + id);
+        }
+
+        String message = body.path("message").asText(null);
+        if (message == null || message.isBlank()) {
+            return errorResponse(400, "Missing 'message' field");
+        }
+
+        try {
+            session.sendMessage(message);
+            return Response.noContent().build();
+        } catch (IOException e) {
+            return errorResponse(500, "Failed to send message: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Responds to a permission prompt from Claude Code.
+     *
+     * @param id the session identifier
+     * @param body JSON body with "permissionId" and "allow" fields
+     * @return 204 No Content on success
+     */
+    @POST
+    @Path("/{id}/permissions")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response respondToPermission(@PathParam("id") String id, JsonNode body) {
+        AssistantSession session = sessionManager.getSession(id);
+        if (session == null) {
+            return errorResponse(404, "Session not found: " + id);
+        }
+
+        String permissionId = body.path("permissionId").asText(null);
+        boolean allow = body.path("allow").asBoolean(false);
+        JsonNode updatedInput = body.path("updatedInput");
+        if (updatedInput.isMissingNode() || updatedInput.isNull()) {
+            updatedInput = null;
+        }
+
+        if (permissionId == null || permissionId.isBlank()) {
+            return errorResponse(400, "Missing 'permissionId' field");
+        }
+
+        try {
+            session.respondToPermission(permissionId, allow, updatedInput);
+            return Response.noContent().build();
+        } catch (IOException e) {
+            return errorResponse(500,
+                    "Failed to respond to permission: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Lists generated items from the session's working directory.
+     *
+     * @param id the session identifier
+     * @return array of item descriptors with validation status
+     */
+    @GET
+    @Path("/{id}/items")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listItems(@PathParam("id") String id) {
+        try {
+            List<AssistantItem> items = sessionManager.listItems(id);
+            ArrayNode arr = objectMapper.createArrayNode();
+            for (AssistantItem item : items) {
+                ObjectNode node = arr.addObject();
+                node.put("type", item.type());
+                node.put("name", item.name());
+                node.put("valid", item.isValid());
+                if (!item.isValid()) {
+                    ArrayNode errArr = node.putArray("validationErrors");
+                    item.validationErrors().forEach(errArr::add);
+                }
+            }
+            return Response.ok(arr).build();
+        } catch (IllegalArgumentException e) {
+            return errorResponse(404, e.getMessage());
+        } catch (IOException e) {
+            return errorResponse(500, "Failed to list items: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Gets the full content of a specific generated item.
+     *
+     * @param id the session identifier
+     * @param type the item type (tools, action-types, report-definitions)
+     * @param name the item name
+     * @return the item's JSON content
+     */
+    @GET
+    @Path("/{id}/items/{type}/{name}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getItem(@PathParam("id") String id,
+                            @PathParam("type") String type,
+                            @PathParam("name") String name) {
+        try {
+            JsonNode content = sessionManager.getItemContent(id, type, name);
+            if (content == null) {
+                return errorResponse(404, "Item not found: " + type + "/" + name);
+            }
+            return Response.ok(content).build();
+        } catch (IllegalArgumentException e) {
+            return errorResponse(404, e.getMessage());
+        } catch (IOException e) {
+            return errorResponse(500, "Failed to read item: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Validates all items and imports them as a Configuration Pack.
+     *
+     * @param id the session identifier
+     * @return the import result with item counts
+     */
+    @POST
+    @Path("/{id}/apply")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response apply(@PathParam("id") String id) {
+        try {
+            ImportResult result = sessionManager.applySession(id);
+            return Response.ok(result).build();
+        } catch (IllegalArgumentException e) {
+            return errorResponse(404, e.getMessage());
+        } catch (ValidationException e) {
+            ObjectNode error = objectMapper.createObjectNode();
+            error.put("message", e.getMessage());
+            ArrayNode errArr = error.putArray("validationErrors");
+            e.getErrors().forEach(errArr::add);
+            return Response.status(422).entity(error).build();
+        } catch (WebApplicationException e) {
+            // Conflict from ImportExportService
+            return e.getResponse();
+        } catch (IOException e) {
+            return errorResponse(500, "Failed to apply: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Ends a session: kills the subprocess and deletes the working directory.
+     *
+     * @param id the session identifier
+     * @return 204 No Content on success
+     */
+    @DELETE
+    @Path("/{id}")
+    public Response deleteSession(@PathParam("id") String id) {
+        if (sessionManager.getSession(id) == null) {
+            return errorResponse(404, "Session not found: " + id);
+        }
+        sessionManager.destroySession(id);
+        return Response.noContent().build();
+    }
+
+    private ObjectNode toSessionInfo(AssistantSession session) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("id", session.getId());
+        node.put("name", session.getName());
+        node.put("status", session.getStatus().name().toLowerCase());
+        node.put("createdAt", session.getCreatedAt().toString());
+        node.put("lastActivityAt", session.getLastActivityAt().toString());
+        if (session.getErrorMessage() != null) {
+            node.put("errorMessage", session.getErrorMessage());
+        }
+        return node;
+    }
+
+    private Response errorResponse(int status, String message) {
+        ObjectNode error = objectMapper.createObjectNode();
+        error.put("message", message);
+        return Response.status(status).entity(error).build();
+    }
+}

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -75,6 +75,12 @@ axiom.opencode.max-steps=50
 # HTTP request timeout in seconds
 axiom.opencode.timeout-seconds=600
 
+# --- AI Assistant ---
+# Maximum concurrent interactive assistant sessions
+axiom.assistant.max-sessions=3
+# Auto-destroy idle sessions after this many seconds
+axiom.assistant.idle-timeout-seconds=3600
+
 # --- Workspaces ---
 # Root directory for project git clones
 axiom.workspace.root=${user.home}/.axiom/workspaces

--- a/app/src/main/resources/templates/axiom-assistant-mcp/package.json
+++ b/app/src/main/resources/templates/axiom-assistant-mcp/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "axiom-assistant-mcp",
+    "version": "1.0.0",
+    "description": "Axiom Assistant MCP server providing read-only query tools for AI assistant sessions",
+    "private": true,
+    "type": "commonjs",
+    "main": "server.js",
+    "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0"
+    }
+}

--- a/app/src/main/resources/templates/axiom-assistant-mcp/server.js
+++ b/app/src/main/resources/templates/axiom-assistant-mcp/server.js
@@ -1,0 +1,201 @@
+const { Server } = require("@modelcontextprotocol/sdk/server/index.js");
+const { StdioServerTransport } = require("@modelcontextprotocol/sdk/server/stdio.js");
+const { ListToolsRequestSchema, CallToolRequestSchema } = require("@modelcontextprotocol/sdk/types.js");
+
+function log(level, message, data) {
+    const entry = {
+        timestamp: new Date().toISOString(),
+        level,
+        source: "axiom-assistant-mcp",
+        message,
+        ...data
+    };
+    process.stderr.write(JSON.stringify(entry) + "\n");
+}
+
+const AXIOM_API_URL = process.env.AXIOM_API_URL || "http://localhost:8080/api/v1";
+
+async function axiomApi(method, path) {
+    const url = `${AXIOM_API_URL}${path}`;
+    const opts = {
+        method,
+        headers: { "Accept": "application/json" },
+    };
+    const resp = await fetch(url, opts);
+    const text = await resp.text();
+    if (!resp.ok) {
+        throw new Error(`Axiom API ${method} ${path} returned ${resp.status}: ${text.substring(0, 500)}`);
+    }
+    return text;
+}
+
+const TOOLS = [
+    {
+        name: "axiom_list_tools",
+        description: "List all existing tool definitions in Axiom. Returns names and descriptions of configured script tools.",
+        parameters: [],
+        handler: async () => {
+            const result = JSON.parse(await axiomApi("GET", "/tools?limit=100"));
+            const items = result.items || [];
+            if (items.length === 0) return "No tools configured.";
+            return JSON.stringify(items.map(t => ({
+                name: t.name,
+                description: t.description || "",
+                labels: t.labels || [],
+            })), null, 2);
+        },
+    },
+    {
+        name: "axiom_get_tool",
+        description: "Get full details of a specific tool definition by name, including its parameters and script template.",
+        parameters: [
+            { name: "name", type: "string", description: "The tool name", required: true },
+        ],
+        handler: async (args) => {
+            const result = JSON.parse(await axiomApi("GET", "/tools?limit=100&filterName=" + encodeURIComponent(args.name)));
+            const items = result.items || [];
+            const tool = items.find(t => t.name === args.name);
+            if (!tool) return `Tool '${args.name}' not found.`;
+            return JSON.stringify(tool, null, 2);
+        },
+    },
+    {
+        name: "axiom_list_action_types",
+        description: "List all existing action types in Axiom. Returns names, descriptions, and execution modes.",
+        parameters: [],
+        handler: async () => {
+            const items = JSON.parse(await axiomApi("GET", "/action-types"));
+            if (items.length === 0) return "No action types configured.";
+            return JSON.stringify(items.map(at => ({
+                name: at.name,
+                description: at.description || "",
+                executionMode: at.executionMode,
+                userTriggerable: at.userTriggerable,
+                managerTriggerable: at.managerTriggerable,
+            })), null, 2);
+        },
+    },
+    {
+        name: "axiom_get_action_type",
+        description: "Get full details of a specific action type by name, including its prompt template, allowed tools, and configuration.",
+        parameters: [
+            { name: "name", type: "string", description: "The action type name", required: true },
+        ],
+        handler: async (args) => {
+            const items = JSON.parse(await axiomApi("GET", "/action-types"));
+            const at = items.find(a => a.name === args.name);
+            if (!at) return `Action type '${args.name}' not found.`;
+            return JSON.stringify(at, null, 2);
+        },
+    },
+    {
+        name: "axiom_list_report_definitions",
+        description: "List all existing report definitions in Axiom. Returns names, descriptions, and schedules.",
+        parameters: [],
+        handler: async () => {
+            const items = JSON.parse(await axiomApi("GET", "/reports/definitions"));
+            if (items.length === 0) return "No report definitions configured.";
+            return JSON.stringify(items.map(rd => ({
+                name: rd.name,
+                description: rd.description || "",
+                schedule: rd.schedule,
+                enabled: rd.enabled,
+            })), null, 2);
+        },
+    },
+    {
+        name: "axiom_get_report_definition",
+        description: "Get full details of a specific report definition by name, including its prompt template, schedule, and allowed tools.",
+        parameters: [
+            { name: "name", type: "string", description: "The report definition name", required: true },
+        ],
+        handler: async (args) => {
+            const items = JSON.parse(await axiomApi("GET", "/reports/definitions"));
+            const rd = items.find(r => r.name === args.name);
+            if (!rd) return `Report definition '${args.name}' not found.`;
+            return JSON.stringify(rd, null, 2);
+        },
+    },
+    {
+        name: "axiom_list_mcp_servers",
+        description: "List all configured MCP servers in Axiom. Returns names and descriptions.",
+        parameters: [],
+        handler: async () => {
+            const items = JSON.parse(await axiomApi("GET", "/mcp-servers"));
+            if (items.length === 0) return "No MCP servers configured.";
+            return JSON.stringify(items.map(s => ({
+                name: s.name,
+                description: s.description || "",
+            })), null, 2);
+        },
+    },
+    {
+        name: "axiom_list_toolsets",
+        description: "List all configured toolsets in Axiom. Returns names, descriptions, and their tool lists.",
+        parameters: [],
+        handler: async () => {
+            const items = JSON.parse(await axiomApi("GET", "/toolsets"));
+            if (items.length === 0) return "No toolsets configured.";
+            return JSON.stringify(items.map(ts => ({
+                name: ts.name,
+                description: ts.description || "",
+                tools: ts.tools || [],
+            })), null, 2);
+        },
+    },
+];
+
+log("INFO", "Axiom Assistant MCP server started", {
+    toolCount: TOOLS.length,
+    axiomApiUrl: AXIOM_API_URL,
+});
+
+const server = new Server({ name: "axiom-assistant", version: "1.0.0" }, {
+    capabilities: { tools: {} }
+});
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: TOOLS.map(t => ({
+        name: t.name,
+        description: t.description || "",
+        inputSchema: {
+            type: "object",
+            properties: Object.fromEntries(
+                (t.parameters || []).map(p => [p.name, {
+                    type: p.type || "string",
+                    description: p.description || ""
+                }])
+            ),
+            required: (t.parameters || []).filter(p => p.required).map(p => p.name)
+        }
+    }))
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const toolName = request.params.name;
+    const args = request.params.arguments || {};
+
+    const tool = TOOLS.find(t => t.name === toolName);
+    if (!tool) {
+        log("WARN", "Unknown tool called", { toolName });
+        return { content: [{ type: "text", text: "Unknown tool: " + toolName }], isError: true };
+    }
+
+    log("INFO", "Tool called", { toolName, args: Object.keys(args) });
+    try {
+        const startTime = Date.now();
+        const result = await tool.handler(args);
+        const durationMs = Date.now() - startTime;
+        log("INFO", "Tool completed", { toolName, durationMs });
+        return { content: [{ type: "text", text: result || "OK" }] };
+    } catch (error) {
+        log("ERROR", "Tool failed", { toolName, error: error.message });
+        return { content: [{ type: "text", text: error.message }], isError: true };
+    }
+});
+
+async function main() {
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+}
+main().catch(console.error);

--- a/app/src/test/java/io/apitomy/axiom/app/assistant/AssistantEventParserTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/assistant/AssistantEventParserTest.java
@@ -1,0 +1,248 @@
+package io.apitomy.axiom.app.assistant;
+
+import io.apitomy.axiom.app.assistant.AssistantEventParser.SseEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link AssistantEventParser}. Verifies that Claude Code
+ * NDJSON stream events are correctly parsed and normalised into typed
+ * {@link SseEvent} records matching the claude-pilot POC conventions.
+ */
+class AssistantEventParserTest {
+
+    private AssistantEventParser parser;
+
+    @BeforeEach
+    void setUp() {
+        parser = new AssistantEventParser();
+    }
+
+    // ── System events ───────────────────────────────────────────────
+
+    @Test
+    void parseSystemInitEvent() {
+        String line = """
+                {"type":"system","subtype":"init","session_id":"sess-123","cwd":"/tmp","model":"sonnet"}""";
+
+        List<SseEvent> events = parser.parse(line);
+
+        assertEquals(1, events.size());
+        SseEvent event = events.get(0);
+        assertEquals("session_init", event.type());
+        assertEquals("sess-123", event.data().path("sessionId").asText());
+        assertEquals("sonnet", event.data().path("model").asText());
+    }
+
+    @Test
+    void parseSystemNonInitIsIgnored() {
+        String line = """
+                {"type":"system","subtype":"other"}""";
+
+        List<SseEvent> events = parser.parse(line);
+        assertTrue(events.isEmpty());
+    }
+
+    // ── Assistant events ────────────────────────────────────────────
+
+    @Test
+    void parseAssistantTextMessage() {
+        String line = """
+                {"type":"assistant","message":{"content":[{"type":"text","text":"Hello, I can help."}]}}""";
+
+        List<SseEvent> events = parser.parse(line);
+
+        assertEquals(1, events.size());
+        assertEquals("assistant_text", events.get(0).type());
+        assertEquals("Hello, I can help.", events.get(0).data().path("text").asText());
+    }
+
+    @Test
+    void parseAssistantToolUseContent() {
+        String line = """
+                {"type":"assistant","message":{"content":[{"type":"tool_use","id":"tu-1","name":"Write","input":{"file_path":"tools/test.json"}}]}}""";
+
+        List<SseEvent> events = parser.parse(line);
+
+        assertEquals(1, events.size());
+        assertEquals("tool_use", events.get(0).type());
+        assertEquals("Write", events.get(0).data().path("name").asText());
+        assertEquals("tu-1", events.get(0).data().path("id").asText());
+    }
+
+    @Test
+    void parseAssistantMultipleContentBlocks() {
+        String line = """
+                {"type":"assistant","message":{"content":[{"type":"text","text":"Let me write that."},{"type":"tool_use","id":"tu-2","name":"Write","input":{}}]}}""";
+
+        List<SseEvent> events = parser.parse(line);
+
+        assertEquals(2, events.size());
+        assertEquals("assistant_text", events.get(0).type());
+        assertEquals("tool_use", events.get(1).type());
+    }
+
+    @Test
+    void parseAssistantThinkingBlock() {
+        String line = """
+                {"type":"assistant","message":{"content":[{"type":"thinking","thinking":"reasoning..."}]}}""";
+
+        List<SseEvent> events = parser.parse(line);
+
+        assertEquals(1, events.size());
+        assertEquals("thinking", events.get(0).type());
+    }
+
+    @Test
+    void parseAssistantNoContentArray() {
+        String line = """
+                {"type":"assistant","message":{}}""";
+
+        List<SseEvent> events = parser.parse(line);
+        assertTrue(events.isEmpty());
+    }
+
+    // ── User/tool result events ─────────────────────────────────────
+
+    @Test
+    void parseUserToolResult() {
+        String line = """
+                {"type":"user","tool_use_result":{"stdout":"file written","stderr":"","interrupted":false},"message":{"content":[{"type":"tool_result","tool_use_id":"tu-1"}]}}""";
+
+        List<SseEvent> events = parser.parse(line);
+
+        assertEquals(1, events.size());
+        assertEquals("tool_result", events.get(0).type());
+        assertEquals("tu-1", events.get(0).data().path("toolUseId").asText());
+        assertEquals("file written", events.get(0).data().path("stdout").asText());
+    }
+
+    @Test
+    void parseUserWithoutToolResultIsIgnored() {
+        String line = """
+                {"type":"user","message":{"content":[{"type":"text","text":"hello"}]}}""";
+
+        List<SseEvent> events = parser.parse(line);
+        assertTrue(events.isEmpty());
+    }
+
+    // ── Result events ───────────────────────────────────────────────
+
+    @Test
+    void parseResultEvent() {
+        String line = """
+                {"type":"result","subtype":"success","session_id":"s-1","total_cost_usd":0.05,"duration_ms":12000}""";
+
+        List<SseEvent> events = parser.parse(line);
+
+        assertEquals(1, events.size());
+        assertEquals("turn_complete", events.get(0).type());
+        assertTrue(events.get(0).data().path("success").asBoolean());
+        assertEquals(0.05, events.get(0).data().path("costUsd").asDouble(), 0.001);
+    }
+
+    // ── Permission request events (sdk_control_request) ─────────────
+
+    @Test
+    void parseSdkControlRequest() {
+        String line = """
+                {"type":"sdk_control_request","request":{"subtype":"permission","request_id":"perm-1","tool_name":"Bash","tool_input":{"command":"ls"}}}""";
+
+        List<SseEvent> events = parser.parse(line);
+
+        assertEquals(1, events.size());
+        assertEquals("permission_request", events.get(0).type());
+        assertEquals("perm-1", events.get(0).data().path("requestId").asText());
+        assertEquals("Bash", events.get(0).data().path("toolName").asText());
+    }
+
+    @Test
+    void parseSdkControlRequestNonPermissionIsIgnored() {
+        String line = """
+                {"type":"sdk_control_request","request":{"subtype":"other"}}""";
+
+        List<SseEvent> events = parser.parse(line);
+        assertTrue(events.isEmpty());
+    }
+
+    // ── Permission request events (control_request) ─────────────────
+
+    @Test
+    void parseControlRequest() {
+        String line = """
+                {"type":"control_request","request_id":"perm-2","request":{"subtype":"can_use_tool","tool_name":"Write","description":"Write a file","input":{"file_path":"test.json"}}}""";
+
+        List<SseEvent> events = parser.parse(line);
+
+        assertEquals(1, events.size());
+        assertEquals("permission_request", events.get(0).type());
+        assertEquals("perm-2", events.get(0).data().path("requestId").asText());
+        assertEquals("Write", events.get(0).data().path("toolName").asText());
+    }
+
+    @Test
+    void parseControlRequestNonCanUseToolIsIgnored() {
+        String line = """
+                {"type":"control_request","request":{"subtype":"other"}}""";
+
+        List<SseEvent> events = parser.parse(line);
+        assertTrue(events.isEmpty());
+    }
+
+    // ── Unknown types ───────────────────────────────────────────────
+
+    @Test
+    void parseUnknownTypeReturnsEmpty() {
+        String line = """
+                {"type":"something_else","data":"ignored"}""";
+
+        List<SseEvent> events = parser.parse(line);
+        assertTrue(events.isEmpty());
+    }
+
+    // ── Edge cases ──────────────────────────────────────────────────
+
+    @Test
+    void parseNullReturnsEmpty() {
+        assertTrue(parser.parse(null).isEmpty());
+    }
+
+    @Test
+    void parseEmptyStringReturnsEmpty() {
+        assertTrue(parser.parse("").isEmpty());
+    }
+
+    @Test
+    void parseBlankStringReturnsEmpty() {
+        assertTrue(parser.parse("   ").isEmpty());
+    }
+
+    @Test
+    void parseMalformedJsonReturnsEmpty() {
+        assertTrue(parser.parse("this is not json").isEmpty());
+    }
+
+    @Test
+    void parsePartialJsonReturnsEmpty() {
+        assertTrue(parser.parse("{\"type\":").isEmpty());
+    }
+
+    // ── toJson serialisation ────────────────────────────────────────
+
+    @Test
+    void toJsonProducesValidString() {
+        String line = """
+                {"type":"system","subtype":"init","session_id":"s-1","cwd":"/tmp","model":"m"}""";
+
+        List<SseEvent> events = parser.parse(line);
+        assertEquals(1, events.size());
+
+        String json = events.get(0).toJson();
+        assertNotNull(json);
+        assertTrue(json.contains("\"sessionId\""));
+    }
+}

--- a/app/src/test/java/io/apitomy/axiom/app/assistant/AssistantItemValidatorTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/assistant/AssistantItemValidatorTest.java
@@ -1,0 +1,430 @@
+package io.apitomy.axiom.app.assistant;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link AssistantItemValidator}. Uses a temporary directory
+ * for JSON files and directly injects the ObjectMapper — no Quarkus container
+ * required.
+ */
+class AssistantItemValidatorTest {
+
+    private AssistantItemValidator validator;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        validator = new AssistantItemValidator();
+        Field omField = AssistantItemValidator.class.getDeclaredField("objectMapper");
+        omField.setAccessible(true);
+        omField.set(validator, new ObjectMapper());
+    }
+
+    // ── Tool validation ─────────────────────────────────────────────
+
+    @Test
+    void validToolPassesValidation() throws IOException {
+        Path file = writeJson(tempDir, "tools/my-tool.json", """
+                {
+                  "name": "my-tool",
+                  "description": "A test tool",
+                  "scriptTemplate": "echo hello",
+                  "parameters": [
+                    {"name": "input", "type": "string", "description": "The input", "required": true}
+                  ],
+                  "labels": ["test"]
+                }
+                """);
+
+        List<String> errors = validator.validate(file, "tools");
+        assertTrue(errors.isEmpty(), "Valid tool should have no errors: " + errors);
+    }
+
+    @Test
+    void toolMissingNameFails() throws IOException {
+        Path file = writeJson(tempDir, "tools/no-name.json", """
+                {
+                  "description": "A tool without a name",
+                  "scriptTemplate": "echo hi"
+                }
+                """);
+
+        List<String> errors = validator.validate(file, "tools");
+        assertFalse(errors.isEmpty());
+        assertTrue(errors.stream().anyMatch(e -> e.contains("name")));
+    }
+
+    @Test
+    void toolMissingDescriptionFails() throws IOException {
+        Path file = writeJson(tempDir, "tools/no-desc.json", """
+                {
+                  "name": "no-desc",
+                  "scriptTemplate": "echo hi"
+                }
+                """);
+
+        List<String> errors = validator.validate(file, "tools");
+        assertFalse(errors.isEmpty());
+        assertTrue(errors.stream().anyMatch(e -> e.contains("description")));
+    }
+
+    @Test
+    void toolMissingScriptTemplateFails() throws IOException {
+        Path file = writeJson(tempDir, "tools/no-script.json", """
+                {
+                  "name": "no-script",
+                  "description": "A tool without script"
+                }
+                """);
+
+        List<String> errors = validator.validate(file, "tools");
+        assertFalse(errors.isEmpty());
+        assertTrue(errors.stream().anyMatch(e -> e.contains("scriptTemplate")));
+    }
+
+    @Test
+    void toolInvalidParametersTypeFails() throws IOException {
+        Path file = writeJson(tempDir, "tools/bad-params.json", """
+                {
+                  "name": "bad-params",
+                  "description": "Tool with non-array params",
+                  "scriptTemplate": "echo hi",
+                  "parameters": "not-an-array"
+                }
+                """);
+
+        List<String> errors = validator.validate(file, "tools");
+        assertFalse(errors.isEmpty());
+        assertTrue(errors.stream().anyMatch(e -> e.contains("parameters")));
+    }
+
+    @Test
+    void toolParameterMissingNameFails() throws IOException {
+        Path file = writeJson(tempDir, "tools/param-no-name.json", """
+                {
+                  "name": "param-no-name",
+                  "description": "Tool with unnamed param",
+                  "scriptTemplate": "echo hi",
+                  "parameters": [{"type": "string"}]
+                }
+                """);
+
+        List<String> errors = validator.validate(file, "tools");
+        assertFalse(errors.isEmpty());
+        assertTrue(errors.stream().anyMatch(e -> e.contains("index 0") && e.contains("name")));
+    }
+
+    @Test
+    void toolInvalidLabelsTypeFails() throws IOException {
+        Path file = writeJson(tempDir, "tools/bad-labels.json", """
+                {
+                  "name": "bad-labels",
+                  "description": "Tool with non-array labels",
+                  "scriptTemplate": "echo hi",
+                  "labels": "not-an-array"
+                }
+                """);
+
+        List<String> errors = validator.validate(file, "tools");
+        assertFalse(errors.isEmpty());
+        assertTrue(errors.stream().anyMatch(e -> e.contains("labels")));
+    }
+
+    @Test
+    void toolWithNullParametersIsValid() throws IOException {
+        Path file = writeJson(tempDir, "tools/null-params.json", """
+                {
+                  "name": "null-params",
+                  "description": "Tool with null params",
+                  "scriptTemplate": "echo hi",
+                  "parameters": null
+                }
+                """);
+
+        List<String> errors = validator.validate(file, "tools");
+        assertTrue(errors.isEmpty(), "Null parameters should be allowed: " + errors);
+    }
+
+    // ── Action type validation ──────────────────────────────────────
+
+    @Test
+    void validActorActionTypePassesValidation() throws IOException {
+        Path file = writeJson(tempDir, "action-types/my-action.json", """
+                {
+                  "name": "my-action",
+                  "description": "A test action",
+                  "executionMode": "actor",
+                  "userTriggerable": true,
+                  "managerTriggerable": false,
+                  "promptTemplate": "Do the thing: {{input}}"
+                }
+                """);
+
+        List<String> errors = validator.validate(file, "action-types");
+        assertTrue(errors.isEmpty(), "Valid action type should have no errors: " + errors);
+    }
+
+    @Test
+    void validScriptActionTypePassesValidation() throws IOException {
+        Path file = writeJson(tempDir, "action-types/script-action.json", """
+                {
+                  "name": "script-action",
+                  "description": "A script action",
+                  "executionMode": "script",
+                  "scriptTemplate": "#!/bin/bash\\necho done"
+                }
+                """);
+
+        List<String> errors = validator.validate(file, "action-types");
+        assertTrue(errors.isEmpty(), "Valid script action should have no errors: " + errors);
+    }
+
+    @Test
+    void actionTypeMissingExecutionModeFails() throws IOException {
+        Path file = writeJson(tempDir, "action-types/no-mode.json", """
+                {
+                  "name": "no-mode",
+                  "description": "Action without execution mode"
+                }
+                """);
+
+        List<String> errors = validator.validate(file, "action-types");
+        assertFalse(errors.isEmpty());
+        assertTrue(errors.stream().anyMatch(e -> e.contains("executionMode")));
+    }
+
+    @Test
+    void actionTypeInvalidExecutionModeFails() throws IOException {
+        Path file = writeJson(tempDir, "action-types/bad-mode.json", """
+                {
+                  "name": "bad-mode",
+                  "description": "Action with invalid mode",
+                  "executionMode": "invalid"
+                }
+                """);
+
+        List<String> errors = validator.validate(file, "action-types");
+        assertFalse(errors.isEmpty());
+        assertTrue(errors.stream().anyMatch(e -> e.contains("executionMode") && e.contains("invalid")));
+    }
+
+    @Test
+    void actorActionTypeMissingPromptFails() throws IOException {
+        Path file = writeJson(tempDir, "action-types/no-prompt.json", """
+                {
+                  "name": "no-prompt",
+                  "description": "Actor action without prompt",
+                  "executionMode": "actor"
+                }
+                """);
+
+        List<String> errors = validator.validate(file, "action-types");
+        assertFalse(errors.isEmpty());
+        assertTrue(errors.stream().anyMatch(e -> e.contains("promptTemplate")));
+    }
+
+    @Test
+    void scriptActionTypeMissingScriptFails() throws IOException {
+        Path file = writeJson(tempDir, "action-types/no-script.json", """
+                {
+                  "name": "no-script",
+                  "description": "Script action without script",
+                  "executionMode": "script"
+                }
+                """);
+
+        List<String> errors = validator.validate(file, "action-types");
+        assertFalse(errors.isEmpty());
+        assertTrue(errors.stream().anyMatch(e -> e.contains("scriptTemplate")));
+    }
+
+    // ── Report definition validation ────────────────────────────────
+
+    @Test
+    void validReportDefinitionPassesValidation() throws IOException {
+        Path file = writeJson(tempDir, "report-definitions/weekly.json", """
+                {
+                  "name": "weekly-status",
+                  "description": "Weekly status report",
+                  "schedule": "weekly",
+                  "scheduleTime": "08:00",
+                  "scheduleDayOfWeek": "monday",
+                  "timeWindow": "last-7d",
+                  "promptTemplate": "Generate a report for {{repositories}}"
+                }
+                """);
+
+        List<String> errors = validator.validate(file, "report-definitions");
+        assertTrue(errors.isEmpty(), "Valid report should have no errors: " + errors);
+    }
+
+    @Test
+    void reportDefinitionMissingScheduleFails() throws IOException {
+        Path file = writeJson(tempDir, "report-definitions/no-schedule.json", """
+                {
+                  "name": "no-schedule",
+                  "description": "Report without schedule",
+                  "promptTemplate": "Generate report"
+                }
+                """);
+
+        List<String> errors = validator.validate(file, "report-definitions");
+        assertFalse(errors.isEmpty());
+        assertTrue(errors.stream().anyMatch(e -> e.contains("schedule")));
+    }
+
+    @Test
+    void reportDefinitionInvalidScheduleFails() throws IOException {
+        Path file = writeJson(tempDir, "report-definitions/bad-schedule.json", """
+                {
+                  "name": "bad-schedule",
+                  "description": "Report with invalid schedule",
+                  "schedule": "biweekly",
+                  "promptTemplate": "Generate report"
+                }
+                """);
+
+        List<String> errors = validator.validate(file, "report-definitions");
+        assertFalse(errors.isEmpty());
+        assertTrue(errors.stream().anyMatch(e -> e.contains("schedule") && e.contains("biweekly")));
+    }
+
+    @Test
+    void reportDefinitionCronScheduleIsValid() throws IOException {
+        Path file = writeJson(tempDir, "report-definitions/cron.json", """
+                {
+                  "name": "cron-report",
+                  "description": "Report with cron schedule",
+                  "schedule": "0 8 * * 1",
+                  "timeWindow": "last-7d",
+                  "promptTemplate": "Generate report"
+                }
+                """);
+
+        List<String> errors = validator.validate(file, "report-definitions");
+        assertTrue(errors.isEmpty(), "Cron schedule should be accepted: " + errors);
+    }
+
+    @Test
+    void reportDefinitionInvalidTimeWindowFails() throws IOException {
+        Path file = writeJson(tempDir, "report-definitions/bad-tw.json", """
+                {
+                  "name": "bad-tw",
+                  "description": "Report with bad time window",
+                  "schedule": "daily",
+                  "timeWindow": "last-year",
+                  "promptTemplate": "Generate report"
+                }
+                """);
+
+        List<String> errors = validator.validate(file, "report-definitions");
+        assertFalse(errors.isEmpty());
+        assertTrue(errors.stream().anyMatch(e -> e.contains("timeWindow")));
+    }
+
+    @Test
+    void reportDefinitionMissingPromptFails() throws IOException {
+        Path file = writeJson(tempDir, "report-definitions/no-prompt.json", """
+                {
+                  "name": "no-prompt",
+                  "description": "Report without prompt",
+                  "schedule": "daily"
+                }
+                """);
+
+        List<String> errors = validator.validate(file, "report-definitions");
+        assertFalse(errors.isEmpty());
+        assertTrue(errors.stream().anyMatch(e -> e.contains("promptTemplate")));
+    }
+
+    // ── General validation ──────────────────────────────────────────
+
+    @Test
+    void invalidJsonFails() throws IOException {
+        Path file = tempDir.resolve("tools");
+        Files.createDirectories(file);
+        file = file.resolve("bad.json");
+        Files.writeString(file, "this is not JSON");
+
+        List<String> errors = validator.validate(file, "tools");
+        assertFalse(errors.isEmpty());
+        assertTrue(errors.stream().anyMatch(e -> e.contains("Invalid JSON")));
+    }
+
+    @Test
+    void nonObjectRootFails() throws IOException {
+        Path file = writeJson(tempDir, "tools/array-root.json", "[1, 2, 3]");
+
+        List<String> errors = validator.validate(file, "tools");
+        assertFalse(errors.isEmpty());
+        assertTrue(errors.stream().anyMatch(e -> e.contains("JSON object")));
+    }
+
+    @Test
+    void nonExistentFileFails() {
+        Path file = tempDir.resolve("tools/does-not-exist.json");
+
+        List<String> errors = validator.validate(file, "tools");
+        assertFalse(errors.isEmpty());
+        assertTrue(errors.stream().anyMatch(e -> e.contains("does not exist")));
+    }
+
+    @Test
+    void unknownItemTypeFails() throws IOException {
+        Path file = writeJson(tempDir, "unknown/item.json", """
+                {"name": "item", "description": "test"}
+                """);
+
+        List<String> errors = validator.validate(file, "unknown");
+        assertFalse(errors.isEmpty());
+        assertTrue(errors.stream().anyMatch(e -> e.contains("Unknown item type")));
+    }
+
+    // ── detectItemType ──────────────────────────────────────────────
+
+    @Test
+    void detectItemTypeForTools() {
+        Path file = tempDir.resolve("tools/my-tool.json");
+        assertEquals("tools", validator.detectItemType(file, tempDir));
+    }
+
+    @Test
+    void detectItemTypeForActionTypes() {
+        Path file = tempDir.resolve("action-types/my-action.json");
+        assertEquals("action-types", validator.detectItemType(file, tempDir));
+    }
+
+    @Test
+    void detectItemTypeForReportDefinitions() {
+        Path file = tempDir.resolve("report-definitions/my-report.json");
+        assertEquals("report-definitions", validator.detectItemType(file, tempDir));
+    }
+
+    @Test
+    void detectItemTypeReturnsNullForUnknown() {
+        Path file = tempDir.resolve("other/something.json");
+        assertNull(validator.detectItemType(file, tempDir));
+    }
+
+    // ── Helper ──────────────────────────────────────────────────────
+
+    private Path writeJson(Path base, String relativePath, String content) throws IOException {
+        Path file = base.resolve(relativePath);
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, content);
+        return file;
+    }
+}

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -2860,6 +2860,329 @@
           }
         }
       }
+    },
+    "/assistant/sessions": {
+      "get": {
+        "tags": [
+          "Assistant"
+        ],
+        "summary": "List active assistant sessions",
+        "operationId": "listAssistantSessions",
+        "responses": {
+          "200": {
+            "description": "List of active sessions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantSessionInfoList"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Assistant"
+        ],
+        "summary": "Create a new interactive AI assistant session",
+        "operationId": "createAssistantSession",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAssistantSessionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Session created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantSessionInfo"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/assistant/sessions/{sessionId}": {
+      "get": {
+        "tags": [
+          "Assistant"
+        ],
+        "summary": "Get assistant session info",
+        "operationId": "getAssistantSession",
+        "responses": {
+          "200": {
+            "description": "Session info",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantSessionInfo"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Assistant"
+        ],
+        "summary": "End an assistant session",
+        "operationId": "deleteAssistantSession",
+        "responses": {
+          "204": {
+            "description": "Session ended"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Assistant"
+        ],
+        "summary": "Rename an assistant session",
+        "operationId": "renameAssistantSession",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RenameAssistantSessionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Session renamed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantSessionInfo"
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "sessionId",
+          "in": "path",
+          "description": "The assistant session identifier",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/assistant/sessions/{sessionId}/events": {
+      "get": {
+        "tags": [
+          "Assistant"
+        ],
+        "summary": "SSE event stream for an assistant session",
+        "operationId": "streamAssistantEvents"
+      },
+      "parameters": [
+        {
+          "name": "sessionId",
+          "in": "path",
+          "description": "The assistant session identifier",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/assistant/sessions/{sessionId}/messages": {
+      "post": {
+        "tags": [
+          "Assistant"
+        ],
+        "summary": "Send a user message to the AI assistant",
+        "operationId": "sendAssistantMessage",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendAssistantMessageRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Message sent"
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "sessionId",
+          "in": "path",
+          "description": "The assistant session identifier",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/assistant/sessions/{sessionId}/permissions": {
+      "post": {
+        "tags": [
+          "Assistant"
+        ],
+        "summary": "Respond to a permission prompt",
+        "operationId": "respondToAssistantPermission",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssistantPermissionResponse"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Permission response sent"
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "sessionId",
+          "in": "path",
+          "description": "The assistant session identifier",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/assistant/sessions/{sessionId}/items": {
+      "get": {
+        "tags": [
+          "Assistant"
+        ],
+        "summary": "List generated items from the session",
+        "operationId": "listAssistantItems",
+        "responses": {
+          "200": {
+            "description": "List of generated items",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantItemList"
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "sessionId",
+          "in": "path",
+          "description": "The assistant session identifier",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/assistant/sessions/{sessionId}/items/{itemType}/{itemName}": {
+      "get": {
+        "tags": [
+          "Assistant"
+        ],
+        "summary": "Get full content of a generated item",
+        "operationId": "getAssistantItem",
+        "responses": {
+          "200": {
+            "description": "Item content",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantItem"
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "sessionId",
+          "in": "path",
+          "description": "The assistant session identifier",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "itemType",
+          "in": "path",
+          "description": "Item type (tools, action-types, report-definitions)",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "itemName",
+          "in": "path",
+          "description": "Item name (file name without .json extension)",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/assistant/sessions/{sessionId}/apply": {
+      "post": {
+        "tags": [
+          "Assistant"
+        ],
+        "summary": "Import all generated items as a Configuration Pack",
+        "operationId": "applyAssistantSession",
+        "responses": {
+          "200": {
+            "description": "Items imported successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantApplyResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "sessionId",
+          "in": "path",
+          "description": "The assistant session identifier",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
     }
   },
   "components": {
@@ -4740,6 +5063,158 @@
             "type": "string"
           }
         }
+      },
+      "AssistantSessionInfo": {
+        "required": [
+          "id",
+          "name",
+          "status",
+          "createdAt",
+          "lastActivityAt"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "Unique session identifier",
+            "type": "string"
+          },
+          "name": {
+            "description": "User-visible session name",
+            "type": "string"
+          },
+          "status": {
+            "description": "Session status (starting, running, stopped, error)",
+            "enum": [
+              "starting",
+              "running",
+              "stopped",
+              "error"
+            ],
+            "type": "string"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "description": "Session creation timestamp",
+            "type": "string"
+          },
+          "lastActivityAt": {
+            "format": "date-time",
+            "description": "Last activity timestamp",
+            "type": "string"
+          },
+          "errorMessage": {
+            "description": "Error message if status is error",
+            "type": "string"
+          }
+        }
+      },
+      "CreateAssistantSessionRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Optional session name",
+            "type": "string"
+          }
+        }
+      },
+      "SendAssistantMessageRequest": {
+        "required": [
+          "message"
+        ],
+        "type": "object",
+        "properties": {
+          "message": {
+            "description": "The user message to send to the AI assistant",
+            "type": "string"
+          }
+        }
+      },
+      "AssistantPermissionResponse": {
+        "required": [
+          "permissionId",
+          "allow"
+        ],
+        "type": "object",
+        "properties": {
+          "permissionId": {
+            "description": "The permission request ID to respond to",
+            "type": "string"
+          },
+          "allow": {
+            "description": "Whether to allow (true) or deny (false) the tool call",
+            "type": "boolean"
+          }
+        }
+      },
+      "RenameAssistantSessionRequest": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "New session name",
+            "type": "string"
+          }
+        }
+      },
+      "AssistantItem": {
+        "required": [
+          "type",
+          "name",
+          "valid"
+        ],
+        "type": "object",
+        "properties": {
+          "type": {
+            "description": "Item type directory (tools, action-types, report-definitions)",
+            "type": "string"
+          },
+          "name": {
+            "description": "Item name (file name without .json)",
+            "type": "string"
+          },
+          "valid": {
+            "description": "Whether the item passed validation",
+            "type": "boolean"
+          },
+          "validationErrors": {
+            "description": "List of validation errors (empty if valid)",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "AssistantApplyResult": {
+        "type": "object",
+        "properties": {
+          "tools": {
+            "description": "Number of tools imported",
+            "type": "integer"
+          },
+          "actionTypes": {
+            "description": "Number of action types imported",
+            "type": "integer"
+          },
+          "reportDefinitions": {
+            "description": "Number of report definitions imported",
+            "type": "integer"
+          }
+        }
+      },
+      "AssistantSessionInfoList": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/AssistantSessionInfo"
+        }
+      },
+      "AssistantItemList": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/AssistantItem"
+        }
       }
     },
     "responses": {
@@ -4851,6 +5326,10 @@
     {
       "name": "Tools",
       "description": "Custom tool definitions for AI agents"
+    },
+    {
+      "name": "Assistant",
+      "description": "Interactive AI assistant session management"
     }
   ]
 }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -13,11 +13,13 @@
                 "@patternfly/react-core": "6.4.3",
                 "@patternfly/react-icons": "6.4.0",
                 "@patternfly/react-table": "6.4.3",
+                "@types/react-syntax-highlighter": "^15.5.13",
                 "monaco-editor": "0.55.1",
                 "react": "19.2.5",
                 "react-dom": "19.2.5",
                 "react-markdown": "10.1.0",
                 "react-router-dom": "7.15.0",
+                "react-syntax-highlighter": "^16.1.1",
                 "remark-gfm": "4.0.1"
             },
             "devDependencies": {
@@ -277,6 +279,15 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/runtime": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+            "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/template": {
@@ -1392,6 +1403,12 @@
             "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
             "license": "MIT"
         },
+        "node_modules/@types/prismjs": {
+            "version": "1.26.6",
+            "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.6.tgz",
+            "integrity": "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==",
+            "license": "MIT"
+        },
         "node_modules/@types/react": {
             "version": "19.2.14",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -1409,6 +1426,15 @@
             "license": "MIT",
             "peerDependencies": {
                 "@types/react": "^19.2.0"
+            }
+        },
+        "node_modules/@types/react-syntax-highlighter": {
+            "version": "15.5.13",
+            "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.13.tgz",
+            "integrity": "sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/react": "*"
             }
         },
         "node_modules/@types/trusted-types": {
@@ -1795,6 +1821,19 @@
             "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
             "license": "MIT"
         },
+        "node_modules/fault": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+            "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+            "license": "MIT",
+            "dependencies": {
+                "format": "^0.2.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/fdir": {
             "version": "6.5.0",
             "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1832,6 +1871,14 @@
             "license": "MIT",
             "dependencies": {
                 "tabbable": "^6.2.0"
+            }
+        },
+        "node_modules/format": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+            "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+            "engines": {
+                "node": ">=0.4.x"
             }
         },
         "node_modules/fsevents": {
@@ -1877,6 +1924,19 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/hast-util-parse-selector": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+            "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
         "node_modules/hast-util-to-jsx-runtime": {
             "version": "2.3.6",
             "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -1916,6 +1976,38 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
             }
+        },
+        "node_modules/hastscript": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+            "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "comma-separated-tokens": "^2.0.0",
+                "hast-util-parse-selector": "^4.0.0",
+                "property-information": "^7.0.0",
+                "space-separated-tokens": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/highlight.js": {
+            "version": "10.7.3",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+            "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/highlightjs-vue": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/highlightjs-vue/-/highlightjs-vue-1.0.0.tgz",
+            "integrity": "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==",
+            "license": "CC0-1.0"
         },
         "node_modules/html-url-attributes": {
             "version": "3.0.1",
@@ -2057,6 +2149,20 @@
             },
             "bin": {
                 "loose-envify": "cli.js"
+            }
+        },
+        "node_modules/lowlight": {
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
+            "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
+            "license": "MIT",
+            "dependencies": {
+                "fault": "^1.0.0",
+                "highlight.js": "~10.7.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/lru-cache": {
@@ -3132,6 +3238,15 @@
                 "node": "^10 || ^12 || >=14"
             }
         },
+        "node_modules/prismjs": {
+            "version": "1.30.0",
+            "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+            "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/prop-types": {
             "version": "15.8.1",
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -3270,6 +3385,42 @@
             "peerDependencies": {
                 "react": ">=18",
                 "react-dom": ">=18"
+            }
+        },
+        "node_modules/react-syntax-highlighter": {
+            "version": "16.1.1",
+            "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-16.1.1.tgz",
+            "integrity": "sha512-PjVawBGy80C6YbC5DDZJeUjBmC7skaoEUdvfFQediQHgCL7aKyVHe57SaJGfQsloGDac+gCpTfRdtxzWWKmCXA==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.28.4",
+                "highlight.js": "^10.4.1",
+                "highlightjs-vue": "^1.0.0",
+                "lowlight": "^1.17.0",
+                "prismjs": "^1.30.0",
+                "refractor": "^5.0.0"
+            },
+            "engines": {
+                "node": ">= 16.20.2"
+            },
+            "peerDependencies": {
+                "react": ">= 0.14.0"
+            }
+        },
+        "node_modules/refractor": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/refractor/-/refractor-5.0.0.tgz",
+            "integrity": "sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@types/prismjs": "^1.0.0",
+                "hastscript": "^9.0.0",
+                "parse-entities": "^4.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/remark-gfm": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -15,19 +15,21 @@
         "@patternfly/react-core": "6.4.3",
         "@patternfly/react-icons": "6.4.0",
         "@patternfly/react-table": "6.4.3",
+        "@types/react-syntax-highlighter": "^15.5.13",
         "monaco-editor": "0.55.1",
         "react": "19.2.5",
         "react-dom": "19.2.5",
         "react-markdown": "10.1.0",
         "react-router-dom": "7.15.0",
+        "react-syntax-highlighter": "^16.1.1",
         "remark-gfm": "4.0.1"
     },
     "devDependencies": {
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
         "@vitejs/plugin-react": "4.7.0",
-        "typescript": "5.9.3",
         "rimraf": "6.1.3",
+        "typescript": "5.9.3",
         "vite": "6.4.2"
     }
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,32 +1,6 @@
-import { useState, useEffect, useCallback } from "react";
-import { Routes, Route, useNavigate, useLocation } from "react-router-dom";
-import {
-    AboutModal,
-    Button,
-    Masthead,
-    MastheadBrand,
-    MastheadContent,
-    MastheadMain,
-    Nav,
-    NavExpandable,
-    NavItem,
-    NavList,
-    NotificationDrawer,
-    NotificationDrawerBody,
-    NotificationDrawerHeader,
-    NotificationDrawerList,
-    NotificationDrawerListItem,
-    NotificationDrawerListItemBody,
-    NotificationDrawerListItemHeader,
-    Page,
-    PageSidebar,
-    PageSidebarBody,
-    Toolbar,
-    ToolbarContent,
-    ToolbarItem,
-    Content,
-} from "@patternfly/react-core";
-import QuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/question-circle-icon";
+import { useState, useEffect } from "react";
+import { Routes, Route } from "react-router-dom";
+import { Page } from "@patternfly/react-core";
 
 import { DashboardPage } from "./pages/DashboardPage";
 import { ProjectsPage } from "./pages/ProjectsPage";
@@ -54,49 +28,21 @@ import { ToolDetailPage } from "./pages/ToolDetailPage";
 import { ToolsetsPage } from "./pages/ToolsetsPage";
 import { ToolsetDetailPage } from "./pages/ToolsetDetailPage";
 import { SecretsPage } from "./pages/SecretsPage";
+import { AppMasthead } from "./components/AppMasthead";
+import { AppSidebar } from "./components/AppSidebar";
 import { ConfigurationWarning } from "./components/ConfigurationWarning";
 import { ConfigurationPacksPage } from "./pages/ConfigurationPacksPage";
 import { EngineSettingsPage } from "./pages/EngineSettingsPage";
 import { EventSourceDetailPage } from "./pages/EventSourceDetailPage";
+import { AssistantPage } from "./pages/AssistantPage";
+import { AssistantSessionPage } from "./pages/AssistantSessionPage";
 import { type StartupCheck, fetchSystemHealth, fetchSystemConfig } from "./config/api";
-import { sseClient, type AxiomSseEvent } from "./config/sse";
-
-interface Notification {
-    id: number;
-    message: string;
-    severity: string;
-    timestamp: Date;
-    read: boolean;
-}
-
-const CONFIG_PATHS = ["/actors", "/manager", "/action-types", "/tools", "/toolsets", "/mcp-servers", "/secrets", "/event-sources", "/report-definitions", "/engine", "/configuration-packs"];
-
-let notificationIdCounter = 0;
+import { sseClient } from "./config/sse";
 
 export function App() {
-    const navigate = useNavigate();
-    const location = useLocation();
-    const [isDrawerOpen, setIsDrawerOpen] = useState(false);
-    const [isAboutOpen, setIsAboutOpen] = useState(false);
     const [startupChecks, setStartupChecks] = useState<StartupCheck[] | null>(null);
     const [engineName, setEngineName] = useState<string | undefined>(undefined);
     const [appVersion, setAppVersion] = useState<string>("");
-    const [notifications, setNotifications] = useState<Notification[]>([]);
-
-    const unreadCount = notifications.filter((n) => !n.read).length;
-
-    const addNotification = useCallback((message: string, severity: string) => {
-        setNotifications((prev) => [
-            {
-                id: ++notificationIdCounter,
-                message,
-                severity,
-                timestamp: new Date(),
-                read: false,
-            },
-            ...prev,
-        ].slice(0, 50)); // Keep last 50
-    }, []);
 
     useEffect(() => {
         fetchSystemHealth()
@@ -117,226 +63,19 @@ export function App() {
             })
             .catch(console.error);
 
-        const unsubscribe = sseClient.subscribe((event: AxiomSseEvent) => {
-            if (event.type === "notification") {
-                const data = event.data as { message?: string; severity?: string };
-                addNotification(
-                    data.message || "New notification",
-                    data.severity || "info"
-                );
-            }
-        });
-
         return () => {
-            unsubscribe();
             sseClient.disconnect();
         };
-    }, [addNotification]);
-
-    const markAllRead = () => {
-        setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
-    };
-
-    const clearAll = () => {
-        setNotifications([]);
-        setIsDrawerOpen(false);
-    };
-
-    const masthead = (
-        <Masthead style={{
-            position: "relative",
-            borderBottom: "none",
-            boxShadow: "none",
-            background: "white",
-            marginBottom: "6px",
-        }}>
-            <MastheadMain>
-                <MastheadBrand>
-                    <span
-                        style={{ fontSize: "20px", fontWeight: 600, color: "#0b2545", cursor: "pointer", letterSpacing: "-0.5px" }}
-                        onClick={() => navigate("/")}>Apitomy Axiom</span>
-                </MastheadBrand>
-            </MastheadMain>
-            <MastheadContent>
-                <Toolbar>
-                    <ToolbarContent>
-                        <ToolbarItem align={{ default: "alignEnd" }}>
-                            <Button variant="plain" aria-label="About"
-                                onClick={() => setIsAboutOpen(true)}>
-                                <QuestionCircleIcon style={{ color: "#2082a3" }} />
-                            </Button>
-                        </ToolbarItem>
-                    </ToolbarContent>
-                </Toolbar>
-            </MastheadContent>
-            <div style={{
-                position: "absolute",
-                bottom: 0,
-                left: 0,
-                right: 0,
-                height: "3px",
-                background: "linear-gradient(90deg, #0b2545, #1b6b93, #4fc0d0)",
-            }} />
-        </Masthead>
-    );
-
-    const isConfigActive = CONFIG_PATHS.some(
-        (p) => location.pathname === p || location.pathname.startsWith(p + "/")
-    );
-
-    const sidebar = (
-        <PageSidebar>
-            <PageSidebarBody>
-                <Nav>
-                    <NavList>
-                        <NavItem isActive={location.pathname === "/"} onClick={() => navigate("/")}>
-                            Dashboard
-                        </NavItem>
-                        <NavItem isActive={location.pathname.startsWith("/reports")} onClick={() => navigate("/reports")}>
-                            Reports
-                        </NavItem>
-                        <NavItem isActive={location.pathname.startsWith("/projects")} onClick={() => navigate("/projects")}>
-                            Projects
-                        </NavItem>
-                        <NavExpandable title="Logs"
-                            isActive={location.pathname.startsWith("/logs")}
-                            isExpanded={location.pathname.startsWith("/logs")}>
-                            <NavItem isActive={location.pathname === "/logs/activity"} onClick={() => navigate("/logs/activity")}>
-                                All Activity
-                            </NavItem>
-                            <NavItem isActive={location.pathname === "/logs/events"} onClick={() => navigate("/logs/events")}>
-                                Events
-                            </NavItem>
-                            <NavItem isActive={location.pathname === "/logs/manager"} onClick={() => navigate("/logs/manager")}>
-                                Manager Decisions
-                            </NavItem>
-                            <NavItem isActive={location.pathname === "/logs/tasks"} onClick={() => navigate("/logs/tasks")}>
-                                Tasks
-                            </NavItem>
-                        </NavExpandable>
-                        <NavExpandable title="Metrics"
-                            isActive={location.pathname.startsWith("/metrics")}
-                            isExpanded={location.pathname.startsWith("/metrics")}>
-                            <NavItem isActive={location.pathname === "/metrics/ai-usage"} onClick={() => navigate("/metrics/ai-usage")}>
-                                AI Usage
-                            </NavItem>
-                            <NavItem isActive={location.pathname === "/metrics/disk-usage"} onClick={() => navigate("/metrics/disk-usage")}>
-                                Disk Usage
-                            </NavItem>
-                        </NavExpandable>
-                        <NavExpandable title="Configuration" isActive={isConfigActive} isExpanded={isConfigActive}>
-                            <NavItem isActive={location.pathname.startsWith("/engine")} onClick={() => navigate("/engine")}>
-                                AI Engine
-                            </NavItem>
-                            <NavItem isActive={location.pathname.startsWith("/action-types")} onClick={() => navigate("/action-types")}>
-                                Action Types
-                            </NavItem>
-                            <NavItem isActive={location.pathname.startsWith("/actors")} onClick={() => navigate("/actors")}>
-                                Actors
-                            </NavItem>
-                            <NavItem isActive={location.pathname.startsWith("/manager")} onClick={() => navigate("/manager")}>
-                                Manager
-                            </NavItem>
-                            <NavItem isActive={location.pathname.startsWith("/mcp-servers")} onClick={() => navigate("/mcp-servers")}>
-                                MCP Servers
-                            </NavItem>
-                            <NavItem isActive={location.pathname.startsWith("/report-definitions")} onClick={() => navigate("/report-definitions")}>
-                                Report Definitions
-                            </NavItem>
-                            <NavItem isActive={location.pathname.startsWith("/event-sources")} onClick={() => navigate("/event-sources")}>
-                                Event Sources
-                            </NavItem>
-                            <NavItem isActive={location.pathname === "/secrets"} onClick={() => navigate("/secrets")}>
-                                Secrets
-                            </NavItem>
-                            <NavItem isActive={location.pathname.startsWith("/tools") && !location.pathname.startsWith("/toolsets")} onClick={() => navigate("/tools")}>
-                                Tools
-                            </NavItem>
-                            <NavItem isActive={location.pathname.startsWith("/toolsets")} onClick={() => navigate("/toolsets")}>
-                                Toolsets
-                            </NavItem>
-                            <NavItem isActive={location.pathname === "/configuration-packs"} onClick={() => navigate("/configuration-packs")}>
-                                Configuration Packs
-                            </NavItem>
-                        </NavExpandable>
-                    </NavList>
-                </Nav>
-            </PageSidebarBody>
-        </PageSidebar>
-    );
-
-    const notificationDrawer = isDrawerOpen ? (
-        <NotificationDrawer>
-            <NotificationDrawerHeader
-                count={unreadCount}
-                onClose={() => setIsDrawerOpen(false)}
-            >
-                <Button variant="link" onClick={markAllRead} isInline>
-                    Mark all read
-                </Button>
-                {" "}
-                <Button variant="link" onClick={clearAll} isInline>
-                    Clear all
-                </Button>
-            </NotificationDrawerHeader>
-            <NotificationDrawerBody>
-                <NotificationDrawerList>
-                    {notifications.length === 0 ? (
-                        <div style={{ padding: "24px", textAlign: "center", color: "#6a6e73" }}>
-                            No notifications
-                        </div>
-                    ) : (
-                        notifications.map((n) => (
-                            <NotificationDrawerListItem
-                                key={n.id}
-                                variant={
-                                    n.severity === "error"
-                                        ? "danger"
-                                        : n.severity === "warning"
-                                          ? "warning"
-                                          : "info"
-                                }
-                                isRead={n.read}
-                                onClick={() =>
-                                    setNotifications((prev) =>
-                                        prev.map((x) =>
-                                            x.id === n.id
-                                                ? { ...x, read: true }
-                                                : x
-                                        )
-                                    )
-                                }
-                            >
-                                <NotificationDrawerListItemHeader
-                                    title={n.message}
-                                    variant={
-                                        n.severity === "error"
-                                            ? "danger"
-                                            : n.severity === "warning"
-                                              ? "warning"
-                                              : "info"
-                                    }
-                                />
-                                <NotificationDrawerListItemBody
-                                    timestamp={n.timestamp.toLocaleString()}
-                                />
-                            </NotificationDrawerListItem>
-                        ))
-                    )}
-                </NotificationDrawerList>
-            </NotificationDrawerBody>
-        </NotificationDrawer>
-    ) : undefined;
+    }, []);
 
     const hasCheckErrors = startupChecks != null &&
         startupChecks.some((c) => c.status === "error");
 
     return (
         <Page
-            masthead={masthead}
-            sidebar={hasCheckErrors ? undefined : sidebar}
-            notificationDrawer={notificationDrawer}
-            isNotificationDrawerExpanded={isDrawerOpen}
+            masthead={<AppMasthead engineName={engineName} appVersion={appVersion} />}
+            sidebar={hasCheckErrors ? undefined : <AppSidebar />}
+            isContentFilled
         >
             {hasCheckErrors ? (
                 <ConfigurationWarning checks={startupChecks!} />
@@ -371,36 +110,10 @@ export function App() {
                     <Route path="/event-sources/:eventSourceId" element={<EventSourceDetailPage />} />
                     <Route path="/secrets" element={<SecretsPage />} />
                     <Route path="/configuration-packs" element={<ConfigurationPacksPage />} />
+                    <Route path="/assistant" element={<AssistantPage />} />
+                    <Route path="/assistant/:sessionId" element={<AssistantSessionPage />} />
                 </Routes>
             )}
-
-            <AboutModal
-                isOpen={isAboutOpen}
-                onClose={() => setIsAboutOpen(false)}
-                brandImageSrc="/logo.png"
-                brandImageAlt="Apitomy Axiom"
-                trademark="Copyright &copy; 2025-2026"
-            >
-                <Content component="dl">
-                    <dt>Version</dt>
-                    <dd>{appVersion || "—"}</dd>
-                    <dt>AI Engine</dt>
-                    <dd>
-                        {engineName === "opencode" ? "OpenCode"
-                            : engineName === "claude-code" ? "Claude Code"
-                            : engineName || "—"}
-                    </dd>
-                    <dt>License</dt>
-                    <dd>Apache License 2.0</dd>
-                    <dt>Source</dt>
-                    <dd>
-                        <a href="https://github.com/Apitomy/apitomy-axiom"
-                            target="_blank" rel="noopener noreferrer">
-                            github.com/Apitomy/apitomy-axiom
-                        </a>
-                    </dd>
-                </Content>
-            </AboutModal>
         </Page>
     );
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { Routes, Route } from "react-router-dom";
+import { Routes, Route, useLocation } from "react-router-dom";
 import { Page } from "@patternfly/react-core";
 
 import { DashboardPage } from "./pages/DashboardPage";
@@ -40,6 +40,7 @@ import { type StartupCheck, fetchSystemHealth, fetchSystemConfig } from "./confi
 import { sseClient } from "./config/sse";
 
 export function App() {
+    const location = useLocation();
     const [startupChecks, setStartupChecks] = useState<StartupCheck[] | null>(null);
     const [engineName, setEngineName] = useState<string | undefined>(undefined);
     const [appVersion, setAppVersion] = useState<string>("");
@@ -70,11 +71,12 @@ export function App() {
 
     const hasCheckErrors = startupChecks != null &&
         startupChecks.some((c) => c.status === "error");
+    const isAssistantPage = location.pathname.startsWith("/assistant");
 
     return (
         <Page
             masthead={<AppMasthead engineName={engineName} appVersion={appVersion} />}
-            sidebar={hasCheckErrors ? undefined : <AppSidebar />}
+            sidebar={hasCheckErrors || isAssistantPage ? undefined : <AppSidebar />}
             isContentFilled
         >
             {hasCheckErrors ? (

--- a/ui/src/components/AppMasthead.css
+++ b/ui/src/components/AppMasthead.css
@@ -1,0 +1,20 @@
+@keyframes axiom-throb {
+    0%, 100% {
+        transform: scale(1);
+        color: #2082a3;
+    }
+    50% {
+        transform: scale(2);
+        color: #cc6600;
+    }
+}
+
+.axiom-assistant-throb svg {
+    animation: axiom-throb 2s ease-in-out infinite;
+}
+
+.axiom-assistant-throb:hover svg {
+    animation: none;
+    transform: scale(1.3);
+    color: #0066cc;
+}

--- a/ui/src/components/AppMasthead.tsx
+++ b/ui/src/components/AppMasthead.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import "./AppMasthead.css";
+import {
+    AboutModal,
+    Button,
+    Content,
+    Masthead,
+    MastheadBrand,
+    MastheadContent,
+    MastheadMain,
+    Toolbar,
+    ToolbarContent,
+    ToolbarItem,
+    Tooltip,
+} from "@patternfly/react-core";
+import QuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/question-circle-icon";
+import RobotIcon from "@patternfly/react-icons/dist/esm/icons/robot-icon";
+
+interface AppMastheadProps {
+    engineName?: string;
+    appVersion: string;
+}
+
+export function AppMasthead({ engineName, appVersion }: AppMastheadProps) {
+    const navigate = useNavigate();
+    const [isAboutOpen, setIsAboutOpen] = useState(false);
+
+    return (
+        <>
+            <Masthead style={{
+                position: "relative",
+                borderBottom: "none",
+                boxShadow: "none",
+                background: "white",
+                marginBottom: "6px",
+            }}>
+                <MastheadMain>
+                    <MastheadBrand>
+                        <span
+                            style={{ fontSize: "20px", fontWeight: 600, color: "#0b2545", cursor: "pointer", letterSpacing: "-0.5px" }}
+                            onClick={() => navigate("/")}>Apitomy Axiom</span>
+                    </MastheadBrand>
+                </MastheadMain>
+                <MastheadContent>
+                    <Toolbar>
+                        <ToolbarContent>
+                            <ToolbarItem align={{ default: "alignEnd" }}>
+                                {engineName === "claude-code" && (
+                                    <Tooltip content="AI Assistant">
+                                        <Button variant="plain" aria-label="AI Assistant"
+                                            onClick={() => {
+                                                localStorage.setItem("axiom.assistant.discovered", "true");
+                                                navigate("/assistant");
+                                            }}
+                                            className={
+                                                localStorage.getItem("axiom.assistant.discovered")
+                                                    ? undefined : "axiom-assistant-throb"
+                                            }>
+                                            <RobotIcon style={{ color: "#2082a3", transform: "scale(1.25)" }} />
+                                        </Button>
+                                    </Tooltip>
+                                )}
+                            </ToolbarItem>
+                            <ToolbarItem>
+                                <Tooltip content="About Axiom">
+                                    <Button variant="plain" aria-label="About"
+                                        onClick={() => setIsAboutOpen(true)}>
+                                        <QuestionCircleIcon style={{ color: "#2082a3" }} />
+                                    </Button>
+                                </Tooltip>
+                            </ToolbarItem>
+                        </ToolbarContent>
+                    </Toolbar>
+                </MastheadContent>
+                <div style={{
+                    position: "absolute",
+                    bottom: 0,
+                    left: 0,
+                    right: 0,
+                    height: "3px",
+                    background: "linear-gradient(90deg, #0b2545, #1b6b93, #4fc0d0)",
+                }} />
+            </Masthead>
+
+            <AboutModal
+                isOpen={isAboutOpen}
+                onClose={() => setIsAboutOpen(false)}
+                brandImageSrc="/logo.png"
+                brandImageAlt="Apitomy Axiom"
+                trademark="Copyright &copy; 2025-2026"
+            >
+                <Content component="dl">
+                    <dt>Version</dt>
+                    <dd>{appVersion || "—"}</dd>
+                    <dt>AI Engine</dt>
+                    <dd>
+                        {engineName === "opencode" ? "OpenCode"
+                            : engineName === "claude-code" ? "Claude Code"
+                            : engineName || "—"}
+                    </dd>
+                    <dt>License</dt>
+                    <dd>Apache License 2.0</dd>
+                    <dt>Source</dt>
+                    <dd>
+                        <a href="https://github.com/Apitomy/apitomy-axiom"
+                            target="_blank" rel="noopener noreferrer">
+                            github.com/Apitomy/apitomy-axiom
+                        </a>
+                    </dd>
+                </Content>
+            </AboutModal>
+        </>
+    );
+}

--- a/ui/src/components/AppSidebar.tsx
+++ b/ui/src/components/AppSidebar.tsx
@@ -1,0 +1,101 @@
+import { useNavigate, useLocation } from "react-router-dom";
+import {
+    Nav,
+    NavExpandable,
+    NavItem,
+    NavList,
+    PageSidebar,
+    PageSidebarBody,
+} from "@patternfly/react-core";
+
+const CONFIG_PATHS = ["/actors", "/manager", "/action-types", "/tools", "/toolsets", "/mcp-servers", "/secrets", "/event-sources", "/report-definitions", "/engine", "/configuration-packs"];
+
+export function AppSidebar() {
+    const navigate = useNavigate();
+    const location = useLocation();
+
+    const isConfigActive = CONFIG_PATHS.some(
+        (p) => location.pathname === p || location.pathname.startsWith(p + "/")
+    );
+
+    return (
+        <PageSidebar>
+            <PageSidebarBody>
+                <Nav>
+                    <NavList>
+                        <NavItem isActive={location.pathname === "/"} onClick={() => navigate("/")}>
+                            Dashboard
+                        </NavItem>
+                        <NavItem isActive={location.pathname.startsWith("/reports")} onClick={() => navigate("/reports")}>
+                            Reports
+                        </NavItem>
+                        <NavItem isActive={location.pathname.startsWith("/projects")} onClick={() => navigate("/projects")}>
+                            Projects
+                        </NavItem>
+                        <NavExpandable title="Logs"
+                            isActive={location.pathname.startsWith("/logs")}
+                            isExpanded={location.pathname.startsWith("/logs")}>
+                            <NavItem isActive={location.pathname === "/logs/activity"} onClick={() => navigate("/logs/activity")}>
+                                All Activity
+                            </NavItem>
+                            <NavItem isActive={location.pathname === "/logs/events"} onClick={() => navigate("/logs/events")}>
+                                Events
+                            </NavItem>
+                            <NavItem isActive={location.pathname === "/logs/manager"} onClick={() => navigate("/logs/manager")}>
+                                Manager Decisions
+                            </NavItem>
+                            <NavItem isActive={location.pathname === "/logs/tasks"} onClick={() => navigate("/logs/tasks")}>
+                                Tasks
+                            </NavItem>
+                        </NavExpandable>
+                        <NavExpandable title="Metrics"
+                            isActive={location.pathname.startsWith("/metrics")}
+                            isExpanded={location.pathname.startsWith("/metrics")}>
+                            <NavItem isActive={location.pathname === "/metrics/ai-usage"} onClick={() => navigate("/metrics/ai-usage")}>
+                                AI Usage
+                            </NavItem>
+                            <NavItem isActive={location.pathname === "/metrics/disk-usage"} onClick={() => navigate("/metrics/disk-usage")}>
+                                Disk Usage
+                            </NavItem>
+                        </NavExpandable>
+                        <NavExpandable title="Configuration" isActive={isConfigActive} isExpanded={isConfigActive}>
+                            <NavItem isActive={location.pathname.startsWith("/engine")} onClick={() => navigate("/engine")}>
+                                AI Engine
+                            </NavItem>
+                            <NavItem isActive={location.pathname.startsWith("/action-types")} onClick={() => navigate("/action-types")}>
+                                Action Types
+                            </NavItem>
+                            <NavItem isActive={location.pathname.startsWith("/actors")} onClick={() => navigate("/actors")}>
+                                Actors
+                            </NavItem>
+                            <NavItem isActive={location.pathname.startsWith("/manager")} onClick={() => navigate("/manager")}>
+                                Manager
+                            </NavItem>
+                            <NavItem isActive={location.pathname.startsWith("/mcp-servers")} onClick={() => navigate("/mcp-servers")}>
+                                MCP Servers
+                            </NavItem>
+                            <NavItem isActive={location.pathname.startsWith("/report-definitions")} onClick={() => navigate("/report-definitions")}>
+                                Report Definitions
+                            </NavItem>
+                            <NavItem isActive={location.pathname.startsWith("/event-sources")} onClick={() => navigate("/event-sources")}>
+                                Event Sources
+                            </NavItem>
+                            <NavItem isActive={location.pathname === "/secrets"} onClick={() => navigate("/secrets")}>
+                                Secrets
+                            </NavItem>
+                            <NavItem isActive={location.pathname.startsWith("/tools") && !location.pathname.startsWith("/toolsets")} onClick={() => navigate("/tools")}>
+                                Tools
+                            </NavItem>
+                            <NavItem isActive={location.pathname.startsWith("/toolsets")} onClick={() => navigate("/toolsets")}>
+                                Toolsets
+                            </NavItem>
+                            <NavItem isActive={location.pathname === "/configuration-packs"} onClick={() => navigate("/configuration-packs")}>
+                                Configuration Packs
+                            </NavItem>
+                        </NavExpandable>
+                    </NavList>
+                </Nav>
+            </PageSidebarBody>
+        </PageSidebar>
+    );
+}

--- a/ui/src/components/assistant/ActionTypeDetailModal.css
+++ b/ui/src/components/assistant/ActionTypeDetailModal.css
@@ -1,0 +1,19 @@
+.assistant-tabbed-modal-body {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+
+.assistant-tabbed-modal-body > .pf-v6-c-tab-content:not([hidden]) {
+    flex: 1 1 0;
+    min-height: 0;
+    display: flex !important;
+    flex-direction: column;
+}
+
+.assistant-tabbed-modal-body > .pf-v6-c-tab-content:not([hidden]) > div {
+    flex: 1 1 0;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+}

--- a/ui/src/components/assistant/ActionTypeDetailModal.tsx
+++ b/ui/src/components/assistant/ActionTypeDetailModal.tsx
@@ -1,0 +1,128 @@
+import {
+    Modal,
+    ModalBody,
+    ModalHeader,
+    DescriptionList,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    DescriptionListDescription,
+    Label,
+    CodeBlock,
+    CodeBlockCode,
+} from "@patternfly/react-core";
+
+interface ActionTypeDetailModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    name: string;
+    content: Record<string, unknown>;
+}
+
+export function ActionTypeDetailModal({ isOpen, onClose, name, content }: ActionTypeDetailModalProps) {
+    const description = (content.description as string) || "";
+    const executionMode = (content.executionMode as string) || "actor";
+    const userTriggerable = content.userTriggerable as boolean ?? false;
+    const managerTriggerable = content.managerTriggerable as boolean ?? false;
+    const emitsEvent = content.emitsEvent as boolean ?? false;
+    const allowedTools = (content.allowedTools as string) || "";
+    const promptTemplate = (content.promptTemplate as string) || "";
+    const scriptTemplate = (content.scriptTemplate as string) || "";
+    const model = (content.model as string) || "";
+    const engine = (content.engine as string) || "";
+
+    const toolsList = allowedTools
+        ? allowedTools.split(",").map((t) => t.trim()).filter(Boolean)
+        : [];
+
+    return (
+        <Modal
+            isOpen={isOpen}
+            onClose={onClose}
+            variant="large"
+            aria-label={`Action Type: ${name}`}
+        >
+            <ModalHeader title={`Action Type: ${name}`} />
+            <ModalBody>
+                <DescriptionList isHorizontal>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Name</DescriptionListTerm>
+                        <DescriptionListDescription>{name}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Description</DescriptionListTerm>
+                        <DescriptionListDescription>{description || "—"}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Execution Mode</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            <Label isCompact color={executionMode === "actor" ? "blue" : "orange"}>
+                                {executionMode}
+                            </Label>
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Flags</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            {userTriggerable && <Label isCompact color="green" style={{ marginRight: 4 }}>User Triggerable</Label>}
+                            {managerTriggerable && <Label isCompact color="blue" style={{ marginRight: 4 }}>Manager Triggerable</Label>}
+                            {emitsEvent && <Label isCompact color="purple" style={{ marginRight: 4 }}>Emits Event</Label>}
+                            {!userTriggerable && !managerTriggerable && !emitsEvent && "—"}
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                </DescriptionList>
+
+                {toolsList.length > 0 && (
+                    <>
+                        <h4 style={{ marginTop: 16, marginBottom: 8 }}>Allowed Tools</h4>
+                        <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
+                            {toolsList.map((tool) => (
+                                <Label key={tool} isCompact
+                                    color={tool.startsWith("@") ? "green" : "blue"}>
+                                    {tool}
+                                </Label>
+                            ))}
+                        </div>
+                    </>
+                )}
+
+                {promptTemplate && (
+                    <>
+                        <h4 style={{ marginTop: 16, marginBottom: 8 }}>Prompt Template</h4>
+                        <CodeBlock>
+                            <CodeBlockCode>{promptTemplate}</CodeBlockCode>
+                        </CodeBlock>
+                    </>
+                )}
+
+                {scriptTemplate && (
+                    <>
+                        <h4 style={{ marginTop: 16, marginBottom: 8 }}>Script Template</h4>
+                        <CodeBlock>
+                            <CodeBlockCode>{scriptTemplate}</CodeBlockCode>
+                        </CodeBlock>
+                    </>
+                )}
+
+                {(model || engine) && (
+                    <>
+                        <h4 style={{ marginTop: 16, marginBottom: 8 }}>Advanced</h4>
+                        <DescriptionList isHorizontal isCompact>
+                            {model && (
+                                <DescriptionListGroup>
+                                    <DescriptionListTerm>Model</DescriptionListTerm>
+                                    <DescriptionListDescription>{model}</DescriptionListDescription>
+                                </DescriptionListGroup>
+                            )}
+                            {engine && (
+                                <DescriptionListGroup>
+                                    <DescriptionListTerm>Engine</DescriptionListTerm>
+                                    <DescriptionListDescription>{engine}</DescriptionListDescription>
+                                </DescriptionListGroup>
+                            )}
+                        </DescriptionList>
+                    </>
+                )}
+            </ModalBody>
+        </Modal>
+    );
+}

--- a/ui/src/components/assistant/ActionTypeDetailModal.tsx
+++ b/ui/src/components/assistant/ActionTypeDetailModal.tsx
@@ -115,7 +115,7 @@ export function ActionTypeDetailModal({ isOpen, onClose, name, content }: Action
                             </DescriptionList>
                         </div>
                     </Tab>
-                    {templateContent && (
+                    {templateContent ? (
                         <Tab eventKey={1} title={<TabTitleText>{templateLabel}</TabTitleText>}>
                             <div style={{ paddingTop: 16, flex: "1 1 0", minHeight: 0 }}>
                                 <CodeEditor
@@ -127,7 +127,7 @@ export function ActionTypeDetailModal({ isOpen, onClose, name, content }: Action
                                 />
                             </div>
                         </Tab>
-                    )}
+                    ) : null}
                 </Tabs>
             </ModalBody>
         </Modal>

--- a/ui/src/components/assistant/ActionTypeDetailModal.tsx
+++ b/ui/src/components/assistant/ActionTypeDetailModal.tsx
@@ -7,9 +7,13 @@ import {
     DescriptionListTerm,
     DescriptionListDescription,
     Label,
-    CodeBlock,
-    CodeBlockCode,
+    Tab,
+    Tabs,
+    TabTitleText,
 } from "@patternfly/react-core";
+import { CodeEditor, Language } from "@patternfly/react-code-editor";
+import { useState } from "react";
+import "./ActionTypeDetailModal.css";
 
 interface ActionTypeDetailModalProps {
     isOpen: boolean;
@@ -19,6 +23,8 @@ interface ActionTypeDetailModalProps {
 }
 
 export function ActionTypeDetailModal({ isOpen, onClose, name, content }: ActionTypeDetailModalProps) {
+    const [activeTab, setActiveTab] = useState(0);
+
     const description = (content.description as string) || "";
     const executionMode = (content.executionMode as string) || "actor";
     const userTriggerable = content.userTriggerable as boolean ?? false;
@@ -34,94 +40,95 @@ export function ActionTypeDetailModal({ isOpen, onClose, name, content }: Action
         ? allowedTools.split(",").map((t) => t.trim()).filter(Boolean)
         : [];
 
+    const isActorMode = executionMode === "actor";
+    const templateContent = isActorMode ? promptTemplate : scriptTemplate;
+    const templateLabel = isActorMode ? "Prompt Template" : "Script Template";
+    const templateLanguage = isActorMode ? Language.markdown : Language.shell;
+
     return (
         <Modal
             isOpen={isOpen}
             onClose={onClose}
             variant="large"
             aria-label={`Action Type: ${name}`}
+            style={{ height: "80vh" }}
         >
             <ModalHeader title={`Action Type: ${name}`} />
-            <ModalBody>
-                <DescriptionList isHorizontal>
-                    <DescriptionListGroup>
-                        <DescriptionListTerm>Name</DescriptionListTerm>
-                        <DescriptionListDescription>{name}</DescriptionListDescription>
-                    </DescriptionListGroup>
-                    <DescriptionListGroup>
-                        <DescriptionListTerm>Description</DescriptionListTerm>
-                        <DescriptionListDescription>{description || "—"}</DescriptionListDescription>
-                    </DescriptionListGroup>
-                    <DescriptionListGroup>
-                        <DescriptionListTerm>Execution Mode</DescriptionListTerm>
-                        <DescriptionListDescription>
-                            <Label isCompact color={executionMode === "actor" ? "blue" : "orange"}>
-                                {executionMode}
-                            </Label>
-                        </DescriptionListDescription>
-                    </DescriptionListGroup>
-                    <DescriptionListGroup>
-                        <DescriptionListTerm>Flags</DescriptionListTerm>
-                        <DescriptionListDescription>
-                            {userTriggerable && <Label isCompact color="green" style={{ marginRight: 4 }}>User Triggerable</Label>}
-                            {managerTriggerable && <Label isCompact color="blue" style={{ marginRight: 4 }}>Manager Triggerable</Label>}
-                            {emitsEvent && <Label isCompact color="purple" style={{ marginRight: 4 }}>Emits Event</Label>}
-                            {!userTriggerable && !managerTriggerable && !emitsEvent && "—"}
-                        </DescriptionListDescription>
-                    </DescriptionListGroup>
-                </DescriptionList>
-
-                {toolsList.length > 0 && (
-                    <>
-                        <h4 style={{ marginTop: 16, marginBottom: 8 }}>Allowed Tools</h4>
-                        <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
-                            {toolsList.map((tool) => (
-                                <Label key={tool} isCompact
-                                    color={tool.startsWith("@") ? "green" : "blue"}>
-                                    {tool}
-                                </Label>
-                            ))}
+            <ModalBody className="assistant-tabbed-modal-body">
+                <Tabs activeKey={activeTab}
+                    onSelect={(_e, key) => setActiveTab(key as number)}>
+                    <Tab eventKey={0} title={<TabTitleText>Details</TabTitleText>}>
+                        <div style={{ paddingTop: 16 }}>
+                            <DescriptionList isHorizontal isCompact>
+                                <DescriptionListGroup>
+                                    <DescriptionListTerm>Name</DescriptionListTerm>
+                                    <DescriptionListDescription>{name}</DescriptionListDescription>
+                                </DescriptionListGroup>
+                                <DescriptionListGroup>
+                                    <DescriptionListTerm>Description</DescriptionListTerm>
+                                    <DescriptionListDescription>{description || "—"}</DescriptionListDescription>
+                                </DescriptionListGroup>
+                                <DescriptionListGroup>
+                                    <DescriptionListTerm style={{ whiteSpace: "nowrap" }}>Execution Mode</DescriptionListTerm>
+                                    <DescriptionListDescription>
+                                        <Label isCompact color={isActorMode ? "blue" : "orange"}>
+                                            {executionMode}
+                                        </Label>
+                                    </DescriptionListDescription>
+                                </DescriptionListGroup>
+                                <DescriptionListGroup>
+                                    <DescriptionListTerm>Flags</DescriptionListTerm>
+                                    <DescriptionListDescription>
+                                        {userTriggerable && <Label isCompact color="green" style={{ marginRight: 4 }}>User Triggerable</Label>}
+                                        {managerTriggerable && <Label isCompact color="blue" style={{ marginRight: 4 }}>Manager Triggerable</Label>}
+                                        {emitsEvent && <Label isCompact color="purple" style={{ marginRight: 4 }}>Emits Event</Label>}
+                                        {!userTriggerable && !managerTriggerable && !emitsEvent && "—"}
+                                    </DescriptionListDescription>
+                                </DescriptionListGroup>
+                                {toolsList.length > 0 && (
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm style={{ whiteSpace: "nowrap" }}>Allowed Tools</DescriptionListTerm>
+                                        <DescriptionListDescription>
+                                            <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
+                                                {toolsList.map((tool) => (
+                                                    <Label key={tool} isCompact
+                                                        color={tool.startsWith("@") ? "green" : "blue"}>
+                                                        {tool}
+                                                    </Label>
+                                                ))}
+                                            </div>
+                                        </DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                )}
+                                {model && (
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm>Model</DescriptionListTerm>
+                                        <DescriptionListDescription>{model}</DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                )}
+                                {engine && (
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm>Engine</DescriptionListTerm>
+                                        <DescriptionListDescription>{engine}</DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                )}
+                            </DescriptionList>
                         </div>
-                    </>
-                )}
-
-                {promptTemplate && (
-                    <>
-                        <h4 style={{ marginTop: 16, marginBottom: 8 }}>Prompt Template</h4>
-                        <CodeBlock>
-                            <CodeBlockCode>{promptTemplate}</CodeBlockCode>
-                        </CodeBlock>
-                    </>
-                )}
-
-                {scriptTemplate && (
-                    <>
-                        <h4 style={{ marginTop: 16, marginBottom: 8 }}>Script Template</h4>
-                        <CodeBlock>
-                            <CodeBlockCode>{scriptTemplate}</CodeBlockCode>
-                        </CodeBlock>
-                    </>
-                )}
-
-                {(model || engine) && (
-                    <>
-                        <h4 style={{ marginTop: 16, marginBottom: 8 }}>Advanced</h4>
-                        <DescriptionList isHorizontal isCompact>
-                            {model && (
-                                <DescriptionListGroup>
-                                    <DescriptionListTerm>Model</DescriptionListTerm>
-                                    <DescriptionListDescription>{model}</DescriptionListDescription>
-                                </DescriptionListGroup>
-                            )}
-                            {engine && (
-                                <DescriptionListGroup>
-                                    <DescriptionListTerm>Engine</DescriptionListTerm>
-                                    <DescriptionListDescription>{engine}</DescriptionListDescription>
-                                </DescriptionListGroup>
-                            )}
-                        </DescriptionList>
-                    </>
-                )}
+                    </Tab>
+                    {templateContent && (
+                        <Tab eventKey={1} title={<TabTitleText>{templateLabel}</TabTitleText>}>
+                            <div style={{ paddingTop: 16, flex: "1 1 0", minHeight: 0 }}>
+                                <CodeEditor
+                                    code={templateContent}
+                                    language={templateLanguage}
+                                    height="100%"
+                                    isReadOnly
+                                    isLineNumbersVisible
+                                />
+                            </div>
+                        </Tab>
+                    )}
+                </Tabs>
             </ModalBody>
         </Modal>
     );

--- a/ui/src/components/assistant/AssistantAskUserQuestion.tsx
+++ b/ui/src/components/assistant/AssistantAskUserQuestion.tsx
@@ -1,0 +1,231 @@
+import { useState } from "react";
+import {
+    Button,
+    ExpandableSection,
+    Flex,
+    FlexItem,
+    Radio,
+    Checkbox,
+    TextInput,
+    Label,
+} from "@patternfly/react-core";
+
+interface QuestionOption {
+    label: string;
+    description?: string;
+}
+
+interface Question {
+    question: string;
+    header?: string;
+    options: QuestionOption[];
+    multiSelect?: boolean;
+}
+
+interface AssistantAskUserQuestionProps {
+    permissionId: string;
+    questions: Question[];
+    onRespond: (permissionId: string, allow: boolean, updatedInput?: Record<string, unknown>) => void;
+    resolved?: boolean;
+}
+
+export function AssistantAskUserQuestion({
+    permissionId,
+    questions,
+    onRespond,
+    resolved,
+}: AssistantAskUserQuestionProps) {
+    const [answers, setAnswers] = useState<Record<number, string | string[]>>({});
+    const [otherText, setOtherText] = useState<Record<number, string>>({});
+    const [isExpanded, setIsExpanded] = useState(!resolved);
+
+    const handleSingleSelect = (questionIdx: number, label: string) => {
+        setAnswers((prev) => ({ ...prev, [questionIdx]: label }));
+    };
+
+    const handleMultiSelect = (questionIdx: number, label: string, checked: boolean) => {
+        setAnswers((prev) => {
+            const current = (prev[questionIdx] as string[]) || [];
+            if (checked) {
+                return { ...prev, [questionIdx]: [...current, label] };
+            }
+            return { ...prev, [questionIdx]: current.filter((l) => l !== label) };
+        });
+    };
+
+    const handleSubmit = () => {
+        const answersMap: Record<string, string> = {};
+        questions.forEach((q, idx) => {
+            const answer = answers[idx];
+            if (answer === "Other" && otherText[idx]) {
+                answersMap[q.question] = otherText[idx];
+            } else if (Array.isArray(answer)) {
+                const selected = answer.includes("Other") && otherText[idx]
+                    ? [...answer.filter((a) => a !== "Other"), otherText[idx]]
+                    : answer;
+                answersMap[q.question] = selected.join(", ");
+            } else if (answer) {
+                answersMap[q.question] = answer;
+            }
+        });
+
+        onRespond(permissionId, true, {
+            questions: questions.map((q) => ({
+                ...q,
+                options: q.options.map((o) => ({ ...o })),
+            })),
+            answers: answersMap,
+        });
+        setIsExpanded(false);
+    };
+
+    const allAnswered = questions.every((_, idx) => {
+        const a = answers[idx];
+        if (!a) return false;
+        if (Array.isArray(a)) return a.length > 0;
+        return true;
+    });
+
+    const summaryText = resolved
+        ? questions.map((q, idx) => {
+            const a = answers[idx];
+            const display = a === "Other" && otherText[idx]
+                ? otherText[idx]
+                : Array.isArray(a) ? a.join(", ") : (a || "—");
+            return `${q.header || "Q"}: ${display}`;
+        }).join(" | ")
+        : undefined;
+
+    return (
+        <div style={{
+            padding: "8px 12px",
+            backgroundColor: "#f0f8ff",
+        }}>
+            <ExpandableSection
+                toggleText={
+                    <span>
+                        <Label isCompact color="blue" style={{ marginRight: 8 }}>
+                            Question
+                        </Label>
+                        {resolved && summaryText && (
+                            <span style={{ fontSize: "13px", color: "#6a6e73" }}>
+                                {summaryText}
+                            </span>
+                        )}
+                        {!resolved && (
+                            <span style={{ fontSize: "13px" }}>
+                                Claude has a question
+                            </span>
+                        )}
+                    </span>
+                }
+                isExpanded={isExpanded}
+                onToggle={(_e, expanded) => setIsExpanded(expanded)}
+                isIndented
+            >
+                {questions.map((q, qIdx) => (
+                    <div key={qIdx} style={{ marginBottom: qIdx < questions.length - 1 ? 16 : 8 }}>
+                        {q.header && (
+                            <div style={{
+                                fontSize: "11px",
+                                fontWeight: 600,
+                                textTransform: "uppercase",
+                                color: "#6a6e73",
+                                marginBottom: 4,
+                            }}>
+                                {q.header}
+                            </div>
+                        )}
+                        <div style={{ fontWeight: 600, marginBottom: 8 }}>
+                            {q.question}
+                        </div>
+                        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+                            {q.options.concat(
+                                q.options.some((o) => o.label === "Other") ? [] : [{ label: "Other", description: "Provide your own answer" }]
+                            ).map((opt) => {
+                                const isOther = opt.label === "Other";
+                                if (q.multiSelect) {
+                                    const selected = ((answers[qIdx] as string[]) || []).includes(opt.label);
+                                    return (
+                                        <div key={opt.label}>
+                                            <Checkbox
+                                                id={`q${qIdx}-${opt.label}`}
+                                                label={
+                                                    <span>
+                                                        {opt.label}
+                                                        {opt.description && (
+                                                            <span style={{ color: "#6a6e73", marginLeft: 6, fontSize: "13px" }}>
+                                                                — {opt.description}
+                                                            </span>
+                                                        )}
+                                                    </span>
+                                                }
+                                                isChecked={selected}
+                                                onChange={(_e, checked) => handleMultiSelect(qIdx, opt.label, checked)}
+                                                isDisabled={resolved}
+                                            />
+                                            {isOther && selected && (
+                                                <TextInput
+                                                    value={otherText[qIdx] || ""}
+                                                    onChange={(_e, val) => setOtherText((prev) => ({ ...prev, [qIdx]: val }))}
+                                                    placeholder="Type your answer..."
+                                                    style={{ marginTop: 4, marginLeft: 24 }}
+                                                    isDisabled={resolved}
+                                                />
+                                            )}
+                                        </div>
+                                    );
+                                }
+                                const selected = answers[qIdx] === opt.label;
+                                return (
+                                    <div key={opt.label}>
+                                        <Radio
+                                            id={`q${qIdx}-${opt.label}`}
+                                            name={`question-${qIdx}`}
+                                            label={
+                                                <span>
+                                                    {opt.label}
+                                                    {opt.description && (
+                                                        <span style={{ color: "#6a6e73", marginLeft: 6, fontSize: "13px" }}>
+                                                            — {opt.description}
+                                                        </span>
+                                                    )}
+                                                </span>
+                                            }
+                                            isChecked={selected}
+                                            onChange={() => handleSingleSelect(qIdx, opt.label)}
+                                            isDisabled={resolved}
+                                        />
+                                        {isOther && selected && (
+                                            <TextInput
+                                                value={otherText[qIdx] || ""}
+                                                onChange={(_e, val) => setOtherText((prev) => ({ ...prev, [qIdx]: val }))}
+                                                placeholder="Type your answer..."
+                                                style={{ marginTop: 4, marginLeft: 24 }}
+                                                isDisabled={resolved}
+                                            />
+                                        )}
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    </div>
+                ))}
+                {!resolved && (
+                    <Flex style={{ marginTop: 12 }}>
+                        <FlexItem>
+                            <Button
+                                variant="primary"
+                                size="sm"
+                                onClick={handleSubmit}
+                                isDisabled={!allAnswered}
+                            >
+                                Submit
+                            </Button>
+                        </FlexItem>
+                    </Flex>
+                )}
+            </ExpandableSection>
+        </div>
+    );
+}

--- a/ui/src/components/assistant/AssistantAskUserQuestion.tsx
+++ b/ui/src/components/assistant/AssistantAskUserQuestion.tsx
@@ -102,7 +102,7 @@ export function AssistantAskUserQuestion({
             backgroundColor: "#f0f8ff",
         }}>
             <ExpandableSection
-                toggleText={
+                toggleContent={
                     <span>
                         <Label isCompact color="blue" style={{ marginRight: 8 }}>
                             Question

--- a/ui/src/components/assistant/AssistantChatPanel.tsx
+++ b/ui/src/components/assistant/AssistantChatPanel.tsx
@@ -1,0 +1,173 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { AssistantMessageList, type ChatMessage } from "./AssistantMessageList";
+import { AssistantMessageInput } from "./AssistantMessageInput";
+import {
+    assistantEventsUrl,
+    sendAssistantMessage,
+    respondToAssistantPermission,
+} from "../../config/api";
+
+interface AssistantChatPanelProps {
+    sessionId: string;
+    onItemsChanged?: () => void;
+}
+
+let messageIdCounter = 0;
+
+export function AssistantChatPanel({ sessionId, onItemsChanged }: AssistantChatPanelProps) {
+    const [messages, setMessages] = useState<ChatMessage[]>(() => [{
+        id: String(++messageIdCounter),
+        type: "system" as const,
+        content: "Axiom Configuration Assistant ready. Describe what you'd like to create.",
+    }]);
+    const [isProcessing, setIsProcessing] = useState(false);
+    const eventSourceRef = useRef<EventSource | null>(null);
+
+    const addMessage = useCallback((msg: Omit<ChatMessage, "id">) => {
+        setMessages((prev) => [...prev, { ...msg, id: String(++messageIdCounter) }]);
+    }, []);
+
+    useEffect(() => {
+        const url = assistantEventsUrl(sessionId);
+        const es = new EventSource(url);
+        eventSourceRef.current = es;
+
+        es.addEventListener("assistant_text", (e) => {
+            try {
+                const data = JSON.parse(e.data);
+                if (data.text) {
+                    setMessages((prev) => {
+                        const last = prev[prev.length - 1];
+                        if (last && last.type === "assistant") {
+                            return [...prev.slice(0, -1), { ...last, content: data.text }];
+                        }
+                        return [...prev, { id: String(++messageIdCounter), type: "assistant", content: data.text }];
+                    });
+                }
+            } catch {
+                // ignore
+            }
+        });
+
+        es.addEventListener("thinking", () => {
+            setMessages((prev) => {
+                const last = prev[prev.length - 1];
+                if (last && last.type === "thinking") return prev;
+                return [...prev, { id: String(++messageIdCounter), type: "thinking" }];
+            });
+        });
+
+        es.addEventListener("tool_use", (e) => {
+            try {
+                const data = JSON.parse(e.data);
+                addMessage({
+                    type: "tool_use",
+                    toolName: data.name,
+                    toolInput: data.input,
+                    toolUseId: data.id,
+                });
+            } catch {
+                // ignore
+            }
+        });
+
+        es.addEventListener("tool_result", (e) => {
+            try {
+                const data = JSON.parse(e.data);
+                setMessages((prev) =>
+                    prev.map((m) =>
+                        m.type === "tool_use" && m.toolUseId === data.toolUseId
+                            ? { ...m, toolResult: data.stdout || data.stderr || "", isError: !!data.stderr && !data.stdout }
+                            : m
+                    )
+                );
+                onItemsChanged?.();
+            } catch {
+                // ignore
+            }
+        });
+
+        es.addEventListener("permission_request", (e) => {
+            try {
+                const data = JSON.parse(e.data);
+                addMessage({
+                    type: "permission_request",
+                    permissionId: data.requestId,
+                    toolName: data.toolName,
+                    toolInput: data.toolInput,
+                });
+            } catch {
+                // ignore
+            }
+        });
+
+        es.addEventListener("turn_complete", () => {
+            setIsProcessing(false);
+        });
+
+        es.addEventListener("session_error", (e) => {
+            try {
+                const data = JSON.parse(e.data);
+                addMessage({ type: "system", content: data.message || "Session error" });
+            } catch {
+                // ignore
+            }
+            setIsProcessing(false);
+        });
+
+        es.onerror = () => {
+            if (es.readyState === EventSource.CLOSED) {
+                setIsProcessing(false);
+            }
+        };
+
+        return () => {
+            es.close();
+            eventSourceRef.current = null;
+        };
+    }, [sessionId, addMessage, onItemsChanged]);
+
+    const handleSend = useCallback(async (message: string) => {
+        addMessage({ type: "user", content: message });
+        setIsProcessing(true);
+        try {
+            await sendAssistantMessage(sessionId, message);
+        } catch (err) {
+            console.error("Failed to send message:", err);
+            setIsProcessing(false);
+        }
+    }, [sessionId, addMessage]);
+
+    const handlePermissionRespond = useCallback(async (
+        permissionId: string, allow: boolean, toolInput?: Record<string, unknown>
+    ) => {
+        setMessages((prev) =>
+            prev.map((m) =>
+                m.permissionId === permissionId
+                    ? { ...m, permissionResolved: true }
+                    : m
+            )
+        );
+        try {
+            await respondToAssistantPermission(sessionId, permissionId, allow, toolInput);
+        } catch (err) {
+            console.error("Failed to respond to permission:", err);
+        }
+    }, [sessionId]);
+
+    return (
+        <div style={{
+            display: "flex",
+            flexDirection: "column",
+            flex: "1 1 0",
+            minHeight: 0,
+        }}>
+            <AssistantMessageList
+                messages={messages}
+                onPermissionRespond={handlePermissionRespond}
+                isProcessing={isProcessing}
+            />
+            <AssistantMessageInput onSend={handleSend} disabled={isProcessing} />
+        </div>
+    );
+}

--- a/ui/src/components/assistant/AssistantChatPanel.tsx
+++ b/ui/src/components/assistant/AssistantChatPanel.tsx
@@ -90,12 +90,32 @@ export function AssistantChatPanel({ sessionId, onItemsChanged }: AssistantChatP
         es.addEventListener("permission_request", (e) => {
             try {
                 const data = JSON.parse(e.data);
-                addMessage({
-                    type: "permission_request",
-                    permissionId: data.requestId,
-                    toolName: data.toolName,
-                    toolInput: data.toolInput,
+
+                // Attach permission to the matching tool_use block
+                setMessages((prev) => {
+                    const lastToolIdx = prev.findLastIndex(
+                        (m) => m.type === "tool_use" && m.toolName === data.toolName && !m.permissionId
+                    );
+                    if (lastToolIdx >= 0) {
+                        const updated = [...prev];
+                        updated[lastToolIdx] = {
+                            ...updated[lastToolIdx],
+                            permissionId: data.requestId,
+                            permissionResolved: false,
+                            toolInput: data.toolInput || updated[lastToolIdx].toolInput,
+                        };
+                        return updated;
+                    }
+                    // Fallback: add as standalone if no matching tool_use
+                    return [...prev, {
+                        id: String(++messageIdCounter),
+                        type: "permission_request" as const,
+                        permissionId: data.requestId,
+                        toolName: data.toolName,
+                        toolInput: data.toolInput,
+                    }];
                 });
+                setIsProcessing(false);
             } catch {
                 // ignore
             }
@@ -148,10 +168,12 @@ export function AssistantChatPanel({ sessionId, onItemsChanged }: AssistantChatP
                     : m
             )
         );
+        setIsProcessing(true);
         try {
             await respondToAssistantPermission(sessionId, permissionId, allow, toolInput);
         } catch (err) {
             console.error("Failed to respond to permission:", err);
+            setIsProcessing(false);
         }
     }, [sessionId]);
 

--- a/ui/src/components/assistant/AssistantGeneratedItems.tsx
+++ b/ui/src/components/assistant/AssistantGeneratedItems.tsx
@@ -1,0 +1,153 @@
+import { useState, useEffect, useCallback } from "react";
+import {
+    Label,
+    EmptyState,
+    EmptyStateBody,
+    Spinner,
+} from "@patternfly/react-core";
+import CheckCircleIcon from "@patternfly/react-icons/dist/esm/icons/check-circle-icon";
+import ExclamationCircleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon";
+import {
+    fetchAssistantItems,
+    fetchAssistantItemContent,
+    type AssistantItem,
+} from "../../config/api";
+import { ToolDetailModal } from "./ToolDetailModal";
+import { ActionTypeDetailModal } from "./ActionTypeDetailModal";
+import { ReportDefinitionDetailModal } from "./ReportDefinitionDetailModal";
+
+interface AssistantGeneratedItemsProps {
+    sessionId: string;
+    refreshTrigger: number;
+}
+
+const TYPE_LABELS: Record<string, { label: string; color: "blue" | "green" | "purple" }> = {
+    "tools": { label: "Tool", color: "blue" },
+    "action-types": { label: "Action Type", color: "green" },
+    "report-definitions": { label: "Report", color: "purple" },
+};
+
+export function AssistantGeneratedItems({ sessionId, refreshTrigger }: AssistantGeneratedItemsProps) {
+    const [items, setItems] = useState<AssistantItem[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [selectedItem, setSelectedItem] = useState<{ type: string; name: string } | null>(null);
+    const [itemContent, setItemContent] = useState<Record<string, unknown> | null>(null);
+
+    const load = useCallback(() => {
+        setLoading(true);
+        fetchAssistantItems(sessionId)
+            .then(setItems)
+            .catch(console.error)
+            .finally(() => setLoading(false));
+    }, [sessionId]);
+
+    useEffect(() => {
+        load();
+    }, [load, refreshTrigger]);
+
+    const handleItemClick = async (type: string, name: string) => {
+        try {
+            const content = await fetchAssistantItemContent(sessionId, type, name);
+            setItemContent(content);
+            setSelectedItem({ type, name });
+        } catch (err) {
+            console.error("Failed to load item:", err);
+        }
+    };
+
+    const closeModal = () => {
+        setSelectedItem(null);
+        setItemContent(null);
+    };
+
+    return (
+        <div style={{ padding: "16px", height: "100%", overflow: "auto" }}>
+            <div style={{
+                fontWeight: 600,
+                fontSize: "14px",
+                marginBottom: "12px",
+                color: "#151515",
+            }}>
+                Generated Items ({items.length})
+            </div>
+
+            {loading && items.length === 0 && (
+                <EmptyState variant="sm">
+                    <Spinner size="md" />
+                    <EmptyStateBody>Loading items...</EmptyStateBody>
+                </EmptyState>
+            )}
+
+            {!loading && items.length === 0 && (
+                <EmptyState variant="sm">
+                    <EmptyStateBody>
+                        No items generated yet. Ask the assistant to create tools,
+                        action types, or report definitions.
+                    </EmptyStateBody>
+                </EmptyState>
+            )}
+
+            {items.map((item) => {
+                const typeInfo = TYPE_LABELS[item.type] || { label: item.type, color: "blue" as const };
+                return (
+                    <div
+                        key={`${item.type}/${item.name}`}
+                        onClick={() => handleItemClick(item.type, item.name)}
+                        style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: "8px",
+                            padding: "10px 12px",
+                            marginBottom: "4px",
+                            borderRadius: "6px",
+                            cursor: "pointer",
+                            backgroundColor: "#fafafa",
+                            border: "1px solid #d2d2d2",
+                        }}
+                        onMouseEnter={(e) => {
+                            e.currentTarget.style.backgroundColor = "#f0f0f0";
+                        }}
+                        onMouseLeave={(e) => {
+                            e.currentTarget.style.backgroundColor = "#fafafa";
+                        }}
+                    >
+                        <Label isCompact color={typeInfo.color}>
+                            {typeInfo.label}
+                        </Label>
+                        <span style={{ flex: 1, fontSize: "13px" }}>{item.name}</span>
+                        {item.valid ? (
+                            <CheckCircleIcon style={{ color: "#3e8635" }} />
+                        ) : (
+                            <ExclamationCircleIcon style={{ color: "#c9190b" }} />
+                        )}
+                    </div>
+                );
+            })}
+
+            {selectedItem?.type === "tools" && itemContent && (
+                <ToolDetailModal
+                    isOpen
+                    onClose={closeModal}
+                    name={selectedItem.name}
+                    content={itemContent}
+                />
+            )}
+            {selectedItem?.type === "action-types" && itemContent && (
+                <ActionTypeDetailModal
+                    isOpen
+                    onClose={closeModal}
+                    name={selectedItem.name}
+                    content={itemContent}
+                />
+            )}
+            {selectedItem?.type === "report-definitions" && itemContent && (
+                <ReportDefinitionDetailModal
+                    isOpen
+                    onClose={closeModal}
+                    name={selectedItem.name}
+                    content={itemContent}
+                />
+            )}
+        </div>
+    );
+}

--- a/ui/src/components/assistant/AssistantMessageInput.tsx
+++ b/ui/src/components/assistant/AssistantMessageInput.tsx
@@ -1,0 +1,52 @@
+import { useState, useCallback } from "react";
+import { TextArea, Button, Flex, FlexItem } from "@patternfly/react-core";
+import PaperPlaneIcon from "@patternfly/react-icons/dist/esm/icons/paper-plane-icon";
+
+interface AssistantMessageInputProps {
+    onSend: (message: string) => void;
+    disabled?: boolean;
+}
+
+export function AssistantMessageInput({ onSend, disabled }: AssistantMessageInputProps) {
+    const [value, setValue] = useState("");
+
+    const handleSend = useCallback(() => {
+        const trimmed = value.trim();
+        if (!trimmed) return;
+        onSend(trimmed);
+        setValue("");
+    }, [value, onSend]);
+
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+        if (e.key === "Enter" && !e.shiftKey) {
+            e.preventDefault();
+            handleSend();
+        }
+    };
+
+    return (
+        <Flex style={{ padding: "12px 16px", borderTop: "1px solid #d2d2d2", flexShrink: 0 }}>
+            <FlexItem grow={{ default: "grow" }}>
+                <TextArea
+                    value={value}
+                    onChange={(_e, val) => setValue(val)}
+                    onKeyDown={handleKeyDown}
+                    placeholder="Type a message..."
+                    aria-label="Message input"
+                    autoResize
+                    rows={1}
+                    isDisabled={disabled}
+                />
+            </FlexItem>
+            <FlexItem alignSelf={{ default: "alignSelfFlexEnd" }}>
+                <Button
+                    variant="primary"
+                    onClick={handleSend}
+                    isDisabled={disabled || !value.trim()}
+                    aria-label="Send message"
+                    icon={<PaperPlaneIcon />}
+                />
+            </FlexItem>
+        </Flex>
+    );
+}

--- a/ui/src/components/assistant/AssistantMessageList.css
+++ b/ui/src/components/assistant/AssistantMessageList.css
@@ -1,0 +1,27 @@
+.assistant-markdown table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 8px 0;
+    font-size: 13px;
+}
+
+.assistant-markdown th {
+    text-align: left;
+    padding: 6px 10px;
+    border-bottom: 2px solid #d2d2d2;
+    background-color: #f0f0f0;
+    font-weight: 600;
+}
+
+.assistant-markdown td {
+    padding: 6px 10px;
+    border-bottom: 1px solid #e0e0e0;
+}
+
+.assistant-markdown tr:nth-child(even) {
+    background-color: #fafafa;
+}
+
+.assistant-markdown tr:hover {
+    background-color: #f0f5fa;
+}

--- a/ui/src/components/assistant/AssistantMessageList.tsx
+++ b/ui/src/components/assistant/AssistantMessageList.tsx
@@ -4,7 +4,6 @@ import remarkGfm from "remark-gfm";
 import { Content, Spinner } from "@patternfly/react-core";
 import { AssistantToolUseBlock } from "./AssistantToolUseBlock";
 import { AssistantPermissionPrompt } from "./AssistantPermissionPrompt";
-import { AssistantAskUserQuestion } from "./AssistantAskUserQuestion";
 import "./AssistantMessageList.css";
 
 export interface ChatMessage {
@@ -132,7 +131,7 @@ export function AssistantMessageList({ messages, onPermissionRespond, isProcessi
                                 key={msg.id}
                                 permissionId={msg.permissionId || ""}
                                 toolName={msg.toolName || "unknown"}
-                                toolInput={msg.toolInput}
+                                input={msg.toolInput}
                                 onRespond={onPermissionRespond}
                                 resolved={msg.permissionResolved}
                             />

--- a/ui/src/components/assistant/AssistantMessageList.tsx
+++ b/ui/src/components/assistant/AssistantMessageList.tsx
@@ -4,6 +4,8 @@ import remarkGfm from "remark-gfm";
 import { Content, Spinner } from "@patternfly/react-core";
 import { AssistantToolUseBlock } from "./AssistantToolUseBlock";
 import { AssistantPermissionPrompt } from "./AssistantPermissionPrompt";
+import { AssistantAskUserQuestion } from "./AssistantAskUserQuestion";
+import "./AssistantMessageList.css";
 
 export interface ChatMessage {
     id: string;
@@ -81,7 +83,7 @@ export function AssistantMessageList({ messages, onPermissionRespond, isProcessi
                                 justifyContent: "flex-start",
                                 margin: "8px 0",
                             }}>
-                                <div style={{
+                                <div className="assistant-markdown" style={{
                                     maxWidth: "80%",
                                     padding: "10px 14px",
                                     borderRadius: "12px 12px 12px 2px",
@@ -105,6 +107,9 @@ export function AssistantMessageList({ messages, onPermissionRespond, isProcessi
                                 input={msg.toolInput}
                                 result={msg.toolResult}
                                 isError={msg.isError}
+                                permissionId={msg.permissionId}
+                                permissionResolved={msg.permissionResolved}
+                                onPermissionRespond={onPermissionRespond}
                             />
                         );
 

--- a/ui/src/components/assistant/AssistantMessageList.tsx
+++ b/ui/src/components/assistant/AssistantMessageList.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useRef } from "react";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { Content, Spinner } from "@patternfly/react-core";
+import { AssistantToolUseBlock } from "./AssistantToolUseBlock";
+import { AssistantPermissionPrompt } from "./AssistantPermissionPrompt";
+
+export interface ChatMessage {
+    id: string;
+    type: "system" | "user" | "assistant" | "tool_use" | "tool_result" | "permission_request" | "thinking";
+    content?: string;
+    toolName?: string;
+    toolInput?: Record<string, unknown>;
+    toolUseId?: string;
+    toolResult?: string;
+    isError?: boolean;
+    permissionId?: string;
+    permissionResolved?: boolean;
+}
+
+interface AssistantMessageListProps {
+    messages: ChatMessage[];
+    onPermissionRespond: (permissionId: string, allow: boolean, toolInput?: Record<string, unknown>) => void;
+    isProcessing?: boolean;
+}
+
+export function AssistantMessageList({ messages, onPermissionRespond, isProcessing }: AssistantMessageListProps) {
+    const endRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        endRef.current?.scrollIntoView({ behavior: "smooth" });
+    }, [messages.length, isProcessing]);
+
+    return (
+        <div style={{
+            flex: "1 1 0",
+            minHeight: 0,
+            overflowY: "auto",
+            padding: "16px",
+        }}>
+            {messages.map((msg) => {
+                switch (msg.type) {
+                    case "system":
+                        return (
+                            <div key={msg.id} style={{
+                                padding: "8px 12px",
+                                margin: "4px 0",
+                                fontSize: "13px",
+                                color: "#6a6e73",
+                                fontStyle: "italic",
+                            }}>
+                                {msg.content}
+                            </div>
+                        );
+
+                    case "user":
+                        return (
+                            <div key={msg.id} style={{
+                                display: "flex",
+                                justifyContent: "flex-end",
+                                margin: "8px 0",
+                            }}>
+                                <div style={{
+                                    maxWidth: "80%",
+                                    padding: "10px 14px",
+                                    borderRadius: "12px 12px 2px 12px",
+                                    backgroundColor: "#0066cc",
+                                    color: "white",
+                                    whiteSpace: "pre-wrap",
+                                    fontSize: "14px",
+                                }}>
+                                    {msg.content}
+                                </div>
+                            </div>
+                        );
+
+                    case "assistant":
+                        return (
+                            <div key={msg.id} style={{
+                                display: "flex",
+                                justifyContent: "flex-start",
+                                margin: "8px 0",
+                            }}>
+                                <div style={{
+                                    maxWidth: "80%",
+                                    padding: "10px 14px",
+                                    borderRadius: "12px 12px 12px 2px",
+                                    backgroundColor: "#f0f0f0",
+                                    fontSize: "14px",
+                                }}>
+                                    <Content>
+                                        <Markdown remarkPlugins={[remarkGfm]}>
+                                            {msg.content?.trim() || ""}
+                                        </Markdown>
+                                    </Content>
+                                </div>
+                            </div>
+                        );
+
+                    case "tool_use":
+                        return (
+                            <AssistantToolUseBlock
+                                key={msg.id}
+                                toolName={msg.toolName || "unknown"}
+                                input={msg.toolInput}
+                                result={msg.toolResult}
+                                isError={msg.isError}
+                            />
+                        );
+
+                    case "thinking":
+                        return (
+                            <div key={msg.id} style={{
+                                padding: "8px 12px",
+                                margin: "4px 0",
+                                fontSize: "13px",
+                                color: "#6a6e73",
+                                fontStyle: "italic",
+                            }}>
+                                Thinking...
+                            </div>
+                        );
+
+                    case "permission_request":
+                        return (
+                            <AssistantPermissionPrompt
+                                key={msg.id}
+                                permissionId={msg.permissionId || ""}
+                                toolName={msg.toolName || "unknown"}
+                                toolInput={msg.toolInput}
+                                onRespond={onPermissionRespond}
+                                resolved={msg.permissionResolved}
+                            />
+                        );
+
+                    default:
+                        return null;
+                }
+            })}
+            {isProcessing && (
+                <div style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "8px",
+                    padding: "12px",
+                    margin: "8px 0",
+                    fontSize: "13px",
+                    color: "#6a6e73",
+                }}>
+                    <Spinner size="md" />
+                    <span>Claude is working...</span>
+                </div>
+            )}
+            <div ref={endRef} />
+        </div>
+    );
+}

--- a/ui/src/components/assistant/AssistantPermissionPrompt.tsx
+++ b/ui/src/components/assistant/AssistantPermissionPrompt.tsx
@@ -1,0 +1,70 @@
+import {
+    Alert,
+    Button,
+    Flex,
+    FlexItem,
+} from "@patternfly/react-core";
+
+interface AssistantPermissionPromptProps {
+    permissionId: string;
+    toolName: string;
+    input?: Record<string, unknown>;
+    onRespond: (permissionId: string, allow: boolean, toolInput?: Record<string, unknown>) => void;
+    resolved?: boolean;
+}
+
+export function AssistantPermissionPrompt({
+    permissionId,
+    toolName,
+    input,
+    onRespond,
+    resolved,
+}: AssistantPermissionPromptProps) {
+    const inputPreview = input
+        ? JSON.stringify(input, null, 2).substring(0, 300)
+        : "";
+
+    return (
+        <Alert
+            variant="warning"
+            isInline
+            title={`Permission requested: ${toolName}`}
+            style={{ margin: "8px 0" }}
+        >
+            {inputPreview && (
+                <pre style={{
+                    whiteSpace: "pre-wrap",
+                    wordBreak: "break-all",
+                    fontSize: "12px",
+                    maxHeight: "150px",
+                    overflow: "auto",
+                    margin: "8px 0",
+                }}>
+                    {inputPreview}
+                </pre>
+            )}
+            <Flex>
+                <FlexItem>
+                    <Button
+                        variant="primary"
+                        size="sm"
+                        onClick={() => onRespond(permissionId, true, input)}
+                        isDisabled={resolved}
+                    >
+                        Allow
+                    </Button>
+                </FlexItem>
+                <FlexItem>
+                    <Button
+                        variant="secondary"
+                        size="sm"
+                        onClick={() => onRespond(permissionId, false, input)}
+                        isDisabled={resolved}
+                    >
+                        Deny
+                    </Button>
+                </FlexItem>
+            </Flex>
+        </Alert>
+    );
+}

--- a/ui/src/components/assistant/AssistantToolUseBlock.tsx
+++ b/ui/src/components/assistant/AssistantToolUseBlock.tsx
@@ -64,7 +64,7 @@ export function AssistantToolUseBlock({
                 fontSize: "13px",
             }}>
                 <ExpandableSection
-                    toggleText={
+                    toggleContent={
                         <span>
                             <Label isCompact color={isError ? "red" : "blue"}>
                                 {toolName}
@@ -108,7 +108,7 @@ export function AssistantToolUseBlock({
                 </ExpandableSection>
             </div>
 
-            {permissionId && isAskUser && input?.questions && (
+            {permissionId && isAskUser && Array.isArray(input?.questions) && (
                 <div style={{ borderTop: "1px solid #d2d2d2" }}>
                     <AssistantAskUserQuestion
                         permissionId={permissionId}

--- a/ui/src/components/assistant/AssistantToolUseBlock.tsx
+++ b/ui/src/components/assistant/AssistantToolUseBlock.tsx
@@ -1,12 +1,16 @@
 import { useState } from "react";
 import {
+    Button,
     ExpandableSection,
+    Flex,
+    FlexItem,
     Label,
 } from "@patternfly/react-core";
 import { Light as SyntaxHighlighter } from "react-syntax-highlighter";
 import json from "react-syntax-highlighter/dist/esm/languages/hljs/json";
 import bash from "react-syntax-highlighter/dist/esm/languages/hljs/bash";
 import { stackoverflowLight } from "react-syntax-highlighter/dist/esm/styles/hljs";
+import { AssistantAskUserQuestion } from "./AssistantAskUserQuestion";
 
 SyntaxHighlighter.registerLanguage("json", json);
 SyntaxHighlighter.registerLanguage("bash", bash);
@@ -16,14 +20,28 @@ interface AssistantToolUseBlockProps {
     input?: Record<string, unknown>;
     result?: string;
     isError?: boolean;
+    permissionId?: string;
+    permissionResolved?: boolean;
+    onPermissionRespond?: (permissionId: string, allow: boolean, toolInput?: Record<string, unknown>) => void;
 }
 
-export function AssistantToolUseBlock({ toolName, input, result, isError }: AssistantToolUseBlockProps) {
+export function AssistantToolUseBlock({
+    toolName, input, result, isError,
+    permissionId, permissionResolved, onPermissionRespond,
+}: AssistantToolUseBlockProps) {
     const [isExpanded, setIsExpanded] = useState(false);
+
+    const needsPermission = permissionId && !permissionResolved;
+    const isAskUser = toolName === "AskUserQuestion";
+    const borderColor = needsPermission
+        ? (isAskUser ? "#2b9af3" : "#f0ab00")
+        : undefined;
 
     const inputPreview = input
         ? JSON.stringify(input).substring(0, 100)
         : "";
+
+    const contextSummary = getContextSummary(toolName, input);
 
     const codeStyle = {
         margin: 0,
@@ -36,56 +54,150 @@ export function AssistantToolUseBlock({ toolName, input, result, isError }: Assi
     return (
         <div style={{
             margin: "4px 0",
-            padding: "8px 12px",
             borderRadius: "6px",
-            backgroundColor: "#f0f0f0",
-            fontSize: "13px",
+            overflow: "hidden",
+            border: borderColor ? `2px solid ${borderColor}` : undefined,
         }}>
-            <ExpandableSection
-                toggleText={
-                    <span>
-                        <Label isCompact color={isError ? "red" : "blue"}>
-                            {toolName}
-                        </Label>
-                        {inputPreview && (
-                            <span style={{ marginLeft: 8, color: "#6a6e73", fontSize: "12px" }}>
-                                {inputPreview}{input && JSON.stringify(input).length > 100 ? "..." : ""}
-                            </span>
-                        )}
-                    </span>
-                }
-                isExpanded={isExpanded}
-                onToggle={(_e, expanded) => setIsExpanded(expanded)}
-                isIndented
-            >
-                {input && (
-                    <div style={{ marginBottom: result ? 8 : 0 }}>
+            <div style={{
+                padding: "8px 12px",
+                backgroundColor: "#f0f0f0",
+                fontSize: "13px",
+            }}>
+                <ExpandableSection
+                    toggleText={
+                        <span>
+                            <Label isCompact color={isError ? "red" : "blue"}>
+                                {toolName}
+                            </Label>
+                            {inputPreview && (
+                                <span style={{ marginLeft: 8, color: "#6a6e73", fontSize: "12px" }}>
+                                    {inputPreview}{input && JSON.stringify(input).length > 100 ? "..." : ""}
+                                </span>
+                            )}
+                        </span>
+                    }
+                    isExpanded={isExpanded}
+                    onToggle={(_e, expanded) => setIsExpanded(expanded)}
+                    isIndented
+                >
+                    {input && (
+                        <div style={{ marginBottom: result ? 8 : 0 }}>
+                            <SyntaxHighlighter
+                                language="json"
+                                style={stackoverflowLight}
+                                customStyle={codeStyle}
+                                wrapLongLines
+                            >
+                                {JSON.stringify(input, null, 2)}
+                            </SyntaxHighlighter>
+                        </div>
+                    )}
+                    {result && (
                         <SyntaxHighlighter
-                            language="json"
+                            language={isJson(result) ? "json" : "bash"}
                             style={stackoverflowLight}
-                            customStyle={codeStyle}
+                            customStyle={{
+                                ...codeStyle,
+                                ...(isError ? { backgroundColor: "#fef3f2" } : {}),
+                            }}
                             wrapLongLines
                         >
-                            {JSON.stringify(input, null, 2)}
+                            {isJson(result) ? formatJson(result) : result}
                         </SyntaxHighlighter>
-                    </div>
-                )}
-                {result && (
-                    <SyntaxHighlighter
-                        language={isJson(result) ? "json" : "bash"}
-                        style={stackoverflowLight}
-                        customStyle={{
-                            ...codeStyle,
-                            ...(isError ? { backgroundColor: "#fef3f2" } : {}),
-                        }}
-                        wrapLongLines
-                    >
-                        {isJson(result) ? formatJson(result) : result}
-                    </SyntaxHighlighter>
-                )}
-            </ExpandableSection>
+                    )}
+                </ExpandableSection>
+            </div>
+
+            {permissionId && isAskUser && input?.questions && (
+                <div style={{ borderTop: "1px solid #d2d2d2" }}>
+                    <AssistantAskUserQuestion
+                        permissionId={permissionId}
+                        questions={input.questions as {
+                            question: string;
+                            header?: string;
+                            options: { label: string; description?: string }[];
+                            multiSelect?: boolean;
+                        }[]}
+                        onRespond={onPermissionRespond!}
+                        resolved={permissionResolved}
+                    />
+                </div>
+            )}
+
+            {permissionId && !isAskUser && (
+                <div style={{
+                    padding: "10px 12px",
+                    backgroundColor: needsPermission ? "#fdf7e7" : "#f0f0f0",
+                    borderTop: "1px solid #d2d2d2",
+                    fontSize: "13px",
+                }}>
+                    {needsPermission ? (
+                        <>
+                            <div style={{ fontWeight: 600, marginBottom: 6 }}>
+                                Permission required
+                            </div>
+                            {contextSummary && (
+                                <div style={{
+                                    marginBottom: 8,
+                                    padding: "6px 10px",
+                                    backgroundColor: "white",
+                                    borderRadius: "4px",
+                                    border: "1px solid #d2d2d2",
+                                    fontFamily: "monospace",
+                                    fontSize: "12px",
+                                    whiteSpace: "pre-wrap",
+                                    wordBreak: "break-all",
+                                    maxHeight: "120px",
+                                    overflow: "auto",
+                                }}>
+                                    {contextSummary}
+                                </div>
+                            )}
+                            <Flex>
+                                <FlexItem>
+                                    <Button variant="primary" size="sm"
+                                        onClick={() => onPermissionRespond?.(permissionId, true, input)}>
+                                        Allow
+                                    </Button>
+                                </FlexItem>
+                                <FlexItem>
+                                    <Button variant="secondary" size="sm"
+                                        onClick={() => onPermissionRespond?.(permissionId, false, input)}>
+                                        Deny
+                                    </Button>
+                                </FlexItem>
+                            </Flex>
+                        </>
+                    ) : (
+                        <span style={{ color: "#6a6e73", fontStyle: "italic" }}>
+                            Permission granted
+                        </span>
+                    )}
+                </div>
+            )}
         </div>
     );
+}
+
+function getContextSummary(toolName: string, input?: Record<string, unknown>): string | null {
+    if (!input) return null;
+    switch (toolName) {
+        case "Bash":
+            return input.command as string || null;
+        case "Write":
+            return `Write to: ${input.file_path || "unknown file"}`;
+        case "Edit":
+            return `Edit: ${input.file_path || "unknown file"}`;
+        case "Read":
+            return `Read: ${input.file_path || "unknown file"}`;
+        case "Agent":
+            return `Agent: ${input.description || input.prompt || ""}`.substring(0, 200);
+        default:
+            if (typeof input === "object" && Object.keys(input).length > 0) {
+                return JSON.stringify(input, null, 2).substring(0, 200);
+            }
+            return null;
+    }
 }
 
 function isJson(text: string): boolean {

--- a/ui/src/components/assistant/AssistantToolUseBlock.tsx
+++ b/ui/src/components/assistant/AssistantToolUseBlock.tsx
@@ -1,0 +1,110 @@
+import { useState } from "react";
+import {
+    ExpandableSection,
+    Label,
+} from "@patternfly/react-core";
+import { Light as SyntaxHighlighter } from "react-syntax-highlighter";
+import json from "react-syntax-highlighter/dist/esm/languages/hljs/json";
+import bash from "react-syntax-highlighter/dist/esm/languages/hljs/bash";
+import { stackoverflowLight } from "react-syntax-highlighter/dist/esm/styles/hljs";
+
+SyntaxHighlighter.registerLanguage("json", json);
+SyntaxHighlighter.registerLanguage("bash", bash);
+
+interface AssistantToolUseBlockProps {
+    toolName: string;
+    input?: Record<string, unknown>;
+    result?: string;
+    isError?: boolean;
+}
+
+export function AssistantToolUseBlock({ toolName, input, result, isError }: AssistantToolUseBlockProps) {
+    const [isExpanded, setIsExpanded] = useState(false);
+
+    const inputPreview = input
+        ? JSON.stringify(input).substring(0, 100)
+        : "";
+
+    const codeStyle = {
+        margin: 0,
+        borderRadius: "4px",
+        fontSize: "12px",
+        maxHeight: "250px",
+        overflow: "auto",
+    };
+
+    return (
+        <div style={{
+            margin: "4px 0",
+            padding: "8px 12px",
+            borderRadius: "6px",
+            backgroundColor: "#f0f0f0",
+            fontSize: "13px",
+        }}>
+            <ExpandableSection
+                toggleText={
+                    <span>
+                        <Label isCompact color={isError ? "red" : "blue"}>
+                            {toolName}
+                        </Label>
+                        {inputPreview && (
+                            <span style={{ marginLeft: 8, color: "#6a6e73", fontSize: "12px" }}>
+                                {inputPreview}{input && JSON.stringify(input).length > 100 ? "..." : ""}
+                            </span>
+                        )}
+                    </span>
+                }
+                isExpanded={isExpanded}
+                onToggle={(_e, expanded) => setIsExpanded(expanded)}
+                isIndented
+            >
+                {input && (
+                    <div style={{ marginBottom: result ? 8 : 0 }}>
+                        <SyntaxHighlighter
+                            language="json"
+                            style={stackoverflowLight}
+                            customStyle={codeStyle}
+                            wrapLongLines
+                        >
+                            {JSON.stringify(input, null, 2)}
+                        </SyntaxHighlighter>
+                    </div>
+                )}
+                {result && (
+                    <SyntaxHighlighter
+                        language={isJson(result) ? "json" : "bash"}
+                        style={stackoverflowLight}
+                        customStyle={{
+                            ...codeStyle,
+                            ...(isError ? { backgroundColor: "#fef3f2" } : {}),
+                        }}
+                        wrapLongLines
+                    >
+                        {isJson(result) ? formatJson(result) : result}
+                    </SyntaxHighlighter>
+                )}
+            </ExpandableSection>
+        </div>
+    );
+}
+
+function isJson(text: string): boolean {
+    const trimmed = text.trim();
+    return (trimmed.startsWith("{") || trimmed.startsWith("[")) && tryParseJson(trimmed) !== null;
+}
+
+function tryParseJson(text: string): unknown {
+    try {
+        return JSON.parse(text);
+    } catch {
+        return null;
+    }
+}
+
+function formatJson(text: string): string {
+    try {
+        return JSON.stringify(JSON.parse(text), null, 2);
+    } catch {
+        return text;
+    }
+}

--- a/ui/src/components/assistant/ReportDefinitionDetailModal.tsx
+++ b/ui/src/components/assistant/ReportDefinitionDetailModal.tsx
@@ -109,7 +109,7 @@ export function ReportDefinitionDetailModal({
                             </DescriptionList>
                         </div>
                     </Tab>
-                    {promptTemplate && (
+                    {promptTemplate ? (
                         <Tab eventKey={1} title={<TabTitleText>Prompt Template</TabTitleText>}>
                             <div style={{ paddingTop: 16, flex: "1 1 0", minHeight: 0 }}>
                                 <CodeEditor
@@ -121,7 +121,7 @@ export function ReportDefinitionDetailModal({
                                 />
                             </div>
                         </Tab>
-                    )}
+                    ) : null}
                 </Tabs>
             </ModalBody>
         </Modal>

--- a/ui/src/components/assistant/ReportDefinitionDetailModal.tsx
+++ b/ui/src/components/assistant/ReportDefinitionDetailModal.tsx
@@ -1,0 +1,119 @@
+import {
+    Modal,
+    ModalBody,
+    ModalHeader,
+    DescriptionList,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    DescriptionListDescription,
+    Label,
+} from "@patternfly/react-core";
+import { CodeEditor, Language } from "@patternfly/react-code-editor";
+
+interface ReportDefinitionDetailModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    name: string;
+    content: Record<string, unknown>;
+}
+
+export function ReportDefinitionDetailModal({
+    isOpen,
+    onClose,
+    name,
+    content,
+}: ReportDefinitionDetailModalProps) {
+    const description = (content.description as string) || "";
+    const schedule = (content.schedule as string) || "none";
+    const scheduleTime = (content.scheduleTime as string) || "";
+    const scheduleDayOfWeek = (content.scheduleDayOfWeek as string) || "";
+    const timeWindow = (content.timeWindow as string) || "";
+    const promptTemplate = (content.promptTemplate as string) || "";
+    const allowedTools = (content.allowedTools as string) || "";
+    const timeoutSeconds = content.timeoutSeconds as number | undefined;
+
+    const toolsList = allowedTools
+        ? allowedTools.split(",").map((t) => t.trim()).filter(Boolean)
+        : [];
+
+    const formatSchedule = () => {
+        const parts = [schedule];
+        if (scheduleTime) parts.push(`at ${scheduleTime}`);
+        if (scheduleDayOfWeek) parts.push(`on ${scheduleDayOfWeek}`);
+        return parts.join(" ");
+    };
+
+    return (
+        <Modal
+            isOpen={isOpen}
+            onClose={onClose}
+            variant="large"
+            aria-label={`Report Definition: ${name}`}
+        >
+            <ModalHeader title={`Report Definition: ${name}`} />
+            <ModalBody>
+                <DescriptionList isHorizontal isCompact>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Name</DescriptionListTerm>
+                        <DescriptionListDescription>{name}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Description</DescriptionListTerm>
+                        <DescriptionListDescription>{description || "—"}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Schedule</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            <Label isCompact color="blue">{formatSchedule()}</Label>
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    {timeWindow && (
+                        <DescriptionListGroup>
+                            <DescriptionListTerm>Time Window</DescriptionListTerm>
+                            <DescriptionListDescription>{timeWindow}</DescriptionListDescription>
+                        </DescriptionListGroup>
+                    )}
+                    {timeoutSeconds !== undefined && (
+                        <DescriptionListGroup>
+                            <DescriptionListTerm>Timeout</DescriptionListTerm>
+                            <DescriptionListDescription>{timeoutSeconds}s</DescriptionListDescription>
+                        </DescriptionListGroup>
+                    )}
+                    {toolsList.length > 0 && (
+                        <DescriptionListGroup>
+                            <DescriptionListTerm>Allowed Tools</DescriptionListTerm>
+                            <DescriptionListDescription>
+                                <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
+                                    {toolsList.map((tool) => (
+                                        <Label key={tool} isCompact
+                                            color={tool.startsWith("@") ? "green" : "blue"}>
+                                            {tool}
+                                        </Label>
+                                    ))}
+                                </div>
+                            </DescriptionListDescription>
+                        </DescriptionListGroup>
+                    )}
+                </DescriptionList>
+
+                {promptTemplate && (
+                    <>
+                        <DescriptionList isHorizontal isCompact style={{ marginTop: 16 }}>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm style={{ whiteSpace: "nowrap" }}>Prompt Template</DescriptionListTerm>
+                                <DescriptionListDescription />
+                            </DescriptionListGroup>
+                        </DescriptionList>
+                        <CodeEditor
+                            code={promptTemplate}
+                            language={Language.markdown}
+                            height="300px"
+                            isReadOnly
+                            isLineNumbersVisible
+                        />
+                    </>
+                )}
+            </ModalBody>
+        </Modal>
+    );
+}

--- a/ui/src/components/assistant/ReportDefinitionDetailModal.tsx
+++ b/ui/src/components/assistant/ReportDefinitionDetailModal.tsx
@@ -7,8 +7,13 @@ import {
     DescriptionListTerm,
     DescriptionListDescription,
     Label,
+    Tab,
+    Tabs,
+    TabTitleText,
 } from "@patternfly/react-core";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
+import { useState } from "react";
+import "./ActionTypeDetailModal.css";
 
 interface ReportDefinitionDetailModalProps {
     isOpen: boolean;
@@ -23,6 +28,8 @@ export function ReportDefinitionDetailModal({
     name,
     content,
 }: ReportDefinitionDetailModalProps) {
+    const [activeTab, setActiveTab] = useState(0);
+
     const description = (content.description as string) || "";
     const schedule = (content.schedule as string) || "none";
     const scheduleTime = (content.scheduleTime as string) || "";
@@ -49,70 +56,73 @@ export function ReportDefinitionDetailModal({
             onClose={onClose}
             variant="large"
             aria-label={`Report Definition: ${name}`}
+            style={{ height: "80vh" }}
         >
             <ModalHeader title={`Report Definition: ${name}`} />
-            <ModalBody>
-                <DescriptionList isHorizontal isCompact>
-                    <DescriptionListGroup>
-                        <DescriptionListTerm>Name</DescriptionListTerm>
-                        <DescriptionListDescription>{name}</DescriptionListDescription>
-                    </DescriptionListGroup>
-                    <DescriptionListGroup>
-                        <DescriptionListTerm>Description</DescriptionListTerm>
-                        <DescriptionListDescription>{description || "—"}</DescriptionListDescription>
-                    </DescriptionListGroup>
-                    <DescriptionListGroup>
-                        <DescriptionListTerm>Schedule</DescriptionListTerm>
-                        <DescriptionListDescription>
-                            <Label isCompact color="blue">{formatSchedule()}</Label>
-                        </DescriptionListDescription>
-                    </DescriptionListGroup>
-                    {timeWindow && (
-                        <DescriptionListGroup>
-                            <DescriptionListTerm>Time Window</DescriptionListTerm>
-                            <DescriptionListDescription>{timeWindow}</DescriptionListDescription>
-                        </DescriptionListGroup>
+            <ModalBody className="assistant-tabbed-modal-body">
+                <Tabs activeKey={activeTab}
+                    onSelect={(_e, key) => setActiveTab(key as number)}>
+                    <Tab eventKey={0} title={<TabTitleText>Details</TabTitleText>}>
+                        <div style={{ paddingTop: 16 }}>
+                            <DescriptionList isHorizontal isCompact>
+                                <DescriptionListGroup>
+                                    <DescriptionListTerm>Name</DescriptionListTerm>
+                                    <DescriptionListDescription>{name}</DescriptionListDescription>
+                                </DescriptionListGroup>
+                                <DescriptionListGroup>
+                                    <DescriptionListTerm>Description</DescriptionListTerm>
+                                    <DescriptionListDescription>{description || "—"}</DescriptionListDescription>
+                                </DescriptionListGroup>
+                                <DescriptionListGroup>
+                                    <DescriptionListTerm>Schedule</DescriptionListTerm>
+                                    <DescriptionListDescription>
+                                        <Label isCompact color="blue">{formatSchedule()}</Label>
+                                    </DescriptionListDescription>
+                                </DescriptionListGroup>
+                                {timeWindow && (
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm style={{ whiteSpace: "nowrap" }}>Time Window</DescriptionListTerm>
+                                        <DescriptionListDescription>{timeWindow}</DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                )}
+                                {timeoutSeconds !== undefined && (
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm>Timeout</DescriptionListTerm>
+                                        <DescriptionListDescription>{timeoutSeconds}s</DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                )}
+                                {toolsList.length > 0 && (
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm style={{ whiteSpace: "nowrap" }}>Allowed Tools</DescriptionListTerm>
+                                        <DescriptionListDescription>
+                                            <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
+                                                {toolsList.map((tool) => (
+                                                    <Label key={tool} isCompact
+                                                        color={tool.startsWith("@") ? "green" : "blue"}>
+                                                        {tool}
+                                                    </Label>
+                                                ))}
+                                            </div>
+                                        </DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                )}
+                            </DescriptionList>
+                        </div>
+                    </Tab>
+                    {promptTemplate && (
+                        <Tab eventKey={1} title={<TabTitleText>Prompt Template</TabTitleText>}>
+                            <div style={{ paddingTop: 16, flex: "1 1 0", minHeight: 0 }}>
+                                <CodeEditor
+                                    code={promptTemplate}
+                                    language={Language.markdown}
+                                    height="100%"
+                                    isReadOnly
+                                    isLineNumbersVisible
+                                />
+                            </div>
+                        </Tab>
                     )}
-                    {timeoutSeconds !== undefined && (
-                        <DescriptionListGroup>
-                            <DescriptionListTerm>Timeout</DescriptionListTerm>
-                            <DescriptionListDescription>{timeoutSeconds}s</DescriptionListDescription>
-                        </DescriptionListGroup>
-                    )}
-                    {toolsList.length > 0 && (
-                        <DescriptionListGroup>
-                            <DescriptionListTerm>Allowed Tools</DescriptionListTerm>
-                            <DescriptionListDescription>
-                                <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
-                                    {toolsList.map((tool) => (
-                                        <Label key={tool} isCompact
-                                            color={tool.startsWith("@") ? "green" : "blue"}>
-                                            {tool}
-                                        </Label>
-                                    ))}
-                                </div>
-                            </DescriptionListDescription>
-                        </DescriptionListGroup>
-                    )}
-                </DescriptionList>
-
-                {promptTemplate && (
-                    <>
-                        <DescriptionList isHorizontal isCompact style={{ marginTop: 16 }}>
-                            <DescriptionListGroup>
-                                <DescriptionListTerm style={{ whiteSpace: "nowrap" }}>Prompt Template</DescriptionListTerm>
-                                <DescriptionListDescription />
-                            </DescriptionListGroup>
-                        </DescriptionList>
-                        <CodeEditor
-                            code={promptTemplate}
-                            language={Language.markdown}
-                            height="300px"
-                            isReadOnly
-                            isLineNumbersVisible
-                        />
-                    </>
-                )}
+                </Tabs>
             </ModalBody>
         </Modal>
     );

--- a/ui/src/components/assistant/ToolDetailModal.tsx
+++ b/ui/src/components/assistant/ToolDetailModal.tsx
@@ -79,7 +79,7 @@ export function ToolDetailModal({ isOpen, onClose, name, content }: ToolDetailMo
                                     <DescriptionList isHorizontal isCompact style={{ marginTop: 16 }}>
                                         <DescriptionListGroup>
                                             <DescriptionListTerm>Parameters</DescriptionListTerm>
-                                            <DescriptionListDescription />
+                                            <DescriptionListDescription>{" "}</DescriptionListDescription>
                                         </DescriptionListGroup>
                                     </DescriptionList>
                                     <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "13px" }}>
@@ -106,7 +106,7 @@ export function ToolDetailModal({ isOpen, onClose, name, content }: ToolDetailMo
                             )}
                         </div>
                     </Tab>
-                    {scriptTemplate && (
+                    {scriptTemplate ? (
                         <Tab eventKey={1} title={<TabTitleText>Script Template</TabTitleText>}>
                             <div style={{ paddingTop: 16, flex: "1 1 0", minHeight: 0 }}>
                                 <CodeEditor
@@ -118,7 +118,7 @@ export function ToolDetailModal({ isOpen, onClose, name, content }: ToolDetailMo
                                 />
                             </div>
                         </Tab>
-                    )}
+                    ) : null}
                 </Tabs>
             </ModalBody>
         </Modal>

--- a/ui/src/components/assistant/ToolDetailModal.tsx
+++ b/ui/src/components/assistant/ToolDetailModal.tsx
@@ -7,8 +7,13 @@ import {
     DescriptionListTerm,
     DescriptionListDescription,
     Label,
+    Tab,
+    Tabs,
+    TabTitleText,
 } from "@patternfly/react-core";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
+import { useState } from "react";
+import "./ActionTypeDetailModal.css";
 
 interface ToolParam {
     name: string;
@@ -25,6 +30,8 @@ interface ToolDetailModalProps {
 }
 
 export function ToolDetailModal({ isOpen, onClose, name, content }: ToolDetailModalProps) {
+    const [activeTab, setActiveTab] = useState(0);
+
     const description = (content.description as string) || "";
     const parameters = (content.parameters as ToolParam[]) || [];
     const scriptTemplate = (content.scriptTemplate as string) || "";
@@ -36,80 +43,83 @@ export function ToolDetailModal({ isOpen, onClose, name, content }: ToolDetailMo
             onClose={onClose}
             variant="large"
             aria-label={`Tool: ${name}`}
+            style={{ height: "80vh" }}
         >
             <ModalHeader title={`Tool: ${name}`} />
-            <ModalBody>
-                <DescriptionList isHorizontal isCompact>
-                    <DescriptionListGroup>
-                        <DescriptionListTerm>Name</DescriptionListTerm>
-                        <DescriptionListDescription>{name}</DescriptionListDescription>
-                    </DescriptionListGroup>
-                    <DescriptionListGroup>
-                        <DescriptionListTerm>Description</DescriptionListTerm>
-                        <DescriptionListDescription>{description || "—"}</DescriptionListDescription>
-                    </DescriptionListGroup>
-                    {labels.length > 0 && (
-                        <DescriptionListGroup>
-                            <DescriptionListTerm>Labels</DescriptionListTerm>
-                            <DescriptionListDescription>
-                                {labels.map((l) => (
-                                    <Label key={l} isCompact style={{ marginRight: 4 }}>
-                                        {l}
-                                    </Label>
-                                ))}
-                            </DescriptionListDescription>
-                        </DescriptionListGroup>
+            <ModalBody className="assistant-tabbed-modal-body">
+                <Tabs activeKey={activeTab}
+                    onSelect={(_e, key) => setActiveTab(key as number)}>
+                    <Tab eventKey={0} title={<TabTitleText>Details</TabTitleText>}>
+                        <div style={{ paddingTop: 16 }}>
+                            <DescriptionList isHorizontal isCompact>
+                                <DescriptionListGroup>
+                                    <DescriptionListTerm>Name</DescriptionListTerm>
+                                    <DescriptionListDescription>{name}</DescriptionListDescription>
+                                </DescriptionListGroup>
+                                <DescriptionListGroup>
+                                    <DescriptionListTerm>Description</DescriptionListTerm>
+                                    <DescriptionListDescription>{description || "—"}</DescriptionListDescription>
+                                </DescriptionListGroup>
+                                {labels.length > 0 && (
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm>Labels</DescriptionListTerm>
+                                        <DescriptionListDescription>
+                                            {labels.map((l) => (
+                                                <Label key={l} isCompact style={{ marginRight: 4 }}>
+                                                    {l}
+                                                </Label>
+                                            ))}
+                                        </DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                )}
+                            </DescriptionList>
+
+                            {parameters.length > 0 && (
+                                <>
+                                    <DescriptionList isHorizontal isCompact style={{ marginTop: 16 }}>
+                                        <DescriptionListGroup>
+                                            <DescriptionListTerm>Parameters</DescriptionListTerm>
+                                            <DescriptionListDescription />
+                                        </DescriptionListGroup>
+                                    </DescriptionList>
+                                    <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "13px" }}>
+                                        <thead>
+                                            <tr style={{ borderBottom: "2px solid #d2d2d2" }}>
+                                                <th style={{ textAlign: "left", padding: "6px 8px" }}>Name</th>
+                                                <th style={{ textAlign: "left", padding: "6px 8px" }}>Type</th>
+                                                <th style={{ textAlign: "left", padding: "6px 8px" }}>Description</th>
+                                                <th style={{ textAlign: "left", padding: "6px 8px" }}>Required</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {parameters.map((p) => (
+                                                <tr key={p.name} style={{ borderBottom: "1px solid #d2d2d2" }}>
+                                                    <td style={{ padding: "6px 8px", fontFamily: "monospace" }}>{p.name}</td>
+                                                    <td style={{ padding: "6px 8px" }}>{p.type || "string"}</td>
+                                                    <td style={{ padding: "6px 8px" }}>{p.description || "—"}</td>
+                                                    <td style={{ padding: "6px 8px" }}>{p.required ? "Yes" : "No"}</td>
+                                                </tr>
+                                            ))}
+                                        </tbody>
+                                    </table>
+                                </>
+                            )}
+                        </div>
+                    </Tab>
+                    {scriptTemplate && (
+                        <Tab eventKey={1} title={<TabTitleText>Script Template</TabTitleText>}>
+                            <div style={{ paddingTop: 16, flex: "1 1 0", minHeight: 0 }}>
+                                <CodeEditor
+                                    code={scriptTemplate}
+                                    language={Language.shell}
+                                    height="100%"
+                                    isReadOnly
+                                    isLineNumbersVisible
+                                />
+                            </div>
+                        </Tab>
                     )}
-                </DescriptionList>
-
-                {parameters.length > 0 && (
-                    <>
-                        <DescriptionList isHorizontal isCompact style={{ marginTop: 16 }}>
-                            <DescriptionListGroup>
-                                <DescriptionListTerm>Parameters</DescriptionListTerm>
-                                <DescriptionListDescription />
-                            </DescriptionListGroup>
-                        </DescriptionList>
-                        <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "13px" }}>
-                            <thead>
-                                <tr style={{ borderBottom: "2px solid #d2d2d2" }}>
-                                    <th style={{ textAlign: "left", padding: "6px 8px" }}>Name</th>
-                                    <th style={{ textAlign: "left", padding: "6px 8px" }}>Type</th>
-                                    <th style={{ textAlign: "left", padding: "6px 8px" }}>Description</th>
-                                    <th style={{ textAlign: "left", padding: "6px 8px" }}>Required</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {parameters.map((p) => (
-                                    <tr key={p.name} style={{ borderBottom: "1px solid #d2d2d2" }}>
-                                        <td style={{ padding: "6px 8px", fontFamily: "monospace" }}>{p.name}</td>
-                                        <td style={{ padding: "6px 8px" }}>{p.type || "string"}</td>
-                                        <td style={{ padding: "6px 8px" }}>{p.description || "—"}</td>
-                                        <td style={{ padding: "6px 8px" }}>{p.required ? "Yes" : "No"}</td>
-                                    </tr>
-                                ))}
-                            </tbody>
-                        </table>
-                    </>
-                )}
-
-                {scriptTemplate && (
-                    <>
-                        <DescriptionList isHorizontal isCompact style={{ marginTop: 16 }}>
-                            <DescriptionListGroup>
-                                <DescriptionListTerm style={{ whiteSpace: "nowrap" }}>Script Template</DescriptionListTerm>
-                                <DescriptionListDescription />
-                            </DescriptionListGroup>
-                        </DescriptionList>
-                        <CodeEditor
-                            code={scriptTemplate}
-                            language={Language.shell}
-                            height="300px"
-                            isReadOnly
-                            isLineNumbersVisible
-                        />
-                    </>
-                )}
+                </Tabs>
             </ModalBody>
         </Modal>
     );

--- a/ui/src/components/assistant/ToolDetailModal.tsx
+++ b/ui/src/components/assistant/ToolDetailModal.tsx
@@ -1,0 +1,116 @@
+import {
+    Modal,
+    ModalBody,
+    ModalHeader,
+    DescriptionList,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    DescriptionListDescription,
+    Label,
+} from "@patternfly/react-core";
+import { CodeEditor, Language } from "@patternfly/react-code-editor";
+
+interface ToolParam {
+    name: string;
+    type?: string;
+    description?: string;
+    required?: boolean;
+}
+
+interface ToolDetailModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    name: string;
+    content: Record<string, unknown>;
+}
+
+export function ToolDetailModal({ isOpen, onClose, name, content }: ToolDetailModalProps) {
+    const description = (content.description as string) || "";
+    const parameters = (content.parameters as ToolParam[]) || [];
+    const scriptTemplate = (content.scriptTemplate as string) || "";
+    const labels = (content.labels as string[]) || [];
+
+    return (
+        <Modal
+            isOpen={isOpen}
+            onClose={onClose}
+            variant="large"
+            aria-label={`Tool: ${name}`}
+        >
+            <ModalHeader title={`Tool: ${name}`} />
+            <ModalBody>
+                <DescriptionList isHorizontal isCompact>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Name</DescriptionListTerm>
+                        <DescriptionListDescription>{name}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Description</DescriptionListTerm>
+                        <DescriptionListDescription>{description || "—"}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                    {labels.length > 0 && (
+                        <DescriptionListGroup>
+                            <DescriptionListTerm>Labels</DescriptionListTerm>
+                            <DescriptionListDescription>
+                                {labels.map((l) => (
+                                    <Label key={l} isCompact style={{ marginRight: 4 }}>
+                                        {l}
+                                    </Label>
+                                ))}
+                            </DescriptionListDescription>
+                        </DescriptionListGroup>
+                    )}
+                </DescriptionList>
+
+                {parameters.length > 0 && (
+                    <>
+                        <DescriptionList isHorizontal isCompact style={{ marginTop: 16 }}>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>Parameters</DescriptionListTerm>
+                                <DescriptionListDescription />
+                            </DescriptionListGroup>
+                        </DescriptionList>
+                        <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "13px" }}>
+                            <thead>
+                                <tr style={{ borderBottom: "2px solid #d2d2d2" }}>
+                                    <th style={{ textAlign: "left", padding: "6px 8px" }}>Name</th>
+                                    <th style={{ textAlign: "left", padding: "6px 8px" }}>Type</th>
+                                    <th style={{ textAlign: "left", padding: "6px 8px" }}>Description</th>
+                                    <th style={{ textAlign: "left", padding: "6px 8px" }}>Required</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {parameters.map((p) => (
+                                    <tr key={p.name} style={{ borderBottom: "1px solid #d2d2d2" }}>
+                                        <td style={{ padding: "6px 8px", fontFamily: "monospace" }}>{p.name}</td>
+                                        <td style={{ padding: "6px 8px" }}>{p.type || "string"}</td>
+                                        <td style={{ padding: "6px 8px" }}>{p.description || "—"}</td>
+                                        <td style={{ padding: "6px 8px" }}>{p.required ? "Yes" : "No"}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </>
+                )}
+
+                {scriptTemplate && (
+                    <>
+                        <DescriptionList isHorizontal isCompact style={{ marginTop: 16 }}>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm style={{ whiteSpace: "nowrap" }}>Script Template</DescriptionListTerm>
+                                <DescriptionListDescription />
+                            </DescriptionListGroup>
+                        </DescriptionList>
+                        <CodeEditor
+                            code={scriptTemplate}
+                            language={Language.shell}
+                            height="300px"
+                            isReadOnly
+                            isLineNumbersVisible
+                        />
+                    </>
+                )}
+            </ModalBody>
+        </Modal>
+    );
+}

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -1117,3 +1117,103 @@ export async function fetchActivityLogDetails(activityId: number): Promise<strin
     if (!response.ok) throw new Error(`Failed to fetch activity log details: ${response.status}`);
     return response.text();
 }
+
+// ── AI Assistant ────────────────────────────────────────────────
+
+export interface AssistantSessionInfo {
+    id: string;
+    name: string;
+    status: "starting" | "running" | "stopped" | "error";
+    createdAt: string;
+    lastActivityAt: string;
+    errorMessage?: string;
+}
+
+export interface AssistantItem {
+    type: string;
+    name: string;
+    valid: boolean;
+    validationErrors?: string[];
+}
+
+export async function createAssistantSession(name?: string): Promise<AssistantSessionInfo> {
+    const response = await fetch(`${API}/assistant/sessions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name }),
+    });
+    if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw { status: response.status, message: body.message || `Failed: ${response.status}` };
+    }
+    return response.json();
+}
+
+export async function fetchAssistantSessions(): Promise<AssistantSessionInfo[]> {
+    const response = await fetch(`${API}/assistant/sessions`);
+    if (!response.ok) throw new Error(`Failed to fetch sessions: ${response.status}`);
+    return response.json();
+}
+
+export async function fetchAssistantSession(id: string): Promise<AssistantSessionInfo> {
+    const response = await fetch(`${API}/assistant/sessions/${id}`);
+    if (!response.ok) throw new Error(`Failed to fetch session: ${response.status}`);
+    return response.json();
+}
+
+export async function deleteAssistantSession(id: string): Promise<void> {
+    const response = await fetch(`${API}/assistant/sessions/${id}`, { method: "DELETE" });
+    if (!response.ok) throw new Error(`Failed to delete session: ${response.status}`);
+}
+
+export async function sendAssistantMessage(sessionId: string, message: string): Promise<void> {
+    const response = await fetch(`${API}/assistant/sessions/${sessionId}/messages`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message }),
+    });
+    if (!response.ok) throw new Error(`Failed to send message: ${response.status}`);
+}
+
+export async function respondToAssistantPermission(
+    sessionId: string, permissionId: string, allow: boolean,
+    updatedInput?: Record<string, unknown>
+): Promise<void> {
+    const response = await fetch(`${API}/assistant/sessions/${sessionId}/permissions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ permissionId, allow, updatedInput }),
+    });
+    if (!response.ok) throw new Error(`Failed to respond to permission: ${response.status}`);
+}
+
+export async function fetchAssistantItems(sessionId: string): Promise<AssistantItem[]> {
+    const response = await fetch(`${API}/assistant/sessions/${sessionId}/items`);
+    if (!response.ok) throw new Error(`Failed to fetch items: ${response.status}`);
+    return response.json();
+}
+
+export async function fetchAssistantItemContent(
+    sessionId: string, itemType: string, itemName: string
+): Promise<Record<string, unknown>> {
+    const response = await fetch(
+        `${API}/assistant/sessions/${sessionId}/items/${itemType}/${itemName}`
+    );
+    if (!response.ok) throw new Error(`Failed to fetch item: ${response.status}`);
+    return response.json();
+}
+
+export async function applyAssistantSession(sessionId: string): Promise<ImportResult> {
+    const response = await fetch(`${API}/assistant/sessions/${sessionId}/apply`, {
+        method: "POST",
+    });
+    if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw { status: response.status, ...body };
+    }
+    return response.json();
+}
+
+export function assistantEventsUrl(sessionId: string): string {
+    return `${API}/assistant/sessions/${sessionId}/events`;
+}

--- a/ui/src/pages/AssistantPage.tsx
+++ b/ui/src/pages/AssistantPage.tsx
@@ -86,9 +86,9 @@ export function AssistantPage() {
 
     return (
         <PageSection>
-            <Content component="h1">AI Assistant</Content>
+            <Content component="h1"><RobotIcon style={{ marginRight: 8 }} />AI Assistant</Content>
             <Content component="p" style={{ marginBottom: 16 }}>
-                Interactive AI assistant for creating related sets of configuration items.
+                Interactive AI assistant for creating related sets of Axiom configuration items.
             </Content>
 
             {!loading && sessions.length > 0 && (

--- a/ui/src/pages/AssistantPage.tsx
+++ b/ui/src/pages/AssistantPage.tsx
@@ -1,0 +1,219 @@
+import { useState, useEffect, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+    PageSection,
+    Content,
+    Button,
+    EmptyState,
+    EmptyStateBody,
+    EmptyStateFooter,
+    EmptyStateActions,
+    Spinner,
+    Label,
+    Modal,
+    ModalBody,
+    ModalFooter,
+    ModalHeader,
+    TextInput,
+    Toolbar,
+    ToolbarContent,
+    ToolbarItem,
+} from "@patternfly/react-core";
+import PlusCircleIcon from "@patternfly/react-icons/dist/esm/icons/plus-circle-icon";
+import RobotIcon from "@patternfly/react-icons/dist/esm/icons/robot-icon";
+import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
+import {
+    fetchAssistantSessions,
+    createAssistantSession,
+    deleteAssistantSession,
+    type AssistantSessionInfo,
+} from "../config/api";
+
+const STATUS_COLORS: Record<string, "blue" | "green" | "red" | "grey"> = {
+    starting: "blue",
+    running: "green",
+    stopped: "grey",
+    error: "red",
+};
+
+export function AssistantPage() {
+    const navigate = useNavigate();
+    const [sessions, setSessions] = useState<AssistantSessionInfo[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [isCreateOpen, setIsCreateOpen] = useState(false);
+    const [newName, setNewName] = useState("");
+    const [creating, setCreating] = useState(false);
+    const [createError, setCreateError] = useState("");
+
+    const load = useCallback(() => {
+        setLoading(true);
+        fetchAssistantSessions()
+            .then(setSessions)
+            .catch(console.error)
+            .finally(() => setLoading(false));
+    }, []);
+
+    useEffect(() => {
+        load();
+    }, [load]);
+
+    const handleCreate = async () => {
+        setCreating(true);
+        setCreateError("");
+        try {
+            const session = await createAssistantSession(newName || undefined);
+            setIsCreateOpen(false);
+            setNewName("");
+            navigate(`/assistant/${session.id}`);
+        } catch (err: unknown) {
+            const e = err as { message?: string };
+            setCreateError(e.message || "Failed to create session");
+        } finally {
+            setCreating(false);
+        }
+    };
+
+    const handleDelete = async (id: string, e: React.MouseEvent) => {
+        e.stopPropagation();
+        if (!confirm("End this assistant session?")) return;
+        try {
+            await deleteAssistantSession(id);
+            load();
+        } catch (err) {
+            console.error("Failed to delete session:", err);
+        }
+    };
+
+    return (
+        <PageSection>
+            <Content component="h1">AI Assistant</Content>
+            <Content component="p" style={{ marginBottom: 16 }}>
+                Interactive AI assistant for creating related sets of configuration items.
+            </Content>
+
+            {!loading && sessions.length > 0 && (
+                <Toolbar>
+                    <ToolbarContent>
+                        <ToolbarItem>
+                            <Button
+                                variant="primary"
+                                icon={<PlusCircleIcon />}
+                                onClick={() => setIsCreateOpen(true)}
+                            >
+                                New Session
+                            </Button>
+                        </ToolbarItem>
+                    </ToolbarContent>
+                </Toolbar>
+            )}
+
+            {loading ? (
+                <EmptyState variant="lg">
+                    <Spinner size="lg" />
+                    <EmptyStateBody>Loading sessions...</EmptyStateBody>
+                </EmptyState>
+            ) : sessions.length === 0 ? (
+                <EmptyState
+                    headingLevel="h2"
+                    titleText="No active sessions"
+                    icon={RobotIcon}
+                    variant="lg"
+                >
+                    <EmptyStateBody>
+                        Start an interactive AI assistant session to create related sets
+                        of tools, action types, and report definitions through conversation.
+                    </EmptyStateBody>
+                    <EmptyStateFooter>
+                        <EmptyStateActions>
+                            <Button
+                                variant="primary"
+                                icon={<PlusCircleIcon />}
+                                onClick={() => setIsCreateOpen(true)}
+                            >
+                                New Session
+                            </Button>
+                        </EmptyStateActions>
+                    </EmptyStateFooter>
+                </EmptyState>
+            ) : (
+                <div style={{ marginTop: 16 }}>
+                    {sessions.map((s) => (
+                        <div
+                            key={s.id}
+                            onClick={() => navigate(`/assistant/${s.id}`)}
+                            style={{
+                                display: "flex",
+                                alignItems: "center",
+                                gap: 12,
+                                padding: "14px 16px",
+                                marginBottom: 8,
+                                borderRadius: 8,
+                                border: "1px solid #d2d2d2",
+                                cursor: "pointer",
+                                backgroundColor: "#fafafa",
+                            }}
+                            onMouseEnter={(e) => {
+                                e.currentTarget.style.backgroundColor = "#f0f0f0";
+                            }}
+                            onMouseLeave={(e) => {
+                                e.currentTarget.style.backgroundColor = "#fafafa";
+                            }}
+                        >
+                            <div style={{ flex: 1 }}>
+                                <div style={{ fontWeight: 600, fontSize: "14px" }}>{s.name}</div>
+                                <div style={{ fontSize: "12px", color: "#6a6e73", marginTop: 2 }}>
+                                    Created {new Date(s.createdAt).toLocaleString()}
+                                </div>
+                            </div>
+                            <Label isCompact color={STATUS_COLORS[s.status] || "grey"}>
+                                {s.status}
+                            </Label>
+                            <Button
+                                variant="plain"
+                                aria-label="Delete session"
+                                onClick={(e) => handleDelete(s.id, e)}
+                            >
+                                <TrashIcon />
+                            </Button>
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            <Modal
+                isOpen={isCreateOpen}
+                onClose={() => setIsCreateOpen(false)}
+                variant="small"
+                aria-label="New assistant session"
+            >
+                <ModalHeader title="New Assistant Session" />
+                <ModalBody>
+                    <TextInput
+                        value={newName}
+                        onChange={(_e, val) => setNewName(val)}
+                        placeholder="Session name (optional)"
+                        aria-label="Session name"
+                    />
+                    {createError && (
+                        <div style={{ color: "#c9190b", marginTop: 8, fontSize: "13px" }}>
+                            {createError}
+                        </div>
+                    )}
+                </ModalBody>
+                <ModalFooter>
+                    <Button
+                        variant="primary"
+                        onClick={handleCreate}
+                        isLoading={creating}
+                        isDisabled={creating}
+                    >
+                        Create
+                    </Button>
+                    <Button variant="link" onClick={() => setIsCreateOpen(false)}>
+                        Cancel
+                    </Button>
+                </ModalFooter>
+            </Modal>
+        </PageSection>
+    );
+}

--- a/ui/src/pages/AssistantSessionPage.tsx
+++ b/ui/src/pages/AssistantSessionPage.tsx
@@ -1,0 +1,245 @@
+import { useState, useEffect, useCallback } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import {
+    PageSection,
+    Button,
+    Flex,
+    FlexItem,
+    Spinner,
+    Modal,
+    ModalBody,
+    ModalFooter,
+    ModalHeader,
+    Alert,
+} from "@patternfly/react-core";
+import ArrowLeftIcon from "@patternfly/react-icons/dist/esm/icons/arrow-left-icon";
+import { AssistantChatPanel } from "../components/assistant/AssistantChatPanel";
+import { AssistantGeneratedItems } from "../components/assistant/AssistantGeneratedItems";
+import {
+    fetchAssistantSession,
+    deleteAssistantSession,
+    applyAssistantSession,
+    type AssistantSessionInfo,
+    type ImportResult,
+} from "../config/api";
+
+export function AssistantSessionPage() {
+    const { sessionId } = useParams<{ sessionId: string }>();
+    const navigate = useNavigate();
+    const [session, setSession] = useState<AssistantSessionInfo | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [itemsRefresh, setItemsRefresh] = useState(0);
+    const [isEndConfirmOpen, setIsEndConfirmOpen] = useState(false);
+    const [applying, setApplying] = useState(false);
+    const [applyResult, setApplyResult] = useState<ImportResult | null>(null);
+    const [applyError, setApplyError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (!sessionId) return;
+        setLoading(true);
+        fetchAssistantSession(sessionId)
+            .then(setSession)
+            .catch((err) => {
+                console.error("Failed to load session:", err);
+                navigate("/assistant");
+            })
+            .finally(() => setLoading(false));
+    }, [sessionId, navigate]);
+
+    const handleItemsChanged = useCallback(() => {
+        setItemsRefresh((n) => n + 1);
+    }, []);
+
+    const handleEndSession = async () => {
+        if (!sessionId) return;
+        try {
+            await deleteAssistantSession(sessionId);
+            navigate("/assistant");
+        } catch (err) {
+            console.error("Failed to end session:", err);
+        }
+    };
+
+    const handleApply = async () => {
+        if (!sessionId) return;
+        setApplying(true);
+        setApplyError(null);
+        try {
+            const result = await applyAssistantSession(sessionId);
+            setApplyResult(result);
+        } catch (err: unknown) {
+            const e = err as { message?: string; validationErrors?: string[] };
+            if (e.validationErrors) {
+                setApplyError("Validation errors:\n" + e.validationErrors.join("\n"));
+            } else {
+                setApplyError(e.message || "Failed to apply");
+            }
+        } finally {
+            setApplying(false);
+        }
+    };
+
+    if (loading) {
+        return (
+            <PageSection>
+                <Spinner size="lg" />
+            </PageSection>
+        );
+    }
+
+    if (!session || !sessionId) {
+        return (
+            <PageSection>
+                <Alert variant="danger" isInline title="Session not found" />
+            </PageSection>
+        );
+    }
+
+    return (
+        <PageSection padding={{ default: "noPadding" }} isFilled hasBodyWrapper={false}
+            style={{
+                display: "flex",
+                flexDirection: "column",
+                overflow: "hidden",
+                minHeight: 0,
+                flex: "1 1 0",
+            }}>
+            {/* Header — fixed at top */}
+            <Flex style={{
+                padding: "12px 16px",
+                borderBottom: "1px solid #d2d2d2",
+                alignItems: "center",
+                flexShrink: 0,
+            }}>
+                <FlexItem>
+                    <Button variant="plain" onClick={() => navigate("/assistant")}>
+                        <ArrowLeftIcon />
+                    </Button>
+                </FlexItem>
+                <FlexItem grow={{ default: "grow" }}>
+                    <span style={{ fontWeight: 600, fontSize: "16px" }}>{session.name}</span>
+                </FlexItem>
+                <FlexItem>
+                    <Button
+                        variant="primary"
+                        onClick={handleApply}
+                        isLoading={applying}
+                        isDisabled={applying}
+                        style={{ marginRight: 8 }}
+                    >
+                        Apply All
+                    </Button>
+                    <Button
+                        variant="secondary"
+                        isDanger
+                        onClick={() => setIsEndConfirmOpen(true)}
+                    >
+                        End Session
+                    </Button>
+                </FlexItem>
+            </Flex>
+
+            {applyError && (
+                <Alert
+                    variant="danger"
+                    isInline
+                    title="Apply failed"
+                    style={{ margin: "8px 16px", flexShrink: 0 }}
+                >
+                    <pre style={{ whiteSpace: "pre-wrap", fontSize: "12px" }}>{applyError}</pre>
+                </Alert>
+            )}
+
+            {/* Split panels — fills remaining height */}
+            <div style={{
+                display: "flex",
+                flex: "1 1 0",
+                minHeight: 0,
+                overflow: "hidden",
+            }}>
+                {/* Chat Panel - 70% */}
+                <div style={{
+                    flex: "7 1 0",
+                    borderRight: "1px solid #d2d2d2",
+                    display: "flex",
+                    flexDirection: "column",
+                    minWidth: 0,
+                    minHeight: 0,
+                }}>
+                    <AssistantChatPanel
+                        sessionId={sessionId}
+                        onItemsChanged={handleItemsChanged}
+                    />
+                </div>
+
+                {/* Items Panel - 30%, scrolls independently */}
+                <div style={{
+                    flex: "3 1 0",
+                    overflowY: "auto",
+                    minWidth: 0,
+                    minHeight: 0,
+                }}>
+                    <AssistantGeneratedItems
+                        sessionId={sessionId}
+                        refreshTrigger={itemsRefresh}
+                    />
+                </div>
+            </div>
+
+            {/* End session confirmation */}
+            <Modal
+                isOpen={isEndConfirmOpen}
+                onClose={() => setIsEndConfirmOpen(false)}
+                variant="small"
+                aria-label="End session confirmation"
+            >
+                <ModalHeader title="End Session?" />
+                <ModalBody>
+                    This will terminate the AI assistant and delete all generated items
+                    that have not been applied. This action cannot be undone.
+                </ModalBody>
+                <ModalFooter>
+                    <Button variant="danger" onClick={handleEndSession}>
+                        End Session
+                    </Button>
+                    <Button variant="link" onClick={() => setIsEndConfirmOpen(false)}>
+                        Cancel
+                    </Button>
+                </ModalFooter>
+            </Modal>
+
+            {/* Apply success */}
+            <Modal
+                isOpen={applyResult !== null}
+                onClose={() => {
+                    setApplyResult(null);
+                    navigate("/assistant");
+                }}
+                variant="small"
+                aria-label="Apply result"
+            >
+                <ModalHeader title="Items Applied Successfully" />
+                <ModalBody>
+                    {applyResult && (
+                        <div>
+                            <p>The following items were imported:</p>
+                            <ul style={{ marginTop: 8 }}>
+                                {(applyResult.tools ?? 0) > 0 && <li>{applyResult.tools} tool(s)</li>}
+                                {(applyResult.actionTypes ?? 0) > 0 && <li>{applyResult.actionTypes} action type(s)</li>}
+                                {(applyResult.reportDefinitions ?? 0) > 0 && <li>{applyResult.reportDefinitions} report definition(s)</li>}
+                            </ul>
+                        </div>
+                    )}
+                </ModalBody>
+                <ModalFooter>
+                    <Button variant="primary" onClick={() => {
+                        setApplyResult(null);
+                        navigate("/assistant");
+                    }}>
+                        Done
+                    </Button>
+                </ModalFooter>
+            </Modal>
+        </PageSection>
+    );
+}

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -204,7 +204,7 @@ export function DashboardPage() {
     }
 
     return (
-        <PageSection style={{ height: "100vh" }}>
+        <PageSection isFilled={true}>
             <Title headingLevel="h1" size="lg" style={{ marginBottom: "16px" }}>
                 Dashboard
             </Title>

--- a/ui/src/pages/ReportDetailPage.tsx
+++ b/ui/src/pages/ReportDetailPage.tsx
@@ -23,7 +23,14 @@ import {
     Title,
 } from "@patternfly/react-core";
 import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
-import { type Report, fetchReport, deleteReport, updateReportLabels } from "../config/api";
+import {
+    type Report,
+    type ReportDefinition,
+    fetchReport,
+    fetchReportDefinition,
+    deleteReport,
+    updateReportLabels,
+} from "../config/api";
 import { sseClient, type AxiomSseEvent } from "../config/sse";
 import { RenderedReport } from "../components/RenderedReport";
 import { ExecutionLogModal } from "../components/ExecutionLogModal";
@@ -37,6 +44,7 @@ export function ReportDetailPage() {
     const id = Number(reportId);
 
     const [report, setReport] = useState<Report | null>(null);
+    const [definition, setDefinition] = useState<ReportDefinition | null>(null);
     const [loading, setLoading] = useState(true);
     const [isLogModalOpen, setIsLogModalOpen] = useState(false);
     const [isDeleteOpen, setIsDeleteOpen] = useState(false);
@@ -52,7 +60,12 @@ export function ReportDetailPage() {
         if (!id) return;
         setLoading(true);
         fetchReport(id)
-            .then(setReport)
+            .then((r) => {
+                setReport(r);
+                fetchReportDefinition(r.definitionId)
+                    .then(setDefinition)
+                    .catch(console.error);
+            })
             .catch(console.error)
             .finally(() => setLoading(false));
     }, [id]);
@@ -125,6 +138,14 @@ export function ReportDetailPage() {
                                     : report.status === "Failed" ? "red" : "blue"}>
                                     {report.status}
                                 </Label>
+                            </DescriptionListDescription>
+                        </DescriptionListGroup>
+                        <DescriptionListGroup>
+                            <DescriptionListTerm>Definition</DescriptionListTerm>
+                            <DescriptionListDescription>
+                                <Link to={`/report-definitions/${report.definitionId}`}>
+                                    {definition?.name || `Definition #${report.definitionId}`}
+                                </Link>
                             </DescriptionListDescription>
                         </DescriptionListGroup>
                         {report.timeRangeStart && report.timeRangeEnd && (

--- a/ui/src/pages/ReportsPage.tsx
+++ b/ui/src/pages/ReportsPage.tsx
@@ -4,6 +4,8 @@ import {
     Button,
     EmptyState,
     EmptyStateBody,
+    EmptyStateFooter,
+    EmptyStateActions,
     Label,
     Modal,
     ModalBody,
@@ -166,13 +168,27 @@ export function ReportsPage() {
                     <EmptyState>
                         <EmptyStateBody>Loading reports...</EmptyStateBody>
                     </EmptyState>
-                ) : reports.length === 0 ? (
+                ) : reports.length === 0 && isFiltered ? (
                     <EmptyState>
                         <EmptyStateBody>
-                            {isFiltered
-                                ? "No reports match the current filters."
-                                : "No reports generated yet. Configure and enable a report definition under Configuration \u2192 Report Definitions, or click \"Run Now\" to generate one immediately."}
+                            No reports match the current filters.
                         </EmptyStateBody>
+                    </EmptyState>
+                ) : reports.length === 0 ? (
+                    <EmptyState headingLevel="h2" titleText="No reports yet">
+                        <EmptyStateBody>
+                            Reports are generated from Report Definitions. Configure and
+                            enable a report definition, or click "Run Now" on an existing
+                            one to generate a report.
+                        </EmptyStateBody>
+                        <EmptyStateFooter>
+                            <EmptyStateActions>
+                                <Button variant="primary"
+                                    onClick={() => navigate("/report-definitions")}>
+                                    Go to Report Definitions
+                                </Button>
+                            </EmptyStateActions>
+                        </EmptyStateFooter>
                     </EmptyState>
                 ) : (
                     <Table aria-label="Reports" variant="compact">


### PR DESCRIPTION
## Summary
- Adds a new interactive AI Assistant that runs a persistent Claude Code session, enabling users
  to create related sets of configuration items (Tools, Action Types, Report Definitions) through
  natural language conversation
- Backend manages assistant session lifecycle with Claude Code subprocess, NDJSON event parsing,
  real-time validation, and a Node.js MCP server providing 8 read-only query tools
- SSE-driven chat UI with markdown rendering, syntax-highlighted tool blocks, inline permission
  prompts, interactive question handling, generated items panel with detail modals, and session
  management

## Details

### Backend
- `AssistantSession` wraps an interactive Claude Code subprocess with bidirectional stdin/stdout
- `AssistantEventParser` normalizes Claude Code NDJSON events into semantic SSE types
- `AssistantSessionManager` manages session lifecycle with max session limit, MCP server
  installation, real-time validation feedback, and apply via `ImportExportService.importPack()`
- `AssistantContextBuilder` creates working directories with CLAUDE.md system prompt and MCP config
- `AssistantItemValidator` validates generated JSON against item schemas
- `AssistantSessionResource` provides REST API at `/api/v1/assistant/sessions`
- Axiom Assistant MCP Server (Node.js) with 8 read-only query tools

### Frontend
- SSE-driven chat with markdown rendering (`react-markdown` + `remark-gfm`)
- Syntax-highlighted tool use blocks with inline permission prompts
- Interactive AskUserQuestion UI with radio/checkbox options and free-text fallback
- Generated items panel with type badges, validation status, and type-specific detail modals
- Session list page with PatternFly EmptyState
- Masthead robot icon with discovery throb animation
- Full-width layout on assistant pages (sidebar hidden)
- Improved Reports page empty state with link to Report Definitions

### Tests
- `AssistantEventParserTest` (20 tests) - event parsing and normalization
- `AssistantItemValidatorTest` (24 tests) - schema validation for all item types

## Test plan
- [ ] Start a new assistant session and verify the Claude Code subprocess launches
- [ ] Send messages and verify SSE events stream correctly to the chat UI
- [ ] Test permission prompts appear inline and can be accepted/denied
- [ ] Test AskUserQuestion renders options and submits responses
- [ ] Verify generated items appear in the side panel with correct validation status
- [ ] Open detail modals for each item type and verify tabbed layout with CodeEditor
- [ ] Test session cleanup and max session limits
- [ ] Verify robot icon throb animation and localStorage tracking
- [ ] Check full-width layout on assistant pages
- [ ] Verify Reports page empty state links to Report Definitions