### PR TITLE
Set project type to issue or pull-request based on event source (Fixes #33)

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/PipelineOrchestrator.java
+++ b/app/src/main/java/io/apitomy/axiom/app/PipelineOrchestrator.java
@@ -257,7 +257,7 @@ public class PipelineOrchestrator {
     private ProjectEntity createProjectFromEvent(EventEntity event) {
         ProjectEntity project = new ProjectEntity();
         project.name = extractIssueTitle(event);
-        project.type = "other";
+        project.type = determineProjectType(event.eventType);
         project.status = ProjectStatus.Created.name();
         project.issueSource = event.source;
         project.issueRef = event.issueRef != null ? event.issueRef : "unknown";
@@ -283,6 +283,21 @@ public class PipelineOrchestrator {
         }
 
         return project;
+    }
+
+    /**
+     * Determines the project type based on the event type prefix.
+     */
+    private String determineProjectType(String eventType) {
+        if (eventType != null) {
+            if (eventType.startsWith("issue-")) {
+                return "issue";
+            }
+            if (eventType.startsWith("pr-")) {
+                return "pull-request";
+            }
+        }
+        return "other";
     }
 
     private void markQueueEntry(Long queueEntryId, String status) {

--- a/app/src/test/java/io/apitomy/axiom/app/PipelineOrchestratorTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/PipelineOrchestratorTest.java
@@ -70,6 +70,7 @@ class PipelineOrchestratorTest {
         // Verify project was auto-created
         ProjectEntity project = ProjectEntity.find("issueRef", "TestOrg/pipeline-test#1").firstResult();
         assertNotNull(project, "Project should be auto-created");
+        assertEquals("issue", project.type);
         assertEquals("Created", project.status);
         assertEquals("github", project.issueSource);
         assertEquals("TestOrg/pipeline-test", project.repository);
@@ -115,6 +116,47 @@ class PipelineOrchestratorTest {
         List<TaskEntity> tasks = TaskEntity.list("projectId", project.id);
         assertEquals(1, tasks.size());
         assertEquals("answer-question", tasks.getFirst().actionType);
+    }
+
+    @Test
+    @Transactional
+    void testCreateProjectFromPrEventSetsPullRequestType() {
+        EventQueueEntity queueEntry = createEventAndEnqueue(
+                "github", "pr-created", "TestOrg/pipeline-test#10",
+                "TestOrg/pipeline-test",
+                "{\"action\":\"opened\",\"pull_request\":{\"number\":10,\"title\":\"Fix bug\"}}");
+
+        ManagerDecision decision = new ManagerDecision(
+                "create_task", "review", null,
+                "Review this PR", 0.9, "New PR needs review");
+        when(managerService.evaluate(any())).thenReturn(List.of(decision));
+
+        orchestrator.processEvent(queueEntry);
+
+        ProjectEntity project = ProjectEntity.find("issueRef", "TestOrg/pipeline-test#10").firstResult();
+        assertNotNull(project, "Project should be auto-created for PR event");
+        assertEquals("pull-request", project.type);
+        assertEquals("github", project.issueSource);
+    }
+
+    @Test
+    @Transactional
+    void testCreateProjectFromUnknownEventSetsOtherType() {
+        EventQueueEntity queueEntry = createEventAndEnqueue(
+                "github", "task-completed", "TestOrg/pipeline-test#11",
+                "TestOrg/pipeline-test",
+                "{\"action\":\"completed\",\"issue\":{\"number\":11,\"title\":\"Done\"}}");
+
+        ManagerDecision decision = new ManagerDecision(
+                "create_task", "analyze", null,
+                "Analyze this", 0.9, "Needs analysis");
+        when(managerService.evaluate(any())).thenReturn(List.of(decision));
+
+        orchestrator.processEvent(queueEntry);
+
+        ProjectEntity project = ProjectEntity.find("issueRef", "TestOrg/pipeline-test#11").firstResult();
+        assertNotNull(project, "Project should be auto-created for unknown event type");
+        assertEquals("other", project.type);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Replaced hardcoded `project.type = "other"` in `createProjectFromEvent()` with a new
  `determineProjectType()` helper that maps event type prefixes to project types:
  `issue-*` → `"issue"`, `pr-*` → `"pull-request"`, fallback → `"other"`
- Added assertion to existing test verifying issue events produce `type = "issue"`
- Added two new tests: one for PR events (`"pull-request"` type) and one for unknown
  event types (`"other"` fallback)

## Related Issue

Fixes #33

## Test Plan

- [ ] Verify existing `testCreateTaskDecisionAutoCreatesProject` passes with new `type` assertion
- [ ] Verify `testCreateProjectFromPrEventSetsPullRequestType` passes
- [ ] Verify `testCreateProjectFromUnknownEventSetsOtherType` passes
- [ ] Full test suite: `cd app && mvn test -q`