### PR TITLE
Add toggle to hide completed projects from Projects list (#35)

### DIFF
--- a/ui/src/pages/ProjectsPage.tsx
+++ b/ui/src/pages/ProjectsPage.tsx
@@ -96,14 +96,17 @@ export function ProjectsPage() {
         .filter((f) => f.filterBy.value === "status")
         .map((f) => f.filterValue)
         .join(",");
+    const nonCompletedStatuses = Object.keys(STATUS_LABELS)
+        .filter((s) => s !== "Completed")
+        .join(",");
     const filterStatus = explicitStatusFilters
         ? explicitStatusFilters
-        : (!showCompleted ? "Created,InProgress,Idle" : undefined);
+        : (!showCompleted ? nonCompletedStatuses : undefined);
     const filterLabels = filters
         .filter((f) => f.filterBy.value === "labels")
         .map((f) => f.filterValue)
         .join(",");
-    const isFiltered = filters.length > 0;
+    const isFiltered = filters.length > 0 || !showCompleted;
 
     const loadProjects = useCallback(() => {
         setLoading(true);
@@ -259,9 +262,11 @@ export function ProjectsPage() {
                 ) : projects.length === 0 ? (
                     <EmptyState>
                         <EmptyStateBody>
-                            {isFiltered
+                            {filters.length > 0
                                 ? "No projects match the current filters."
-                                : "No projects yet. Create one or wait for events from a monitored repository."}
+                                : !showCompleted
+                                    ? "All projects are completed. Toggle the eye icon to show them."
+                                    : "No projects yet. Create one or wait for events from a monitored repository."}
                         </EmptyStateBody>
                     </EmptyState>
                 ) : (

--- a/ui/src/pages/ProjectsPage.tsx
+++ b/ui/src/pages/ProjectsPage.tsx
@@ -19,12 +19,15 @@ import {
     TextInput,
     Title,
     Toolbar,
+    Tooltip,
     ToolbarContent,
     ToolbarItem,
 } from "@patternfly/react-core";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import PlusCircleIcon from "@patternfly/react-icons/dist/esm/icons/plus-circle-icon";
 import SyncAltIcon from "@patternfly/react-icons/dist/esm/icons/sync-alt-icon";
+import EyeIcon from "@patternfly/react-icons/dist/esm/icons/eye-icon";
+import EyeSlashIcon from "@patternfly/react-icons/dist/esm/icons/eye-slash-icon";
 import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
 import { ColoredLabel } from "../components/ColoredLabel";
 import CodeBranchIcon from "@patternfly/react-icons/dist/esm/icons/code-branch-icon";
@@ -74,6 +77,9 @@ export function ProjectsPage() {
     const [loading, setLoading] = useState(true);
 
     const [filters, setFilters] = useState<ChipFilterCriteria[]>([]);
+    const [showCompleted, setShowCompleted] = useState(
+        () => localStorage.getItem("axiom.projects.showCompleted") === "true"
+    );
 
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [deleteTarget, setDeleteTarget] = useState<number | null>(null);
@@ -86,10 +92,13 @@ export function ProjectsPage() {
     });
 
     const filterName = filters.find((f) => f.filterBy.value === "name")?.filterValue;
-    const filterStatus = filters
+    const explicitStatusFilters = filters
         .filter((f) => f.filterBy.value === "status")
         .map((f) => f.filterValue)
         .join(",");
+    const filterStatus = explicitStatusFilters
+        ? explicitStatusFilters
+        : (!showCompleted ? "Created,InProgress,Idle" : undefined);
     const filterLabels = filters
         .filter((f) => f.filterBy.value === "labels")
         .map((f) => f.filterValue)
@@ -194,6 +203,19 @@ export function ProjectsPage() {
                         <Button variant="control" aria-label="Refresh" onClick={loadProjects}>
                             <SyncAltIcon />
                         </Button>
+                    </ToolbarItem>
+                    <ToolbarItem>
+                        <Tooltip content={showCompleted ? "Hide completed projects" : "Show completed projects"}>
+                            <Button variant="control" aria-label="Toggle completed projects"
+                                onClick={() => {
+                                    const next = !showCompleted;
+                                    setShowCompleted(next);
+                                    localStorage.setItem("axiom.projects.showCompleted", String(next));
+                                    setPage(1);
+                                }}>
+                                {showCompleted ? <EyeIcon /> : <EyeSlashIcon />}
+                            </Button>
+                        </Tooltip>
                     </ToolbarItem>
                     <ToolbarItem>
                         <Button


### PR DESCRIPTION
## Summary

- Add a toggle button (eye icon) in the Projects toolbar that controls whether completed
  projects are shown in the list
- By default, completed projects are hidden; clicking the toggle reveals them
- Toggle state is persisted in localStorage across page navigations
- Explicit status chip filters override the toggle behavior

## Related Issue

Fixes #35

## Test Plan

- [ ] Navigate to Projects page — completed projects should be hidden by default
- [ ] Toggle button shows `EyeSlashIcon` when completed are hidden
- [ ] Click toggle — completed projects appear, icon changes to `EyeIcon`
- [ ] Refresh the page — toggle state persists from localStorage
- [ ] Add an explicit status chip filter (e.g. "Completed") — it overrides the toggle
- [ ] Clear all filters — toggle behavior resumes