### PR TITLE
Fix AI Assistant message input not shrinking after submit (#37)

### DIFF
--- a/ui/src/components/assistant/AssistantMessageInput.tsx
+++ b/ui/src/components/assistant/AssistantMessageInput.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import { TextArea, Button, Flex, FlexItem } from "@patternfly/react-core";
 import PaperPlaneIcon from "@patternfly/react-icons/dist/esm/icons/paper-plane-icon";
 
@@ -9,12 +9,16 @@ interface AssistantMessageInputProps {
 
 export function AssistantMessageInput({ onSend, disabled }: AssistantMessageInputProps) {
     const [value, setValue] = useState("");
+    const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
     const handleSend = useCallback(() => {
         const trimmed = value.trim();
         if (!trimmed) return;
         onSend(trimmed);
         setValue("");
+        setTimeout(() => {
+            textAreaRef.current?.parentElement?.style.removeProperty("height");
+        }, 0);
     }, [value, onSend]);
 
     const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -28,6 +32,7 @@ export function AssistantMessageInput({ onSend, disabled }: AssistantMessageInpu
         <Flex style={{ padding: "12px 16px", borderTop: "1px solid #d2d2d2", flexShrink: 0 }}>
             <FlexItem grow={{ default: "grow" }}>
                 <TextArea
+                    ref={textAreaRef}
                     value={value}
                     onChange={(_e, val) => setValue(val)}
                     onKeyDown={handleKeyDown}

--- a/ui/src/components/assistant/AssistantMessageInput.tsx
+++ b/ui/src/components/assistant/AssistantMessageInput.tsx
@@ -16,7 +16,10 @@ export function AssistantMessageInput({ onSend, disabled }: AssistantMessageInpu
         if (!trimmed) return;
         onSend(trimmed);
         setValue("");
+        // Defer to next tick so React flushes setValue("") before we reset height
         setTimeout(() => {
+            // PF autoResize sets inline height on the textarea's parent <span>;
+            // programmatic value changes don't trigger a recalc, so clear it manually.
             textAreaRef.current?.parentElement?.style.removeProperty("height");
         }, 0);
     }, [value, onSend]);


### PR DESCRIPTION
## Summary
- PatternFly's `TextArea` `autoResize` only recalculates height on user-generated change events,
  not on programmatic value changes
- After `handleSend` clears the value with `setValue("")`, the parent span retains its expanded
  inline height
- Added a ref to the textarea and reset the parent element's inline height after clearing, so the
  textarea collapses back to its natural `rows={1}` height

## Related Issue
Fixes #37

## Test Plan
- [ ] Open the AI Assistant
- [ ] Type a multi-line message that causes the textarea to expand
- [ ] Submit the message (Enter or click Send)
- [ ] Verify the textarea shrinks back to its initial compact height
- [ ] Type another multi-line message and verify auto-expand still works