### PR TITLE
Fix tool test to use current form state instead of saved definition (#18)

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/rest/ToolsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/ToolsResourceImpl.java
@@ -166,12 +166,16 @@ public class ToolsResourceImpl implements ToolsResource {
     public ToolTestResponse testTool(BigInteger toolId, ToolTestRequest data) {
         ToolDefinitionEntity entity = findOrThrow(toolId.longValue());
 
-        if (entity.scriptTemplate == null || entity.scriptTemplate.isBlank()) {
+        String scriptTemplate = (data.getScriptTemplate() != null && !data.getScriptTemplate().isBlank())
+                ? data.getScriptTemplate()
+                : entity.scriptTemplate;
+
+        if (scriptTemplate == null || scriptTemplate.isBlank()) {
             throw new WebApplicationException(
                     "Tool has no script template to test", 400);
         }
 
-        String resolvedScript = resolveParameters(entity.scriptTemplate, data);
+        String resolvedScript = resolveParameters(scriptTemplate, data);
         Instant startTime = Instant.now();
 
         try {

--- a/app/src/test/java/io/apitomy/axiom/app/ToolTestEndpointTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/ToolTestEndpointTest.java
@@ -1,0 +1,94 @@
+package io.apitomy.axiom.app;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Integration tests for the tool test endpoint ({@code POST /tools/{id}/test}).
+ * Verifies that the endpoint respects a {@code scriptTemplate} override from
+ * the request body and falls back to the saved definition when omitted.
+ */
+@QuarkusTest
+class ToolTestEndpointTest {
+
+    private static final String TOOLS_PATH = "/api/v1/tools";
+
+    @Test
+    void testToolUsesRequestScriptTemplate() {
+        int toolId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                    {
+                        "name": "test-override-tool",
+                        "scriptTemplate": "echo saved"
+                    }
+                    """)
+                .when()
+                .post(TOOLS_PATH)
+                .then()
+                .statusCode(200)
+                .extract().path("id");
+
+        try {
+            given()
+                    .contentType(ContentType.JSON)
+                    .body("""
+                        {
+                            "scriptTemplate": "echo override",
+                            "parameters": {}
+                        }
+                        """)
+                    .when()
+                    .post(TOOLS_PATH + "/" + toolId + "/test")
+                    .then()
+                    .statusCode(200)
+                    .body("success", is(true))
+                    .body("output", containsString("override"))
+                    .body("resolvedScript", equalTo("echo override"));
+        } finally {
+            given().when().delete(TOOLS_PATH + "/" + toolId).then().statusCode(204);
+        }
+    }
+
+    @Test
+    void testToolFallsBackToSavedScriptTemplate() {
+        int toolId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                    {
+                        "name": "test-fallback-tool",
+                        "scriptTemplate": "echo saved"
+                    }
+                    """)
+                .when()
+                .post(TOOLS_PATH)
+                .then()
+                .statusCode(200)
+                .extract().path("id");
+
+        try {
+            given()
+                    .contentType(ContentType.JSON)
+                    .body("""
+                        {
+                            "parameters": {}
+                        }
+                        """)
+                    .when()
+                    .post(TOOLS_PATH + "/" + toolId + "/test")
+                    .then()
+                    .statusCode(200)
+                    .body("success", is(true))
+                    .body("output", containsString("saved"))
+                    .body("resolvedScript", equalTo("echo saved"));
+        } finally {
+            given().when().delete(TOOLS_PATH + "/" + toolId).then().statusCode(204);
+        }
+    }
+}

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -4989,6 +4989,10 @@
             "additionalProperties": {
               "type": "string"
             }
+          },
+          "scriptTemplate": {
+            "description": "Script template to use for the test. If provided, this overrides the saved script template from the database, allowing tests against unsaved changes.",
+            "type": "string"
           }
         }
       },

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -537,6 +537,7 @@ export async function deleteTool(id: number): Promise<void> {
 }
 
 export interface ToolTestRequest {
+    scriptTemplate?: string;
     parameters?: Record<string, string>;
 }
 

--- a/ui/src/pages/ToolDetailPage.tsx
+++ b/ui/src/pages/ToolDetailPage.tsx
@@ -464,7 +464,7 @@ function TestTab({ toolId, params, scriptTemplate }: {
     const handleRun = () => {
         setRunning(true);
         setResult(null);
-        testTool(toolId, { parameters: paramValues })
+        testTool(toolId, { scriptTemplate, parameters: paramValues })
             .then((r) => {
                 setResult(r);
                 setResultOpen(true);


### PR DESCRIPTION
## Summary

- Added optional `scriptTemplate` field to `ToolTestRequest` in the OpenAPI contract, backend bean, and
  frontend interface
- Backend `testTool()` now prefers the request-provided `scriptTemplate` over the saved database value,
  with fallback for backward compatibility
- Frontend `TestTab.handleRun()` now passes the current form's `scriptTemplate` in the API call so
  unsaved changes are tested immediately

## Related Issue

Fixes #18

## Test Plan

- [ ] Create a tool with a script template (e.g. `echo hello`)
- [ ] Modify the script template without saving (e.g. change to `echo modified`)
- [ ] Switch to the Test tab and run the test
- [ ] Verify the output reflects the unsaved "modified" version, not the saved "hello" version
- [ ] Save the tool, then run the test again without further edits — verify it still works (fallback path)
- [ ] Run `ToolTestEndpointTest` — both `testToolUsesRequestScriptTemplate` and
  `testToolFallsBackToSavedScriptTemplate` should pass