### PR TITLE
Add project type icon to Projects table name column (#34)

### DIFF
--- a/ui/src/pages/ProjectDetailPage.tsx
+++ b/ui/src/pages/ProjectDetailPage.tsx
@@ -40,6 +40,8 @@ import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import PlayIcon from "@patternfly/react-icons/dist/esm/icons/play-icon";
 import SyncAltIcon from "@patternfly/react-icons/dist/esm/icons/sync-alt-icon";
 import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
+import CodeBranchIcon from "@patternfly/react-icons/dist/esm/icons/code-branch-icon";
+import ExclamationCircleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon";
 import GithubIcon from "@patternfly/react-icons/dist/esm/icons/github-icon";
 import JiraIcon from "@patternfly/react-icons/dist/esm/icons/jira-icon";
 import {
@@ -202,6 +204,8 @@ export function ProjectDetailPage() {
                     <Title headingLevel="h1" size="lg">
                         {project.issueSource === "github" && <GithubIcon style={{ marginRight: 8 }} />}
                         {project.issueSource === "jira" && <JiraIcon style={{ marginRight: 8 }} />}
+                        {project.type === "issue" && <ExclamationCircleIcon style={{ marginRight: 8 }} />}
+                        {project.type === "pull-request" && <CodeBranchIcon style={{ marginRight: 8 }} />}
                         {project.name}
                     </Title>
                 </FlexItem>

--- a/ui/src/pages/ProjectsPage.tsx
+++ b/ui/src/pages/ProjectsPage.tsx
@@ -27,6 +27,8 @@ import PlusCircleIcon from "@patternfly/react-icons/dist/esm/icons/plus-circle-i
 import SyncAltIcon from "@patternfly/react-icons/dist/esm/icons/sync-alt-icon";
 import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
 import { ColoredLabel } from "../components/ColoredLabel";
+import CodeBranchIcon from "@patternfly/react-icons/dist/esm/icons/code-branch-icon";
+import ExclamationCircleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon";
 import GithubIcon from "@patternfly/react-icons/dist/esm/icons/github-icon";
 import JiraIcon from "@patternfly/react-icons/dist/esm/icons/jira-icon";
 import {
@@ -262,6 +264,8 @@ export function ProjectsPage() {
                                     <Td>
                                         {project.issueSource === "github" && <GithubIcon style={{ marginRight: 6 }} />}
                                         {project.issueSource === "jira" && <JiraIcon style={{ marginRight: 6 }} />}
+                                        {project.type === "issue" && <ExclamationCircleIcon style={{ marginRight: 6 }} />}
+                                        {project.type === "pull-request" && <CodeBranchIcon style={{ marginRight: 6 }} />}
                                         {project.name}
                                     </Td>
                                     <Td>


### PR DESCRIPTION
## Summary

- Add `ExclamationCircleIcon` for projects with type "issue" and `CodeBranchIcon` for
  type "pull-request" next to the source icon in the project name column
- Applied to both the Projects list page and the Project detail page header
- Projects with type "other" show no type icon (graceful fallback)

## Related Issue

Fixes #34

## Test Plan

- [ ] Navigate to the Projects list page and verify type icons appear for projects
      with type "issue" or "pull-request"
- [ ] Verify projects with type "other" show only the source icon (no type icon)
- [ ] Open a Project detail page and verify the type icon appears in the header