### PR TITLE
Color-code labels based on text value (#27)

### DIFF
--- a/ui/src/components/ColoredLabel.tsx
+++ b/ui/src/components/ColoredLabel.tsx
@@ -1,0 +1,27 @@
+import { Label, type LabelProps } from "@patternfly/react-core";
+
+const LABEL_COLORS: LabelProps["color"][] = [
+    "blue", "teal", "green", "orange", "purple",
+    "red", "orangered", "grey", "yellow",
+];
+
+/**
+ * Deterministically maps a label string to a PatternFly label color
+ * so that the same text always produces the same color.
+ */
+export function labelColor(text: string): LabelProps["color"] {
+    let hash = 0;
+    for (let i = 0; i < text.length; i++) {
+        hash = (hash * 31 + text.charCodeAt(i)) | 0;
+    }
+    return LABEL_COLORS[Math.abs(hash) % LABEL_COLORS.length];
+}
+
+/**
+ * A PatternFly Label whose color is automatically determined by
+ * its text content. Accepts all standard Label props except `color`.
+ */
+export function ColoredLabel({ children, ...rest }: Omit<LabelProps, "color">) {
+    const text = typeof children === "string" ? children : String(children);
+    return <Label color={labelColor(text)} {...rest}>{children}</Label>;
+}

--- a/ui/src/components/LabelDisplay.tsx
+++ b/ui/src/components/LabelDisplay.tsx
@@ -1,5 +1,6 @@
-import { Button, Label } from "@patternfly/react-core";
+import { Button } from "@patternfly/react-core";
 import PencilAltIcon from "@patternfly/react-icons/dist/esm/icons/pencil-alt-icon";
+import { ColoredLabel } from "./ColoredLabel";
 
 /**
  * Read-only display of labels as blue chips with a pencil icon
@@ -14,7 +15,7 @@ export function LabelDisplay({ labels, onEdit }: {
             {labels.length > 0 ? (
                 <div style={{ display: "flex", flexWrap: "wrap", gap: "4px" }}>
                     {labels.map((label) => (
-                        <Label key={label} isCompact color="purple">{label}</Label>
+                        <ColoredLabel key={label} isCompact>{label}</ColoredLabel>
                     ))}
                 </div>
             ) : (

--- a/ui/src/components/LabelDisplay.tsx
+++ b/ui/src/components/LabelDisplay.tsx
@@ -3,7 +3,7 @@ import PencilAltIcon from "@patternfly/react-icons/dist/esm/icons/pencil-alt-ico
 import { ColoredLabel } from "./ColoredLabel";
 
 /**
- * Read-only display of labels as blue chips with a pencil icon
+ * Read-only display of labels as colored chips with a pencil icon
  * button to trigger editing. Shows "No labels" in italic when empty.
  */
 export function LabelDisplay({ labels, onEdit }: {

--- a/ui/src/components/LabelInput.tsx
+++ b/ui/src/components/LabelInput.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
-import { HelperText, HelperTextItem, Label, TextInput } from "@patternfly/react-core";
+import { HelperText, HelperTextItem, TextInput } from "@patternfly/react-core";
+import { ColoredLabel } from "./ColoredLabel";
 
 /**
  * Editable label list. Type a label and press Enter to add it.
@@ -38,11 +39,11 @@ export function LabelInput({ labels, onChange }: {
             {labels.length > 0 && (
                 <div style={{ display: "flex", flexWrap: "wrap", gap: "4px", marginBottom: "8px" }}>
                     {labels.map((label) => (
-                        <Label key={label} color="purple"
+                        <ColoredLabel key={label}
                             onClose={() => handleRemove(label)}
                             closeBtnAriaLabel={`Remove ${label}`}>
                             {label}
-                        </Label>
+                        </ColoredLabel>
                     ))}
                 </div>
             )}

--- a/ui/src/pages/ProjectsPage.tsx
+++ b/ui/src/pages/ProjectsPage.tsx
@@ -26,6 +26,7 @@ import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import PlusCircleIcon from "@patternfly/react-icons/dist/esm/icons/plus-circle-icon";
 import SyncAltIcon from "@patternfly/react-icons/dist/esm/icons/sync-alt-icon";
 import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
+import { ColoredLabel } from "../components/ColoredLabel";
 import GithubIcon from "@patternfly/react-icons/dist/esm/icons/github-icon";
 import JiraIcon from "@patternfly/react-icons/dist/esm/icons/jira-icon";
 import {
@@ -271,14 +272,14 @@ export function ProjectsPage() {
                                     <Td>{project.issueRef}</Td>
                                     <Td>
                                         {project.labels?.map((label) => (
-                                            <Label key={label} isCompact color="purple"
+                                            <ColoredLabel key={label} isCompact
                                                 style={{ marginRight: "4px", cursor: "pointer" }}
                                                 onClick={(e) => {
                                                     e.stopPropagation();
                                                     addLabelFilter(label);
                                                 }}>
                                                 {label}
-                                            </Label>
+                                            </ColoredLabel>
                                         ))}
                                     </Td>
                                     <Td>{new Date(project.updatedOn).toLocaleString()}</Td>

--- a/ui/src/pages/ReportsPage.tsx
+++ b/ui/src/pages/ReportsPage.tsx
@@ -21,6 +21,7 @@ import {
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import SyncAltIcon from "@patternfly/react-icons/dist/esm/icons/sync-alt-icon";
 import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
+import { ColoredLabel } from "../components/ColoredLabel";
 import {
     type ChipFilterCriteria,
     type ChipFilterType,
@@ -231,7 +232,7 @@ export function ReportsPage() {
                                     </Td>
                                     <Td>
                                         {(report.labels || []).map((label) => (
-                                            <Label key={label} isCompact color="purple"
+                                            <ColoredLabel key={label} isCompact
                                                 style={{ marginRight: "4px", cursor: "pointer" }}
                                                 onClick={(e) => {
                                                     e.stopPropagation();
@@ -244,7 +245,7 @@ export function ReportsPage() {
                                                     }
                                                 }}>
                                                 {label}
-                                            </Label>
+                                            </ColoredLabel>
                                         ))}
                                     </Td>
                                     <Td style={{ whiteSpace: "nowrap" }}>

--- a/ui/src/pages/ToolsPage.tsx
+++ b/ui/src/pages/ToolsPage.tsx
@@ -8,7 +8,6 @@ import {
     FlexItem,
     Form,
     FormGroup,
-    Label,
     Modal,
     ModalBody,
     ModalFooter,
@@ -25,6 +24,7 @@ import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import PlusCircleIcon from "@patternfly/react-icons/dist/esm/icons/plus-circle-icon";
 import SyncAltIcon from "@patternfly/react-icons/dist/esm/icons/sync-alt-icon";
 import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
+import { ColoredLabel } from "../components/ColoredLabel";
 import {
     type ChipFilterCriteria,
     type ChipFilterType,
@@ -220,14 +220,14 @@ export function ToolsPage() {
                                         <Td>{tool.description || "—"}</Td>
                                         <Td>
                                             {tool.labels?.map((label) => (
-                                                <Label key={label} isCompact color="purple"
+                                                <ColoredLabel key={label} isCompact
                                                     style={{ marginRight: "4px", cursor: "pointer" }}
                                                     onClick={(e) => {
                                                         e.stopPropagation();
                                                         addLabelFilter(label);
                                                     }}>
                                                     {label}
-                                                </Label>
+                                                </ColoredLabel>
                                             ))}
                                         </Td>
                                         <Td>


### PR DESCRIPTION
## Summary

- Add a new `ColoredLabel` component that wraps PatternFly's `Label` and deterministically
  assigns a color based on the label text using a hash function
- Replace all user-defined label rendering (5 files) with `ColoredLabel`, distributing labels
  across all 9 PatternFly colors instead of always purple
- Status/type labels with intentional semantic colors are unchanged

## Related Issue

Fixes #27

## Test Plan

- [ ] Navigate to Reports, Tools, and Projects list pages — labels should display in varied colors
- [ ] Verify the same label text always renders in the same color across pages
- [ ] Verify label click-to-filter still works on list pages
- [ ] Open a detail page (Report, Tool, or Project) and verify label editing (add/remove) works
- [ ] Confirm status labels (e.g. Completed, Failed) retain their original semantic colors