### PR TITLE
Add pull request event support to GitHub event source poller

### DIFF
--- a/events/github/pom.xml
+++ b/events/github/pom.xml
@@ -36,6 +36,11 @@
             <groupId>io.smallrye.common</groupId>
             <artifactId>smallrye-common-annotation</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/events/github/src/main/java/io/apitomy/axiom/events/github/GitHubApiClient.java
+++ b/events/github/src/main/java/io/apitomy/axiom/events/github/GitHubApiClient.java
@@ -66,6 +66,43 @@ public class GitHubApiClient {
         return doGet(url, token);
     }
 
+    /**
+     * Fetches pull requests updated since the given timestamp.
+     *
+     * <p>The GitHub Pulls API does not support a {@code since} query parameter,
+     * so all recently-updated PRs are returned. The caller must filter by
+     * {@code updated_at} to find PRs changed since the last poll.</p>
+     *
+     * @param owner the repository owner
+     * @param repo the repository name
+     * @param token GitHub API token (may be null for public repos)
+     * @return the API result with the JSON array of pull requests
+     */
+    public ApiResult fetchPullsUpdatedSince(String owner, String repo, String token) {
+        String url = GITHUB_API_BASE + "/repos/" + owner + "/" + repo
+                + "/pulls?state=all&sort=updated&direction=asc&per_page=100";
+        return doGet(url, token);
+    }
+
+    /**
+     * Fetches pull request review comments updated since the given timestamp.
+     *
+     * @param owner the repository owner
+     * @param repo the repository name
+     * @param since only return comments updated after this time (may be null for first poll)
+     * @param token GitHub API token (may be null for public repos)
+     * @return the API result with the JSON array of review comments
+     */
+    public ApiResult fetchPullReviewCommentsUpdatedSince(String owner, String repo,
+                                                          Instant since, String token) {
+        String url = GITHUB_API_BASE + "/repos/" + owner + "/" + repo
+                + "/pulls/comments?sort=updated&direction=asc&per_page=100";
+        if (since != null) {
+            url += "&since=" + DateTimeFormatter.ISO_INSTANT.format(since);
+        }
+        return doGet(url, token);
+    }
+
     private ApiResult doGet(String url, String token) {
         try {
             HttpRequest.Builder builder = HttpRequest.newBuilder()

--- a/events/github/src/main/java/io/apitomy/axiom/events/github/GitHubEventNormalizer.java
+++ b/events/github/src/main/java/io/apitomy/axiom/events/github/GitHubEventNormalizer.java
@@ -27,7 +27,9 @@ public final class GitHubEventNormalizer {
         return switch (githubEvent) {
             case "issues" -> normalizeIssueEvent(action);
             case "issue_comment" -> normalizeIssueCommentEvent(action);
-            default -> null; // Unsupported event type
+            case "pull_request" -> normalizePullRequestEvent(action, payload);
+            case "pull_request_review_comment" -> normalizePullRequestReviewCommentEvent(action);
+            default -> null;
         };
     }
 
@@ -47,6 +49,31 @@ public final class GitHubEventNormalizer {
 
         String fullName = repo.path("full_name").asText(null);
         int number = issue.path("number").asInt(0);
+
+        if (fullName == null || number == 0) {
+            return null;
+        }
+
+        return fullName + "#" + number;
+    }
+
+    /**
+     * Extracts the pull request reference (owner/repo#number) from the payload.
+     * Falls back to {@link #extractIssueRef(JsonNode)} for issue payloads.
+     *
+     * @param payload the parsed JSON payload
+     * @return the PR or issue reference, or null if not found
+     */
+    public static String extractPrRef(JsonNode payload) {
+        JsonNode pr = payload.path("pull_request");
+        JsonNode repo = payload.path("repository");
+
+        if (pr.isMissingNode() || repo.isMissingNode()) {
+            return extractIssueRef(payload);
+        }
+
+        String fullName = repo.path("full_name").asText(null);
+        int number = pr.path("number").asInt(0);
 
         if (fullName == null || number == 0) {
             return null;
@@ -85,6 +112,35 @@ public final class GitHubEventNormalizer {
         return switch (action) {
             case "created" -> "comment-added";
             default -> null; // edited/deleted comments are ignored for now
+        };
+    }
+
+    private static String normalizePullRequestEvent(String action, JsonNode payload) {
+        if (action == null) {
+            return null;
+        }
+        return switch (action) {
+            case "opened" -> "pr-created";
+            case "edited", "labeled", "unlabeled", "assigned", "unassigned",
+                 "review_requested", "review_request_removed",
+                 "ready_for_review", "converted_to_draft",
+                 "synchronize" -> "pr-updated";
+            case "closed" -> {
+                boolean merged = payload.path("pull_request").path("merged").asBoolean(false);
+                yield merged ? "pr-merged" : "pr-closed";
+            }
+            case "reopened" -> "pr-reopened";
+            default -> null;
+        };
+    }
+
+    private static String normalizePullRequestReviewCommentEvent(String action) {
+        if (action == null) {
+            return null;
+        }
+        return switch (action) {
+            case "created" -> "pr-review-comment";
+            default -> null;
         };
     }
 }

--- a/events/github/src/main/java/io/apitomy/axiom/events/github/GitHubPoller.java
+++ b/events/github/src/main/java/io/apitomy/axiom/events/github/GitHubPoller.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Polls the GitHub API for new issue and comment events on monitored event sources.
+ * Polls the GitHub API for new issue, comment, and pull request events on monitored event sources.
  *
  * <p>This provides an alternative to webhooks for environments where inbound
  * connectivity is not available (e.g. local development behind a firewall).</p>
@@ -28,6 +28,8 @@ import java.util.List;
  * <ol>
  *   <li>Fetches issues updated since the last poll</li>
  *   <li>Fetches comments created since the last poll</li>
+ *   <li>Fetches pull requests updated since the last poll</li>
+ *   <li>Fetches pull request review comments since the last poll</li>
  *   <li>Determines the event type for each and ingests new events</li>
  *   <li>Updates the event source's {@code lastPolledAt} timestamp</li>
  * </ol>
@@ -155,10 +157,32 @@ public class GitHubPoller {
             return;
         }
 
+        ApiResult pullsResult = apiClient.fetchPullsUpdatedSince(owner, name, token);
+        logLines.add("\n── Pull Requests API ──");
+        logLines.add(pullsResult.formatDetail());
+        if (!pullsResult.success()) {
+            LOG.warnf("GitHub Pulls API failed for %s: %s", repo, pullsResult.errorMessage());
+            logLines.add("Pull requests API failed, continuing with issues and comments only.");
+        }
+
+        ApiResult reviewCommentsResult = apiClient.fetchPullReviewCommentsUpdatedSince(owner, name, since, token);
+        logLines.add("\n── Review Comments API ──");
+        logLines.add(reviewCommentsResult.formatDetail());
+        if (!reviewCommentsResult.success()) {
+            LOG.warnf("GitHub Review Comments API failed for %s: %s", repo, reviewCommentsResult.errorMessage());
+            logLines.add("Review comments API failed, continuing without review comments.");
+        }
+
         logLines.add("\n── Events ──");
         int issueEvents = processIssues(source.id, issuesResult, owner, name, since, logLines);
         int commentEvents = processComments(source.id, commentsResult, owner, name, since, logLines);
-        int eventsIngested = issueEvents + commentEvents;
+        int prEvents = pullsResult.success()
+                ? processPullRequests(source.id, pullsResult, owner, name, since, logLines)
+                : 0;
+        int reviewCommentEvents = reviewCommentsResult.success()
+                ? processReviewComments(source.id, reviewCommentsResult, owner, name, since, logLines)
+                : 0;
+        int eventsIngested = issueEvents + commentEvents + prEvents + reviewCommentEvents;
 
         updateLastPolledAt(source.id, pollStartedAt);
 
@@ -228,7 +252,6 @@ public class GitHubPoller {
                 continue;
             }
 
-            // Only process comments created after our last poll (not edited ones)
             Instant createdAt = parseGitHubTimestamp(comment.path("created_at").asText(null));
             if (since != null && createdAt != null && !createdAt.isAfter(since)) {
                 continue;
@@ -252,6 +275,84 @@ public class GitHubPoller {
         return count;
     }
 
+    private int processPullRequests(Long eventSourceId, ApiResult result, String owner, String name,
+                                     Instant since, List<String> logLines) {
+        if (result.data() == null || !result.data().isArray()) {
+            logLines.add("Pull requests: no data returned");
+            return 0;
+        }
+
+        int total = result.data().size();
+        int count = 0;
+        String repoFullName = owner + "/" + name;
+
+        for (JsonNode pr : result.data()) {
+            Instant updatedAt = parseGitHubTimestamp(pr.path("updated_at").asText(null));
+            if (since != null && updatedAt != null && !updatedAt.isAfter(since)) {
+                continue;
+            }
+
+            String eventType = determinePrEventType(pr, since);
+            if (eventType == null) continue;
+
+            int number = pr.path("number").asInt(0);
+            String issueRef = repoFullName + "#" + number;
+
+            try {
+                String payload = objectMapper.writeValueAsString(wrapPrAsWebhookPayload(
+                        pr, repoFullName, eventType));
+                eventService.ingestEvent(eventSourceId, "github", eventType, issueRef, repoFullName, payload);
+                logLines.add("  " + eventType + ": " + issueRef + " — " + pr.path("title").asText(""));
+                count++;
+            } catch (Exception e) {
+                logLines.add("  Failed to ingest PR " + issueRef + ": " + e.getMessage());
+                LOG.warnf(e, "Failed to ingest PR event for %s", issueRef);
+            }
+        }
+        logLines.add("Pull requests: " + total + " returned by API, " + count + " event(s) ingested");
+        return count;
+    }
+
+    private int processReviewComments(Long eventSourceId, ApiResult result, String owner, String name,
+                                       Instant since, List<String> logLines) {
+        if (result.data() == null || !result.data().isArray()) {
+            logLines.add("Review comments: no data returned");
+            return 0;
+        }
+
+        int count = 0;
+        String repoFullName = owner + "/" + name;
+
+        for (JsonNode comment : result.data()) {
+            String prUrl = comment.path("pull_request_url").asText("");
+            int prNumber = extractIssueNumberFromUrl(prUrl);
+            if (prNumber == 0) {
+                continue;
+            }
+
+            Instant createdAt = parseGitHubTimestamp(comment.path("created_at").asText(null));
+            if (since != null && createdAt != null && !createdAt.isAfter(since)) {
+                continue;
+            }
+
+            String issueRef = repoFullName + "#" + prNumber;
+
+            try {
+                String payload = objectMapper.writeValueAsString(wrapReviewCommentAsWebhookPayload(
+                        comment, repoFullName, prNumber));
+                eventService.ingestEvent(eventSourceId, "github", "pr-review-comment", issueRef, repoFullName, payload);
+                String author = comment.path("user").path("login").asText("unknown");
+                logLines.add("  pr-review-comment: " + issueRef + " by " + author);
+                count++;
+            } catch (Exception e) {
+                logLines.add("  Failed to ingest review comment for " + issueRef + ": " + e.getMessage());
+                LOG.warnf(e, "Failed to ingest review comment event for %s", issueRef);
+            }
+        }
+        logLines.add("Review comments: " + result.data().size() + " returned by API, " + count + " new comment(s) ingested");
+        return count;
+    }
+
     /**
      * Determines the event type for an issue based on its state and timing.
      */
@@ -261,31 +362,59 @@ public class GitHubPoller {
         Instant updatedAt = parseGitHubTimestamp(issue.path("updated_at").asText(null));
         Instant closedAt = parseGitHubTimestamp(issue.path("closed_at").asText(null));
 
-        // If this is the first poll, only treat newly created issues as events
         if (since == null) {
             return null;
         }
 
-        // Issue was created after our last poll
         if (createdAt != null && createdAt.isAfter(since)) {
             return "issue-created";
         }
 
-        // Issue was closed after our last poll
         if ("closed".equals(state) && closedAt != null && closedAt.isAfter(since)) {
             return "issue-closed";
         }
 
-        // Issue was updated (but not created or closed) after our last poll
         if (updatedAt != null && updatedAt.isAfter(since)) {
-            // Could be a reopen, edit, label change, etc.
-            // We can't distinguish reopened from other updates via the issues API alone,
-            // so we emit issue-updated as a catch-all
             if ("open".equals(state) && closedAt != null) {
-                // Was previously closed and is now open — likely reopened
                 return "issue-reopened";
             }
             return "issue-updated";
+        }
+
+        return null;
+    }
+
+    /**
+     * Determines the event type for a pull request based on its state and timing.
+     */
+    String determinePrEventType(JsonNode pr, Instant since) {
+        String state = pr.path("state").asText("");
+        Instant createdAt = parseGitHubTimestamp(pr.path("created_at").asText(null));
+        Instant updatedAt = parseGitHubTimestamp(pr.path("updated_at").asText(null));
+        Instant closedAt = parseGitHubTimestamp(pr.path("closed_at").asText(null));
+        Instant mergedAt = parseGitHubTimestamp(pr.path("merged_at").asText(null));
+
+        if (since == null) {
+            return null;
+        }
+
+        if (createdAt != null && createdAt.isAfter(since)) {
+            return "pr-created";
+        }
+
+        if (mergedAt != null && mergedAt.isAfter(since)) {
+            return "pr-merged";
+        }
+
+        if ("closed".equals(state) && closedAt != null && closedAt.isAfter(since) && mergedAt == null) {
+            return "pr-closed";
+        }
+
+        if (updatedAt != null && updatedAt.isAfter(since)) {
+            if ("open".equals(state) && closedAt != null) {
+                return "pr-reopened";
+            }
+            return "pr-updated";
         }
 
         return null;
@@ -321,7 +450,38 @@ public class GitHubPoller {
         return node;
     }
 
-    private Instant parseGitHubTimestamp(String timestamp) {
+    /**
+     * Wraps a GitHub Pulls API response into a structure resembling a webhook payload,
+     * so the downstream processing is consistent regardless of event source.
+     */
+    private JsonNode wrapPrAsWebhookPayload(JsonNode pr, String repoFullName, String eventType) {
+        String action = switch (eventType) {
+            case "pr-created" -> "opened";
+            case "pr-closed" -> "closed";
+            case "pr-merged" -> "closed";
+            case "pr-reopened" -> "reopened";
+            default -> "edited";
+        };
+        var node = objectMapper.createObjectNode();
+        node.put("action", action);
+        node.put("polled", true);
+        node.set("pull_request", pr);
+        return node;
+    }
+
+    /**
+     * Wraps a GitHub Pull Review Comments API response into a structure resembling a webhook payload.
+     */
+    private JsonNode wrapReviewCommentAsWebhookPayload(JsonNode comment, String repoFullName, int prNumber) {
+        var node = objectMapper.createObjectNode();
+        node.put("action", "created");
+        node.put("polled", true);
+        node.putObject("pull_request").put("number", prNumber);
+        node.set("comment", comment);
+        return node;
+    }
+
+    Instant parseGitHubTimestamp(String timestamp) {
         if (timestamp == null || timestamp.isEmpty()) {
             return null;
         }

--- a/events/github/src/test/java/io/apitomy/axiom/events/github/GitHubEventNormalizerTest.java
+++ b/events/github/src/test/java/io/apitomy/axiom/events/github/GitHubEventNormalizerTest.java
@@ -1,0 +1,240 @@
+package io.apitomy.axiom.events.github;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link GitHubEventNormalizer}.
+ */
+class GitHubEventNormalizerTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    // ── Issue events ──
+
+    @Test
+    void normalizeIssueOpened() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("action", "opened");
+        assertEquals("issue-created", GitHubEventNormalizer.normalizeEventType("issues", payload));
+    }
+
+    @Test
+    void normalizeIssueEdited() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("action", "edited");
+        assertEquals("issue-updated", GitHubEventNormalizer.normalizeEventType("issues", payload));
+    }
+
+    @Test
+    void normalizeIssueLabeled() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("action", "labeled");
+        assertEquals("issue-updated", GitHubEventNormalizer.normalizeEventType("issues", payload));
+    }
+
+    @Test
+    void normalizeIssueClosed() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("action", "closed");
+        assertEquals("issue-closed", GitHubEventNormalizer.normalizeEventType("issues", payload));
+    }
+
+    @Test
+    void normalizeIssueReopened() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("action", "reopened");
+        assertEquals("issue-reopened", GitHubEventNormalizer.normalizeEventType("issues", payload));
+    }
+
+    @Test
+    void normalizeIssueCommentCreated() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("action", "created");
+        assertEquals("comment-added", GitHubEventNormalizer.normalizeEventType("issue_comment", payload));
+    }
+
+    @Test
+    void normalizeIssueCommentEditedReturnsNull() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("action", "edited");
+        assertNull(GitHubEventNormalizer.normalizeEventType("issue_comment", payload));
+    }
+
+    @Test
+    void normalizeUnsupportedEventReturnsNull() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("action", "completed");
+        assertNull(GitHubEventNormalizer.normalizeEventType("workflow_run", payload));
+    }
+
+    @Test
+    void normalizeNullActionReturnsNull() {
+        ObjectNode payload = mapper.createObjectNode();
+        assertNull(GitHubEventNormalizer.normalizeEventType("issues", payload));
+    }
+
+    // ── Pull request events ──
+
+    @Test
+    void normalizePrOpened() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("action", "opened");
+        assertEquals("pr-created", GitHubEventNormalizer.normalizeEventType("pull_request", payload));
+    }
+
+    @Test
+    void normalizePrEdited() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("action", "edited");
+        assertEquals("pr-updated", GitHubEventNormalizer.normalizeEventType("pull_request", payload));
+    }
+
+    @Test
+    void normalizePrLabeled() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("action", "labeled");
+        assertEquals("pr-updated", GitHubEventNormalizer.normalizeEventType("pull_request", payload));
+    }
+
+    @Test
+    void normalizePrSynchronize() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("action", "synchronize");
+        assertEquals("pr-updated", GitHubEventNormalizer.normalizeEventType("pull_request", payload));
+    }
+
+    @Test
+    void normalizePrReviewRequested() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("action", "review_requested");
+        assertEquals("pr-updated", GitHubEventNormalizer.normalizeEventType("pull_request", payload));
+    }
+
+    @Test
+    void normalizePrReadyForReview() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("action", "ready_for_review");
+        assertEquals("pr-updated", GitHubEventNormalizer.normalizeEventType("pull_request", payload));
+    }
+
+    @Test
+    void normalizePrConvertedToDraft() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("action", "converted_to_draft");
+        assertEquals("pr-updated", GitHubEventNormalizer.normalizeEventType("pull_request", payload));
+    }
+
+    @Test
+    void normalizePrClosedNotMerged() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("action", "closed");
+        payload.putObject("pull_request").put("merged", false);
+        assertEquals("pr-closed", GitHubEventNormalizer.normalizeEventType("pull_request", payload));
+    }
+
+    @Test
+    void normalizePrClosedAndMerged() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("action", "closed");
+        payload.putObject("pull_request").put("merged", true);
+        assertEquals("pr-merged", GitHubEventNormalizer.normalizeEventType("pull_request", payload));
+    }
+
+    @Test
+    void normalizePrReopened() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("action", "reopened");
+        assertEquals("pr-reopened", GitHubEventNormalizer.normalizeEventType("pull_request", payload));
+    }
+
+    @Test
+    void normalizePrUnknownActionReturnsNull() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("action", "auto_merge_enabled");
+        assertNull(GitHubEventNormalizer.normalizeEventType("pull_request", payload));
+    }
+
+    @Test
+    void normalizePrNullActionReturnsNull() {
+        ObjectNode payload = mapper.createObjectNode();
+        assertNull(GitHubEventNormalizer.normalizeEventType("pull_request", payload));
+    }
+
+    // ── Pull request review comment events ──
+
+    @Test
+    void normalizePrReviewCommentCreated() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("action", "created");
+        assertEquals("pr-review-comment",
+                GitHubEventNormalizer.normalizeEventType("pull_request_review_comment", payload));
+    }
+
+    @Test
+    void normalizePrReviewCommentEditedReturnsNull() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("action", "edited");
+        assertNull(GitHubEventNormalizer.normalizeEventType("pull_request_review_comment", payload));
+    }
+
+    // ── extractIssueRef ──
+
+    @Test
+    void extractIssueRef() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.putObject("repository").put("full_name", "octocat/hello-world");
+        payload.putObject("issue").put("number", 7);
+        assertEquals("octocat/hello-world#7", GitHubEventNormalizer.extractIssueRef(payload));
+    }
+
+    @Test
+    void extractIssueRefMissingIssue() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.putObject("repository").put("full_name", "octocat/hello-world");
+        assertNull(GitHubEventNormalizer.extractIssueRef(payload));
+    }
+
+    // ── extractPrRef ──
+
+    @Test
+    void extractPrRef() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.putObject("repository").put("full_name", "octocat/hello-world");
+        payload.putObject("pull_request").put("number", 42);
+        assertEquals("octocat/hello-world#42", GitHubEventNormalizer.extractPrRef(payload));
+    }
+
+    @Test
+    void extractPrRefFallsBackToIssueRef() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.putObject("repository").put("full_name", "octocat/hello-world");
+        payload.putObject("issue").put("number", 7);
+        assertEquals("octocat/hello-world#7", GitHubEventNormalizer.extractPrRef(payload));
+    }
+
+    @Test
+    void extractPrRefMissingBothReturnsNull() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.putObject("repository").put("full_name", "octocat/hello-world");
+        assertNull(GitHubEventNormalizer.extractPrRef(payload));
+    }
+
+    // ── extractRepository ──
+
+    @Test
+    void extractRepository() {
+        ObjectNode payload = mapper.createObjectNode();
+        payload.putObject("repository").put("full_name", "octocat/hello-world");
+        assertEquals("octocat/hello-world", GitHubEventNormalizer.extractRepository(payload));
+    }
+
+    @Test
+    void extractRepositoryMissingReturnsNull() {
+        ObjectNode payload = mapper.createObjectNode();
+        assertNull(GitHubEventNormalizer.extractRepository(payload));
+    }
+}

--- a/events/github/src/test/java/io/apitomy/axiom/events/github/GitHubPollerPrEventTypeTest.java
+++ b/events/github/src/test/java/io/apitomy/axiom/events/github/GitHubPollerPrEventTypeTest.java
@@ -1,0 +1,111 @@
+package io.apitomy.axiom.events.github;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for PR event type determination logic in {@link GitHubPoller}.
+ */
+class GitHubPollerPrEventTypeTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final GitHubPoller poller = new GitHubPoller();
+
+    private final Instant since = Instant.parse("2025-06-01T00:00:00Z");
+    private static final String AFTER = "2025-06-02T00:00:00Z";
+    private static final String BEFORE = "2025-05-31T00:00:00Z";
+
+    @Test
+    void prCreatedAfterSince() {
+        ObjectNode pr = mapper.createObjectNode();
+        pr.put("state", "open");
+        pr.put("created_at", AFTER);
+        pr.put("updated_at", AFTER);
+        assertEquals("pr-created", poller.determinePrEventType(pr, since));
+    }
+
+    @Test
+    void prMerged() {
+        ObjectNode pr = mapper.createObjectNode();
+        pr.put("state", "closed");
+        pr.put("created_at", BEFORE);
+        pr.put("updated_at", AFTER);
+        pr.put("closed_at", AFTER);
+        pr.put("merged_at", AFTER);
+        assertEquals("pr-merged", poller.determinePrEventType(pr, since));
+    }
+
+    @Test
+    void prClosedNotMerged() {
+        ObjectNode pr = mapper.createObjectNode();
+        pr.put("state", "closed");
+        pr.put("created_at", BEFORE);
+        pr.put("updated_at", AFTER);
+        pr.put("closed_at", AFTER);
+        assertEquals("pr-closed", poller.determinePrEventType(pr, since));
+    }
+
+    @Test
+    void prReopened() {
+        ObjectNode pr = mapper.createObjectNode();
+        pr.put("state", "open");
+        pr.put("created_at", BEFORE);
+        pr.put("updated_at", AFTER);
+        pr.put("closed_at", BEFORE);
+        assertEquals("pr-reopened", poller.determinePrEventType(pr, since));
+    }
+
+    @Test
+    void prUpdated() {
+        ObjectNode pr = mapper.createObjectNode();
+        pr.put("state", "open");
+        pr.put("created_at", BEFORE);
+        pr.put("updated_at", AFTER);
+        assertEquals("pr-updated", poller.determinePrEventType(pr, since));
+    }
+
+    @Test
+    void prNotUpdatedSincePollReturnsNull() {
+        ObjectNode pr = mapper.createObjectNode();
+        pr.put("state", "open");
+        pr.put("created_at", BEFORE);
+        pr.put("updated_at", BEFORE);
+        assertNull(poller.determinePrEventType(pr, since));
+    }
+
+    @Test
+    void nullSinceReturnsNull() {
+        ObjectNode pr = mapper.createObjectNode();
+        pr.put("state", "open");
+        pr.put("created_at", AFTER);
+        pr.put("updated_at", AFTER);
+        assertNull(poller.determinePrEventType(pr, null));
+    }
+
+    @Test
+    void mergedTakesPriorityOverClosed() {
+        ObjectNode pr = mapper.createObjectNode();
+        pr.put("state", "closed");
+        pr.put("created_at", BEFORE);
+        pr.put("updated_at", AFTER);
+        pr.put("closed_at", AFTER);
+        pr.put("merged_at", AFTER);
+        assertEquals("pr-merged", poller.determinePrEventType(pr, since));
+    }
+
+    @Test
+    void createdTakesPriorityOverMerged() {
+        ObjectNode pr = mapper.createObjectNode();
+        pr.put("state", "closed");
+        pr.put("created_at", AFTER);
+        pr.put("updated_at", AFTER);
+        pr.put("closed_at", AFTER);
+        pr.put("merged_at", AFTER);
+        assertEquals("pr-created", poller.determinePrEventType(pr, since));
+    }
+}


### PR DESCRIPTION
## Summary

- Add PR lifecycle event polling via the GitHub Pulls API, generating `pr-created`,
  `pr-updated`, `pr-closed`, `pr-merged`, and `pr-reopened` events alongside existing
  issue and comment events
- Add PR review comment polling via the GitHub Pull Review Comments API, generating
  `pr-review-comment` events
- Extend `GitHubEventNormalizer` to handle `pull_request` and
  `pull_request_review_comment` webhook event types with proper merged-vs-closed
  distinction
- Add unit tests for both the normalizer and the poller's PR event type determination
  logic

## Related Issue

Fixes #19

## Test Plan

- [ ] Run `mvn test -pl events/github` to verify all new unit tests pass
- [ ] Run `mvn compile -pl events/github` to verify compilation
- [ ] Configure a GitHub event source and verify PR events appear in poll logs
- [ ] Open, close, merge, and reopen PRs on a monitored repo to test each event type
- [ ] Verify existing issue and comment event processing is unaffected
- [ ] Verify graceful degradation when Pulls API returns an error (issues and comments
      should still be processed)