### PR TITLE
Fix Create Report Definition modal failing due to empty promptTemplate (#20)

### DIFF
--- a/ui/src/pages/ReportDefinitionsPage.tsx
+++ b/ui/src/pages/ReportDefinitionsPage.tsx
@@ -65,7 +65,7 @@ export function ReportDefinitionsPage() {
             name: newName,
             schedule: newSchedule,
             timeWindow: "last-24h",
-            promptTemplate: "",
+            promptTemplate: "Summarize recent activity across all repositories.",
             enabled: false,
         })
             .then((def) => {


### PR DESCRIPTION
## Summary

- Send a default prompt template instead of an empty string when creating a new report definition
- The empty `promptTemplate` was rejected by backend validation (`ReportDefinitionValidator`), causing a 422 error

## Related Issue

Fixes #20

## Test Plan

- [ ] Open the Report Definitions page
- [ ] Click "Create" to open the modal, enter a name and schedule, then click Create
- [ ] Verify the report definition is created successfully (no 422 error)
- [ ] Verify you are navigated to the new report definition's detail page
- [ ] Verify the default prompt template text appears on the detail page