### PR TITLE
Use pull request title as project name instead of repo#number (#32)

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/PipelineOrchestrator.java
+++ b/app/src/main/java/io/apitomy/axiom/app/PipelineOrchestrator.java
@@ -305,6 +305,10 @@ public class PipelineOrchestrator {
                 if (title != null && !title.isBlank()) {
                     return title;
                 }
+                title = root.path("pull_request").path("title").asText(null);
+                if (title != null && !title.isBlank()) {
+                    return title;
+                }
             } catch (Exception e) {
                 LOG.debugf("Could not parse event payload for issue title: %s", e.getMessage());
             }


### PR DESCRIPTION
## Summary

- Update `extractIssueTitle()` in `PipelineOrchestrator` to also check
  `pull_request.title` in the event payload when `issue.title` is not found
- Projects created from PR events now use the PR title (e.g. "Color-code labels
  based on text value (#27)") instead of the repo#number format

## Related Issue

Fixes #32

## Test Plan

- [ ] Run `./build.sh` — compilation and tests pass
- [ ] Trigger a PR event in Axiom and verify the new project uses the PR title
- [ ] Trigger an issue event and verify project names still use the issue title
- [ ] Verify `issueRef` field still contains the "repo#number" format for reference