### PR TITLE
Add optional title template field to report definitions (#25)

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/ReportExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ReportExecutionService.java
@@ -170,10 +170,16 @@ public class ReportExecutionService {
         ReportEntity report = ReportEntity.findById(reportId);
         if (report == null) return;
 
+        ReportDefinitionEntity def = ReportDefinitionEntity.findById(definitionId);
+
         if (result.success()) {
             report.status = "Completed";
             report.content = result.result();
-            report.title = extractTitle(result.result());
+            if (def != null && def.titleTemplate != null && !def.titleTemplate.isBlank()) {
+                report.title = resolveTitleTemplate(def.titleTemplate, def);
+            } else {
+                report.title = extractTitle(result.result());
+            }
         } else {
             report.status = "Failed";
             report.content = "Report generation failed: " + result.result();
@@ -198,7 +204,6 @@ public class ReportExecutionService {
         usage.persist();
 
         // Log activity
-        ReportDefinitionEntity def = ReportDefinitionEntity.findById(definitionId);
         String defName = def != null ? def.name : "Report #" + reportId;
         String statusText = result.success() ? "completed" : "failed";
         String summary = "Report " + statusText + ": " + defName;
@@ -301,6 +306,28 @@ public class ReportExecutionService {
             }
         }
         return "Report";
+    }
+
+    /**
+     * Resolves a title template by replacing placeholders with actual values.
+     *
+     * @param template the title template string
+     * @param def the report definition entity
+     * @return the resolved title string
+     */
+    private String resolveTitleTemplate(String template, ReportDefinitionEntity def) {
+        java.time.LocalDateTime now = java.time.LocalDateTime.now(ZoneId.systemDefault());
+        String date = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        String time = now.format(DateTimeFormatter.ofPattern("HH:mm"));
+        String datetime = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+
+        return template
+                .replace("{{name}}", def.name != null ? def.name : "")
+                .replace("{{date}}", date)
+                .replace("{{time}}", time)
+                .replace("{{datetime}}", datetime)
+                .replace("{{timeWindow}}", def.timeWindow != null ? def.timeWindow : "")
+                .replace("{{schedule}}", def.schedule != null ? def.schedule : "");
     }
 
     private Map<String, String> buildEnvironment(String customEnvironmentJson) {

--- a/app/src/main/java/io/apitomy/axiom/app/rest/ReportsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/ReportsResourceImpl.java
@@ -341,6 +341,7 @@ public class ReportsResourceImpl implements ReportsResource {
         entity.scheduleDayOfWeek = data.getScheduleDayOfWeek();
         entity.timeWindow = data.getTimeWindow();
         entity.promptTemplate = data.getPromptTemplate();
+        entity.titleTemplate = data.getTitleTemplate();
         entity.allowedTools = data.getAllowedTools() != null
                 ? String.join(",", data.getAllowedTools()) : null;
         entity.enabled = "none".equals(data.getSchedule()) ? false
@@ -370,6 +371,7 @@ public class ReportsResourceImpl implements ReportsResource {
         def.setScheduleDayOfWeek(entity.scheduleDayOfWeek);
         def.setTimeWindow(entity.timeWindow);
         def.setPromptTemplate(entity.promptTemplate);
+        def.setTitleTemplate(entity.titleTemplate);
         if (entity.allowedTools != null && !entity.allowedTools.isBlank()) {
             def.setAllowedTools(java.util.Arrays.stream(entity.allowedTools.split(","))
                     .map(String::trim).filter(s -> !s.isEmpty()).toList());

--- a/app/src/main/resources/db/migration/V21__add_title_template_to_report_definition.sql
+++ b/app/src/main/resources/db/migration/V21__add_title_template_to_report_definition.sql
@@ -1,0 +1,1 @@
+ALTER TABLE report_definition ADD COLUMN IF NOT EXISTS title_template TEXT;

--- a/app/src/test/java/io/apitomy/axiom/core/services/ReportDefinitionValidatorTest.java
+++ b/app/src/test/java/io/apitomy/axiom/core/services/ReportDefinitionValidatorTest.java
@@ -289,6 +289,69 @@ class ReportDefinitionValidatorTest {
                 .count());
     }
 
+    // ── Title template validation ─────────────────────────────────────
+
+    @Test
+    void nullTitleTemplateNoMessages() {
+        NewReportDefinition def = makeDef("test", "desc", "daily", "last-24h", "prompt {{repositories}}");
+
+        ValidationResult result = ReportDefinitionValidator.validate(def);
+
+        assertFalse(result.messages().stream().anyMatch(m -> m.field().equals("titleTemplate")));
+    }
+
+    @Test
+    void blankTitleTemplateNoMessages() {
+        NewReportDefinition def = makeDef("test", "desc", "daily", "last-24h", "prompt {{repositories}}");
+        def.setTitleTemplate("   ");
+
+        ValidationResult result = ReportDefinitionValidator.validate(def);
+
+        assertFalse(result.messages().stream().anyMatch(m -> m.field().equals("titleTemplate")));
+    }
+
+    @Test
+    void titleTemplateWithRecognizedPlaceholdersIsValid() {
+        NewReportDefinition def = makeDef("test", "desc", "daily", "last-24h", "prompt {{repositories}}");
+        def.setTitleTemplate("{{name}} — {{date}}");
+
+        ValidationResult result = ReportDefinitionValidator.validate(def);
+
+        assertFalse(result.errors().stream().anyMatch(m -> m.field().equals("titleTemplate")));
+    }
+
+    @Test
+    void titleTemplateWithAllPlaceholdersIsValid() {
+        NewReportDefinition def = makeDef("test", "desc", "daily", "last-24h", "prompt {{repositories}}");
+        def.setTitleTemplate("{{name}} {{date}} {{time}} {{datetime}} {{timeWindow}} {{schedule}}");
+
+        ValidationResult result = ReportDefinitionValidator.validate(def);
+
+        assertFalse(result.errors().stream().anyMatch(m -> m.field().equals("titleTemplate")));
+    }
+
+    @Test
+    void titleTemplateWithUnrecognizedPlaceholderIsError() {
+        NewReportDefinition def = makeDef("test", "desc", "daily", "last-24h", "prompt {{repositories}}");
+        def.setTitleTemplate("{{name}} — {{foo}}");
+
+        ValidationResult result = ReportDefinitionValidator.validate(def);
+
+        assertTrue(result.hasErrors());
+        assertTrue(result.errors().stream().anyMatch(
+                m -> m.field().equals("titleTemplate") && m.message().contains("{{foo}}")));
+    }
+
+    @Test
+    void titleTemplateWithPlainTextIsValid() {
+        NewReportDefinition def = makeDef("test", "desc", "daily", "last-24h", "prompt {{repositories}}");
+        def.setTitleTemplate("My Custom Report Title");
+
+        ValidationResult result = ReportDefinitionValidator.validate(def);
+
+        assertFalse(result.errors().stream().anyMatch(m -> m.field().equals("titleTemplate")));
+    }
+
     // ── Timeout validation ──────────────────────────────────────────
 
     @Test

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -4128,6 +4128,10 @@
             "items": {
               "type": "string"
             }
+          },
+          "titleTemplate": {
+            "description": "Optional template for the report title. Supports placeholders: {{name}}, {{date}}, {{time}}, {{datetime}}, {{timeWindow}}, {{schedule}}. When set, the resolved template is used as the report title instead of extracting the first H1 heading from the generated markdown.",
+            "type": "string"
           }
         }
       },
@@ -4188,6 +4192,10 @@
             "items": {
               "type": "string"
             }
+          },
+          "titleTemplate": {
+            "description": "Optional template for the report title. Supports placeholders: {{name}}, {{date}}, {{time}}, {{datetime}}, {{timeWindow}}, {{schedule}}. When set, the resolved template is used as the report title instead of extracting the first H1 heading from the generated markdown.",
+            "type": "string"
           }
         }
       },

--- a/core/src/main/java/io/apitomy/axiom/core/entities/ReportDefinitionEntity.java
+++ b/core/src/main/java/io/apitomy/axiom/core/entities/ReportDefinitionEntity.java
@@ -59,6 +59,14 @@ public class ReportDefinitionEntity extends PanacheEntity {
     public String promptTemplate;
 
     /**
+     * Optional template for the report title. Supports placeholders:
+     * {{name}}, {{date}}, {{time}}, {{datetime}}, {{timeWindow}}, {{schedule}}.
+     * When set, the resolved template is used instead of extracting from markdown.
+     */
+    @Column(name = "title_template", columnDefinition = "TEXT")
+    public String titleTemplate;
+
+    /**
      * Comma-separated list of tools the AI agent is allowed to use.
      */
     @Column(name = "allowed_tools", columnDefinition = "TEXT")

--- a/core/src/main/java/io/apitomy/axiom/core/services/ReportDefinitionValidator.java
+++ b/core/src/main/java/io/apitomy/axiom/core/services/ReportDefinitionValidator.java
@@ -37,6 +37,8 @@ public final class ReportDefinitionValidator {
             Pattern.compile("\\{\\{([a-zA-Z_][a-zA-Z0-9_]*)\\}\\}");
     private static final Set<String> RECOGNIZED_PLACEHOLDERS = Set.of(
             "repositories", "timeRangeStart", "timeRangeEnd", "timeWindow");
+    private static final Set<String> RECOGNIZED_TITLE_PLACEHOLDERS = Set.of(
+            "name", "date", "time", "datetime", "timeWindow", "schedule");
 
     private ReportDefinitionValidator() {
     }
@@ -82,6 +84,7 @@ public final class ReportDefinitionValidator {
         validateSchedule(def, messages);
         validateTimeWindow(def, messages);
         validatePromptTemplate(def, messages);
+        validateTitleTemplate(def, messages);
         validateTimeoutSeconds(def, messages);
         validateInitialLabels(def, messages);
         validateAllowedTools(def, known, messages);
@@ -182,6 +185,25 @@ public final class ReportDefinitionValidator {
                         "Unrecognized placeholder '{{" + name + "}}'. "
                                 + "Supported placeholders are: {{repositories}}, "
                                 + "{{timeRangeStart}}, {{timeRangeEnd}}, {{timeWindow}}."));
+            }
+        }
+    }
+
+    private static void validateTitleTemplate(NewReportDefinition def,
+                                               List<ValidationMessage> messages) {
+        String template = def.getTitleTemplate();
+        if (template == null || template.isBlank()) {
+            return;
+        }
+
+        Matcher matcher = PLACEHOLDER_PATTERN.matcher(template);
+        while (matcher.find()) {
+            String name = matcher.group(1);
+            if (!RECOGNIZED_TITLE_PLACEHOLDERS.contains(name)) {
+                messages.add(error("titleTemplate",
+                        "Unrecognized placeholder '{{" + name + "}}'. "
+                                + "Supported placeholders are: {{name}}, {{date}}, "
+                                + "{{time}}, {{datetime}}, {{timeWindow}}, {{schedule}}."));
             }
         }
     }

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -851,6 +851,7 @@ export interface ReportDefinition {
     scheduleDayOfWeek?: string;
     timeWindow: string;
     promptTemplate: string;
+    titleTemplate?: string;
     allowedTools?: string[];
     enabled: boolean;
     timeoutSeconds?: number;

--- a/ui/src/pages/ReportDefinitionDetailPage.tsx
+++ b/ui/src/pages/ReportDefinitionDetailPage.tsx
@@ -97,6 +97,7 @@ export function ReportDefinitionDetailPage() {
                     timeWindow: def.timeWindow,
                     promptTemplate: def.promptTemplate, enabled: def.enabled,
                     timeoutSeconds: def.timeoutSeconds,
+                    titleTemplate: def.titleTemplate,
                 });
                 setTools(def.allowedTools || []);
                 setInitialLabels(def.initialLabels || []);
@@ -364,6 +365,18 @@ function InfoTab({ form, updateForm, initialLabels, onLabelsChange }: {
             <FormGroup label="Name" isRequired fieldId="name">
                 <TextInput id="name" isRequired value={form.name}
                     onChange={(_e, v) => updateForm({ name: v })} />
+            </FormGroup>
+            <FormGroup label="Title Template" fieldId="titleTemplate">
+                <TextInput id="titleTemplate" value={form.titleTemplate || ""}
+                    onChange={(_e, v) => updateForm({ titleTemplate: v || undefined })}
+                    placeholder="e.g. {{name}} — {{date}}" />
+                <p style={{ color: "#6a6e73", fontSize: "0.85em", marginTop: "4px" }}>
+                    Optional. If set, the report title uses this template instead of
+                    extracting from markdown. Placeholders:{" "}
+                    <code>{"{{name}}"}</code>, <code>{"{{date}}"}</code>,{" "}
+                    <code>{"{{time}}"}</code>, <code>{"{{datetime}}"}</code>,{" "}
+                    <code>{"{{timeWindow}}"}</code>, <code>{"{{schedule}}"}</code>
+                </p>
             </FormGroup>
             <FormGroup label="Description" fieldId="description">
                 <TextArea id="description" value={form.description || ""}


### PR DESCRIPTION
## Summary

- Add an optional `titleTemplate` field to report definitions, allowing users to control report
  titles via a template with placeholders (`{{name}}`, `{{date}}`, `{{time}}`, `{{datetime}}`,
  `{{timeWindow}}`, `{{schedule}}`)
- When set, the resolved template is used as the report title instead of extracting the first H1
  heading from AI-generated markdown; when empty, existing behavior is preserved
- Full-stack implementation: OpenAPI spec, DB migration (V21), JPA entity, validator with tests,
  REST layer, execution service, TypeScript types, and UI detail page

## Related Issue

Fixes #25

## Test Plan

- [ ] Build `common/api` to regenerate beans, then build the full project
- [ ] Run `ReportDefinitionValidatorTest` — 6 new test cases for titleTemplate validation
- [ ] Create a report definition, set a title template (e.g. `{{name}} — {{date}}`), run the
      report, and verify the title matches the resolved template
- [ ] Leave titleTemplate empty on a report definition, run a report, and verify the title is
      extracted from the markdown H1 heading as before
- [ ] Verify unrecognized placeholders produce validation errors in the UI