### PR TITLE
Change dev mode ports from 8080/8888 to 9090/9191 (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ dev server side by side:
 ./dev.sh
 ```
 
-- Backend starts on **http://localhost:8080**
-- UI starts on **http://localhost:8888** (proxies API requests to the backend)
+- Backend starts on **http://localhost:9090**
+- UI starts on **http://localhost:9191** (proxies API requests to the backend)
 - Both run in the foreground — **Ctrl+C** stops everything
 
 To run the backend only (no UI):

--- a/agentdocs/architecture-v2.md
+++ b/agentdocs/architecture-v2.md
@@ -629,7 +629,7 @@ services:
   axiom-api:
     build: .
     ports:
-      - "8080:8080"
+      - "9090:9090"
     environment:
       QUARKUS_PROFILE: prod
       QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://axiom-db:5432/axiom
@@ -655,9 +655,9 @@ services:
   axiom-ui:
     build: ./ui
     ports:
-      - "8888:8080"
+      - "9191:9090"
     environment:
-      AXIOM_API_URL: http://localhost:8080
+      AXIOM_API_URL: http://localhost:9090
 
 volumes:
   axiom-pgdata:

--- a/agentdocs/implementation-plan.md
+++ b/agentdocs/implementation-plan.md
@@ -58,7 +58,7 @@ empty UI shell.
 
 ### Done When
 - `mvn clean install` succeeds from the root
-- `mvn quarkus:dev` in `app/` starts the backend on port 8080
+- `mvn quarkus:dev` in `app/` starts the backend on port 9090
 - `npm run dev` in `ui/` starts the frontend with PatternFly navigation
 - The UI can call the backend health endpoint and display the result
 

--- a/app/src/main/java/io/apitomy/axiom/app/McpConfigGenerator.java
+++ b/app/src/main/java/io/apitomy/axiom/app/McpConfigGenerator.java
@@ -53,7 +53,7 @@ public class McpConfigGenerator {
     private static final String[] TEMPLATE_FILES = {
             "package.json", "sdk-server.js", "tools-server.js" };
 
-    @ConfigProperty(name = "quarkus.http.port", defaultValue = "8080")
+    @ConfigProperty(name = "quarkus.http.port", defaultValue = "9090")
     int httpPort;
 
     @Inject

--- a/app/src/main/java/io/apitomy/axiom/app/ScriptAiService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ScriptAiService.java
@@ -54,7 +54,7 @@ public class ScriptAiService {
             - {{repository}} — the repository name (e.g. "owner/repo")
             - {{projectName}} — the project name
             - {{managerInput}} — context/instructions from the Manager
-            - {{apiBaseUrl}} — the Axiom REST API base URL (e.g. "http://localhost:8080/api/v1")
+            - {{apiBaseUrl}} — the Axiom REST API base URL (e.g. "http://localhost:9090/api/v1")
 
             Environment variables are also available:
             - AXIOM_API_URL — same as {{apiBaseUrl}}

--- a/app/src/main/java/io/apitomy/axiom/app/ScriptExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ScriptExecutionService.java
@@ -43,7 +43,7 @@ public class ScriptExecutionService {
     @Inject
     EnvironmentResolver environmentResolver;
 
-    @ConfigProperty(name = "quarkus.http.port", defaultValue = "8080")
+    @ConfigProperty(name = "quarkus.http.port", defaultValue = "9090")
     int httpPort;
 
     @ConfigProperty(name = "axiom.script.timeout-seconds", defaultValue = "60")

--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantContextBuilder.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantContextBuilder.java
@@ -18,7 +18,7 @@ public class AssistantContextBuilder {
 
     private static final Logger LOG = Logger.getLogger(AssistantContextBuilder.class);
 
-    @ConfigProperty(name = "quarkus.http.port", defaultValue = "8080")
+    @ConfigProperty(name = "quarkus.http.port", defaultValue = "9090")
     int httpPort;
 
     /**

--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSessionManager.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSessionManager.java
@@ -51,7 +51,7 @@ public class AssistantSessionManager {
     @ConfigProperty(name = "axiom.claude-code.executable", defaultValue = "claude")
     String claudeExecutable;
 
-    @ConfigProperty(name = "quarkus.http.port", defaultValue = "8080")
+    @ConfigProperty(name = "quarkus.http.port", defaultValue = "9090")
     int httpPort;
 
     @Inject

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -3,7 +3,7 @@
 # =============================================================================
 
 # --- HTTP ---
-quarkus.http.port=8080
+quarkus.http.port=9090
 %prod.quarkus.http.port=9191
 quarkus.http.cors.origins=/.*/
 

--- a/app/src/main/resources/templates/axiom-assistant-mcp/server.js
+++ b/app/src/main/resources/templates/axiom-assistant-mcp/server.js
@@ -13,7 +13,7 @@ function log(level, message, data) {
     process.stderr.write(JSON.stringify(entry) + "\n");
 }
 
-const AXIOM_API_URL = process.env.AXIOM_API_URL || "http://localhost:8080/api/v1";
+const AXIOM_API_URL = process.env.AXIOM_API_URL || "http://localhost:9090/api/v1";
 
 async function axiomApi(method, path) {
     const url = `${AXIOM_API_URL}${path}`;

--- a/app/src/main/resources/templates/axiom-mcp-server/sdk-server.js
+++ b/app/src/main/resources/templates/axiom-mcp-server/sdk-server.js
@@ -13,7 +13,7 @@ function log(level, message, data) {
     process.stderr.write(JSON.stringify(entry) + "\n");
 }
 
-const AXIOM_API_URL = process.env.AXIOM_API_URL || "http://localhost:8080/api/v1";
+const AXIOM_API_URL = process.env.AXIOM_API_URL || "http://localhost:9090/api/v1";
 
 async function axiomApi(method, path, body) {
     const url = `${AXIOM_API_URL}${path}`;

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -11,7 +11,7 @@
   },
   "servers": [
     {
-      "url": "http://localhost:8080",
+      "url": "http://localhost:9090",
       "description": "Local development server"
     }
   ],

--- a/dev.sh
+++ b/dev.sh
@@ -2,8 +2,8 @@
 #
 # Starts Apitomy Axiom in development mode.
 #
-# Launches the Quarkus backend (port 8080) and the Vite UI dev server
-# (port 8888) side by side. Both run in the foreground — Ctrl+C stops
+# Launches the Quarkus backend (port 9090) and the Vite UI dev server
+# (port 9191) side by side. Both run in the foreground — Ctrl+C stops
 # everything.
 #
 # Prerequisites:
@@ -21,7 +21,7 @@
 #   ./dev.sh --skip-ui    # start backend only (Quarkus dev mode)
 #   ./dev.sh --persist    # enable persistent storage (H2 file-based DB)
 #
-# Open http://localhost:8888 in your browser.
+# Open http://localhost:9191 in your browser.
 #
 
 set -euo pipefail
@@ -115,9 +115,9 @@ trap cleanup EXIT INT TERM
 QUARKUS_ARGS=(-pl app -Ddebug=false -q)
 if [[ "$PERSIST" == true ]]; then
     QUARKUS_ARGS+=(-Dquarkus.profile=persist)
-    echo "Starting Quarkus backend on http://localhost:8080 (persistence enabled) ..."
+    echo "Starting Quarkus backend on http://localhost:9090 (persistence enabled) ..."
 else
-    echo "Starting Quarkus backend on http://localhost:8080 ..."
+    echo "Starting Quarkus backend on http://localhost:9090 ..."
 fi
 mvn quarkus:dev "${QUARKUS_ARGS[@]}" &
 PIDS+=($!)
@@ -125,7 +125,7 @@ PIDS+=($!)
 # ── Start Vite dev server ─────────────────────────────────────────
 
 if [[ "$SKIP_UI" == false ]]; then
-    echo "Starting Vite UI on http://localhost:8888 ..."
+    echo "Starting Vite UI on http://localhost:9191 ..."
     (cd ui && npm run dev) &
     PIDS+=($!)
 fi
@@ -133,9 +133,9 @@ fi
 echo ""
 echo "============================================"
 if [[ "$SKIP_UI" == false ]]; then
-    echo "  UI:      http://localhost:8888"
+    echo "  UI:      http://localhost:9191"
 fi
-echo "  API:     http://localhost:8080/api/v1"
+echo "  API:     http://localhost:9090/api/v1"
 echo "  Ctrl+C to stop"
 echo "============================================"
 echo ""

--- a/docs/developer-guide/api-first-development.md
+++ b/docs/developer-guide/api-first-development.md
@@ -127,7 +127,7 @@ The API base URL is resolved differently in development and production:
 
 | Mode | Base URL | Mechanism |
 |------|----------|-----------|
-| Development | (empty string) | Vite proxy forwards `/api` to `localhost:8080` |
+| Development | (empty string) | Vite proxy forwards `/api` to `localhost:9090` |
 | Production | From `window.AXIOM_API_URL` | Injected by the backend at runtime |
 
 This is handled by `getApiBaseUrl()` in `api.ts`.

--- a/docs/developer-guide/building-axiom.md
+++ b/docs/developer-guide/building-axiom.md
@@ -69,11 +69,11 @@ Starts the Quarkus backend (with hot reload) and the Vite UI dev server side by 
 
 | Service | URL |
 |---------|-----|
-| Backend (Quarkus dev mode) | http://localhost:8080 |
-| Frontend (Vite dev server) | http://localhost:8888 |
+| Backend (Quarkus dev mode) | http://localhost:9090 |
+| Frontend (Vite dev server) | http://localhost:9191 |
 
 The Vite dev server proxies `/api` requests to the backend, so you access the UI at
-`http://localhost:8888` and API calls are forwarded automatically.
+`http://localhost:9191` and API calls are forwarded automatically.
 
 Both processes run in the foreground — **Ctrl+C** stops everything.
 
@@ -122,7 +122,7 @@ needed.
 A typical development loop:
 
 1. Run `./dev.sh` to start both backend and frontend
-2. Open `http://localhost:8888` in your browser
+2. Open `http://localhost:9191` in your browser
 3. Edit backend Java code — Quarkus hot-reloads on the next request
 4. Edit frontend TypeScript/React code — Vite hot-reloads instantly
 5. Run `mvn test` in a module directory to run unit tests for that module
@@ -133,8 +133,8 @@ A typical development loop:
 
 | Port | Service | Mode |
 |------|---------|------|
-| 8080 | Quarkus backend | Development (`mvn quarkus:dev`) |
-| 8888 | Vite UI dev server | Development (`npm run dev`) |
+| 9090 | Quarkus backend | Development (`mvn quarkus:dev`) |
+| 9191 | Vite UI dev server | Development (`npm run dev`) |
 | 9191 | Quarkus backend | Production (uber-jar) |
 
 ---

--- a/docs/developer-guide/database-and-migrations.md
+++ b/docs/developer-guide/database-and-migrations.md
@@ -195,5 +195,5 @@ CREATE INDEX IF NOT EXISTS idx_task_status ON task (status);
   data between restarts.
 - When writing a migration, test it against a persistent database that already has
   data to verify it runs cleanly.
-- The H2 console is available at `http://localhost:8080/q/h2` during development
+- The H2 console is available at `http://localhost:9090/q/h2` during development
   (Quarkus dev mode only).

--- a/docs/developer-guide/how-to-contribute.md
+++ b/docs/developer-guide/how-to-contribute.md
@@ -20,7 +20,7 @@ For a quick overview of ways to get involved, see the
    ```bash
    ./dev.sh
    ```
-4. Open `http://localhost:8888` and verify the UI loads
+4. Open `http://localhost:9191` and verify the UI loads
 
 See the [Building Axiom](building-axiom.md) guide for prerequisites and build details.
 

--- a/docs/developer-guide/ui-development.md
+++ b/docs/developer-guide/ui-development.md
@@ -252,7 +252,7 @@ import { CodeEditor, Language } from "@patternfly/react-code-editor";
 
 1. Start the UI dev server: `cd ui && npm run dev` (or use `./dev.sh` which starts
    both)
-2. The Vite dev server runs on port 8888 and proxies `/api` requests to the backend
-   on port 8080
+2. The Vite dev server runs on port 9191 and proxies `/api` requests to the backend
+   on port 9090
 3. Hot module replacement (HMR) updates the browser instantly when you save a file
 4. Run `npm run lint` to check code quality before committing

--- a/docs/getting-started/contributing.md
+++ b/docs/getting-started/contributing.md
@@ -28,7 +28,7 @@ cd apitomy-axiom
 ./dev.sh
 ```
 
-This starts the Quarkus backend on `http://localhost:8080` and the Vite UI dev server on
-`http://localhost:8888`. See the
+This starts the Quarkus backend on `http://localhost:9090` and the Vite UI dev server on
+`http://localhost:9191`. See the
 [README](https://github.com/Apitomy/apitomy-axiom/blob/main/README.md) for full build
 instructions and development workflow details.

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -4,10 +4,10 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
     plugins: [react()],
     server: {
-        port: 8888,
+        port: 9191,
         proxy: {
             "/api/v1/sse": {
-                target: "http://localhost:8080",
+                target: "http://localhost:9090",
                 changeOrigin: true,
                 // Required for SSE: disable response buffering
                 configure: (proxy) => {
@@ -18,7 +18,7 @@ export default defineConfig({
                 },
             },
             "/api": {
-                target: "http://localhost:8080",
+                target: "http://localhost:9090",
                 changeOrigin: true,
             },
         },


### PR DESCRIPTION
## Summary

- Move Quarkus backend dev port from 8080 to 9090 to avoid contention
- Move Vite UI dev server from 8888 to 9191, matching the production port
- Update all `@ConfigProperty` default values, MCP server template fallback URLs,
  OpenAPI spec server URL, and documentation (20 files total)

## Related Issue

Fixes #29

## Test Plan

- [ ] Run `./build.sh` — full build with tests passes
- [ ] Run `./dev.sh` — Quarkus starts on 9090, Vite on 9191
- [ ] Open `http://localhost:9191` — UI loads and API calls proxy correctly
- [ ] Verify SSE events still work through the Vite proxy