### PR TITLE
Dynamic model list per AI engine

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/rest/SystemResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/SystemResourceImpl.java
@@ -103,13 +103,14 @@ public class SystemResourceImpl implements SystemResource {
     /**
      * {@inheritDoc}
      *
-     * Returns the available models for the active AI engine. For Claude Code,
-     * returns the static list from config. For OpenCode, returns models in
-     * provider/model format.
+     * Returns the available models for the specified engine, or the default
+     * engine if not specified. Claude Code returns short model names;
+     * OpenCode returns provider/model format.
      */
     @Override
-    public List<String> listModels() {
-        String models = "opencode".equals(aiEngine.getType())
+    public List<String> listModels(String engine) {
+        String engineType = (engine != null && !engine.isBlank()) ? engine : aiEngine.getType();
+        String models = "opencode".equals(engineType)
                 ? openCodeAvailableModels
                 : claudeAvailableModels;
 

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -65,8 +65,19 @@
           "System"
         ],
         "summary": "List available AI models",
-        "description": "Returns the list of AI models that can be used for action type configuration.",
+        "description": "Returns the list of AI models available for the specified engine, or the default engine if not specified.",
         "operationId": "listModels",
+        "parameters": [
+          {
+            "name": "engine",
+            "in": "query",
+            "description": "Engine type to list models for (e.g. opencode, claude-code). Defaults to the active engine.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -163,8 +163,9 @@ export async function importPack(packJson: string): Promise<ImportResult> {
     return response.json();
 }
 
-export async function fetchModels(): Promise<string[]> {
-    const response = await fetch(`${API}/system/models`);
+export async function fetchModels(engine?: string): Promise<string[]> {
+    const params = engine ? `?engine=${encodeURIComponent(engine)}` : "";
+    const response = await fetch(`${API}/system/models${params}`);
     if (!response.ok) throw new Error(`Failed to fetch models: ${response.status}`);
     return response.json();
 }

--- a/ui/src/pages/ActionTypeDetailPage.tsx
+++ b/ui/src/pages/ActionTypeDetailPage.tsx
@@ -118,11 +118,17 @@ export function ActionTypeDetailPage() {
 
     useEffect(() => { loadData(); }, [loadData]);
     useEffect(() => {
-        fetchModels().then(setAvailableModels).catch(console.error);
         fetchEngines().then(setAvailableEngines).catch(console.error);
     }, []);
 
+    useEffect(() => {
+        fetchModels(form.engine || undefined).then(setAvailableModels).catch(console.error);
+    }, [form.engine]);
+
     const updateForm = (updates: Partial<NewActionType>) => {
+        if (updates.engine !== undefined && updates.engine !== form.engine) {
+            updates = { ...updates, model: undefined };
+        }
         setForm((prev) => {
             const updated = { ...prev, ...updates };
             runValidation(buildValidationData(updated, tools, envVars));


### PR DESCRIPTION
## Summary

Rebases and applies the changes from PR #3 by @carlesarnal onto current `main` (post-rebrand, post-validation).

When switching the AI engine on an action type, the model dropdown now refreshes to show models for the selected engine instead of always showing the global default's models.

## Changes

- `GET /system/models` now accepts an optional `?engine=` query parameter
- `fetchModels(engine?)` API function passes the engine parameter
- ActionTypeDetailPage refetches models when the engine dropdown changes
- Model selection is cleared when switching engines
- Validation re-runs on engine/model changes

## Test plan

- [ ] Open an Action Type detail page
- [ ] Change the AI Engine dropdown to a different engine
- [ ] Verify the Model dropdown refreshes with that engine's models
- [ ] Verify the previously selected model is cleared
- [ ] Call `GET /api/v1/system/models?engine=opencode` — returns OpenCode models
- [ ] Call `GET /api/v1/system/models` (no param) — returns default engine models