### PR TITLE
Add GitHub/Jira source icons to Projects pages and remove redundant columns

### DIFF
--- a/ui/src/pages/ProjectDetailPage.tsx
+++ b/ui/src/pages/ProjectDetailPage.tsx
@@ -40,6 +40,8 @@ import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import PlayIcon from "@patternfly/react-icons/dist/esm/icons/play-icon";
 import SyncAltIcon from "@patternfly/react-icons/dist/esm/icons/sync-alt-icon";
 import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
+import GithubIcon from "@patternfly/react-icons/dist/esm/icons/github-icon";
+import JiraIcon from "@patternfly/react-icons/dist/esm/icons/jira-icon";
 import {
     type ActionType,
     type AxiomEvent,
@@ -198,6 +200,8 @@ export function ProjectDetailPage() {
             >
                 <FlexItem>
                     <Title headingLevel="h1" size="lg">
+                        {project.issueSource === "github" && <GithubIcon style={{ marginRight: 8 }} />}
+                        {project.issueSource === "jira" && <JiraIcon style={{ marginRight: 8 }} />}
                         {project.name}
                     </Title>
                 </FlexItem>

--- a/ui/src/pages/ProjectsPage.tsx
+++ b/ui/src/pages/ProjectsPage.tsx
@@ -26,6 +26,8 @@ import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import PlusCircleIcon from "@patternfly/react-icons/dist/esm/icons/plus-circle-icon";
 import SyncAltIcon from "@patternfly/react-icons/dist/esm/icons/sync-alt-icon";
 import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
+import GithubIcon from "@patternfly/react-icons/dist/esm/icons/github-icon";
+import JiraIcon from "@patternfly/react-icons/dist/esm/icons/jira-icon";
 import {
     type ChipFilterCriteria,
     type ChipFilterType,
@@ -243,9 +245,7 @@ export function ProjectsPage() {
                             <Tr>
                                 <Th>Name</Th>
                                 <Th>Status</Th>
-                                <Th>Type</Th>
                                 <Th>Issue</Th>
-                                <Th>Repository</Th>
                                 <Th>Labels</Th>
                                 <Th>Updated</Th>
                                 <Th />
@@ -258,17 +258,17 @@ export function ProjectsPage() {
                                     isClickable
                                     onRowClick={() => navigate(`/projects/${project.id}`)}
                                 >
-                                    <Td>{project.name}</Td>
+                                    <Td>
+                                        {project.issueSource === "github" && <GithubIcon style={{ marginRight: 6 }} />}
+                                        {project.issueSource === "jira" && <JiraIcon style={{ marginRight: 6 }} />}
+                                        {project.name}
+                                    </Td>
                                     <Td>
                                         <Label isCompact={true} color={STATUS_COLORS[project.status] || "grey"}>
                                             {STATUS_LABELS[project.status] || project.status}
                                         </Label>
                                     </Td>
-                                    <Td>
-                                        <Label isCompact>{project.type}</Label>
-                                    </Td>
                                     <Td>{project.issueRef}</Td>
-                                    <Td>{project.repository}</Td>
                                     <Td>
                                         {project.labels?.map((label) => (
                                             <Label key={label} isCompact color="purple"


### PR DESCRIPTION
## Summary

- Add GitHub and Jira icons (from PatternFly) next to project names on both the
  Projects list page and the Project detail page, based on the project's `issueSource`
  field
- Remove the Repository column from the Projects table (redundant with the Issue column)
- Remove the Type column from the Projects table (always shows "other" for
  auto-created projects)

## Test Plan

- [ ] Verify GitHub icon appears next to project names on the Projects list page
- [ ] Verify GitHub icon appears in the title on the Project detail page
- [ ] Verify Jira icon would appear for projects with `issueSource: "jira"`
- [ ] Verify the Repository and Type columns are no longer shown in the Projects table
- [ ] Verify no regressions in project row click navigation or delete functionality