### PR TITLE
Tracing data model — Trace, TraceNode, and ToolExecution entities (#45)

### DIFF
--- a/app/src/main/resources/db/migration/V22__create_tracing_tables.sql
+++ b/app/src/main/resources/db/migration/V22__create_tracing_tables.sql
@@ -1,0 +1,61 @@
+-- =============================================================================
+-- V22: Create tracing tables for end-to-end activity tracing (Epic #36)
+-- =============================================================================
+
+-- Trace table: UUID primary key (first table to use UUID PK)
+CREATE TABLE IF NOT EXISTS trace (
+    trace_id UUID NOT NULL PRIMARY KEY,
+    trace_type VARCHAR(64) NOT NULL,
+    status VARCHAR(32) NOT NULL,
+    summary VARCHAR(1024) NOT NULL,
+    event_id BIGINT,
+    project_id BIGINT,
+    report_id BIGINT,
+    started_on TIMESTAMP NOT NULL,
+    completed_on TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_trace_event ON trace(event_id);
+CREATE INDEX IF NOT EXISTS idx_trace_project ON trace(project_id);
+CREATE INDEX IF NOT EXISTS idx_trace_report ON trace(report_id);
+CREATE INDEX IF NOT EXISTS idx_trace_status ON trace(status);
+
+-- Trace node table: individual span/step in a trace tree
+CREATE TABLE IF NOT EXISTS trace_node (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    trace_id UUID NOT NULL,
+    parent_node_id BIGINT,
+    node_type VARCHAR(64) NOT NULL,
+    status VARCHAR(32) NOT NULL,
+    summary VARCHAR(1024) NOT NULL,
+    started_on TIMESTAMP NOT NULL,
+    completed_on TIMESTAMP,
+    duration_ms BIGINT,
+    entity_type VARCHAR(64),
+    entity_id BIGINT,
+    FOREIGN KEY (trace_id) REFERENCES trace(trace_id) ON DELETE CASCADE,
+    FOREIGN KEY (parent_node_id) REFERENCES trace_node(id) ON DELETE SET NULL
+);
+CREATE SEQUENCE IF NOT EXISTS trace_node_SEQ START WITH 1 INCREMENT BY 50;
+CREATE INDEX IF NOT EXISTS idx_trace_node_trace ON trace_node(trace_id);
+CREATE INDEX IF NOT EXISTS idx_trace_node_parent ON trace_node(parent_node_id);
+CREATE INDEX IF NOT EXISTS idx_trace_node_entity ON trace_node(entity_type, entity_id);
+
+-- Tool execution table: detailed record of an MCP tool invocation
+CREATE TABLE IF NOT EXISTS tool_execution (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    trace_id UUID NOT NULL,
+    tool_name VARCHAR(255) NOT NULL,
+    tool_input TEXT,
+    tool_output TEXT,
+    status VARCHAR(32) NOT NULL,
+    duration_ms BIGINT,
+    created_on TIMESTAMP NOT NULL,
+    FOREIGN KEY (trace_id) REFERENCES trace(trace_id) ON DELETE CASCADE
+);
+CREATE SEQUENCE IF NOT EXISTS tool_execution_SEQ START WITH 1 INCREMENT BY 50;
+CREATE INDEX IF NOT EXISTS idx_tool_execution_trace ON tool_execution(trace_id);
+
+-- Add trace_id column to existing tables for direct trace lookup
+ALTER TABLE event ADD COLUMN IF NOT EXISTS trace_id UUID;
+ALTER TABLE task ADD COLUMN IF NOT EXISTS trace_id UUID;
+ALTER TABLE report ADD COLUMN IF NOT EXISTS trace_id UUID;

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -32,6 +32,11 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/src/main/java/io/apitomy/axiom/core/entities/EventEntity.java
+++ b/core/src/main/java/io/apitomy/axiom/core/entities/EventEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 
 import java.time.Instant;
+import java.util.UUID;
 
 /**
  * Represents something that happened — either externally or internally.
@@ -36,6 +37,10 @@ public class EventEntity extends PanacheEntity {
 
     @Column(nullable = false, columnDefinition = "TEXT")
     public String payload;
+
+
+    @Column(name = "trace_id")
+    public UUID traceId;
 
     @Column(name = "received_at", nullable = false)
     public Instant receivedAt;

--- a/core/src/main/java/io/apitomy/axiom/core/entities/ReportEntity.java
+++ b/core/src/main/java/io/apitomy/axiom/core/entities/ReportEntity.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Table;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.UUID;
 import java.util.List;
 
 /**
@@ -53,6 +54,10 @@ public class ReportEntity extends PanacheEntity {
 
     @Column(name = "completed_on")
     public Instant completedOn;
+
+
+    @Column(name = "trace_id")
+    public UUID traceId;
 
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "report_label", joinColumns = @JoinColumn(name = "report_id"))

--- a/core/src/main/java/io/apitomy/axiom/core/entities/TaskEntity.java
+++ b/core/src/main/java/io/apitomy/axiom/core/entities/TaskEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 
 import java.time.Instant;
+import java.util.UUID;
 
 /**
  * Represents a discrete unit of work within a Project.
@@ -43,6 +44,10 @@ public class TaskEntity extends PanacheEntity {
 
     @Column(name = "completed_on")
     public Instant completedOn;
+
+
+    @Column(name = "trace_id")
+    public UUID traceId;
 
     @Column(name = "session_id")
     public String sessionId;

--- a/core/src/main/java/io/apitomy/axiom/core/entities/ToolExecutionEntity.java
+++ b/core/src/main/java/io/apitomy/axiom/core/entities/ToolExecutionEntity.java
@@ -1,0 +1,40 @@
+package io.apitomy.axiom.core.entities;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Detailed record of an MCP tool invocation, storing the full JSON input and
+ * output. Referenced by a {@link TraceNodeEntity} via
+ * {@code entityType="tool-execution"}.
+ */
+@Entity
+@Table(name = "tool_execution")
+public class ToolExecutionEntity extends PanacheEntity {
+
+    @Column(name = "trace_id", nullable = false)
+    public UUID traceId;
+
+    @Column(name = "tool_name", nullable = false)
+    public String toolName;
+
+    @Column(name = "tool_input", columnDefinition = "TEXT")
+    public String toolInput;
+
+    @Column(name = "tool_output", columnDefinition = "TEXT")
+    public String toolOutput;
+
+    @Column(nullable = false)
+    public String status;
+
+    @Column(name = "duration_ms")
+    public Long durationMs;
+
+    @Column(name = "created_on", nullable = false)
+    public Instant createdOn;
+}

--- a/core/src/main/java/io/apitomy/axiom/core/entities/TraceEntity.java
+++ b/core/src/main/java/io/apitomy/axiom/core/entities/TraceEntity.java
@@ -1,0 +1,47 @@
+package io.apitomy.axiom.core.entities;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Root of a complete execution trace — connects every step in a pipeline run
+ * or report generation into a directed graph of {@link TraceNodeEntity} spans.
+ */
+@Entity
+@Table(name = "trace")
+public class TraceEntity extends PanacheEntityBase {
+
+    @Id
+    @Column(name = "trace_id", nullable = false)
+    public UUID traceId;
+
+    @Column(name = "trace_type", nullable = false)
+    public String traceType;
+
+    @Column(nullable = false)
+    public String status;
+
+    @Column(nullable = false, length = 1024)
+    public String summary;
+
+    @Column(name = "event_id")
+    public Long eventId;
+
+    @Column(name = "project_id")
+    public Long projectId;
+
+    @Column(name = "report_id")
+    public Long reportId;
+
+    @Column(name = "started_on", nullable = false)
+    public Instant startedOn;
+
+    @Column(name = "completed_on")
+    public Instant completedOn;
+}

--- a/core/src/main/java/io/apitomy/axiom/core/entities/TraceNodeEntity.java
+++ b/core/src/main/java/io/apitomy/axiom/core/entities/TraceNodeEntity.java
@@ -1,0 +1,49 @@
+package io.apitomy.axiom.core.entities;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * A single span/step within a {@link TraceEntity} tree. Lightweight breadcrumb
+ * that references a more detailed record elsewhere via {@code entityType} and
+ * {@code entityId}.
+ */
+@Entity
+@Table(name = "trace_node")
+public class TraceNodeEntity extends PanacheEntity {
+
+    @Column(name = "trace_id", nullable = false)
+    public UUID traceId;
+
+    @Column(name = "parent_node_id")
+    public Long parentNodeId;
+
+    @Column(name = "node_type", nullable = false)
+    public String nodeType;
+
+    @Column(nullable = false)
+    public String status;
+
+    @Column(nullable = false, length = 1024)
+    public String summary;
+
+    @Column(name = "started_on", nullable = false)
+    public Instant startedOn;
+
+    @Column(name = "completed_on")
+    public Instant completedOn;
+
+    @Column(name = "duration_ms")
+    public Long durationMs;
+
+    @Column(name = "entity_type")
+    public String entityType;
+
+    @Column(name = "entity_id")
+    public Long entityId;
+}

--- a/core/src/main/java/io/apitomy/axiom/core/tracing/TraceContext.java
+++ b/core/src/main/java/io/apitomy/axiom/core/tracing/TraceContext.java
@@ -1,0 +1,61 @@
+package io.apitomy.axiom.core.tracing;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.UUID;
+
+/**
+ * Mutable context threaded through pipeline and report processing to track the
+ * current position in the trace tree. Uses an internal stack so callers can
+ * {@link #push(Long)} when descending into a child scope and {@link #pop()}
+ * when returning to the parent.
+ */
+public class TraceContext {
+
+    private final UUID traceId;
+    private final Deque<Long> nodeStack = new ArrayDeque<>();
+
+    /**
+     * Creates a new context rooted at the given node.
+     *
+     * @param traceId    the trace UUID
+     * @param rootNodeId the ID of the root {@code TraceNodeEntity}
+     */
+    public TraceContext(UUID traceId, Long rootNodeId) {
+        this.traceId = traceId;
+        this.nodeStack.push(rootNodeId);
+    }
+
+    /**
+     * Returns the trace UUID.
+     */
+    public UUID traceId() {
+        return traceId;
+    }
+
+    /**
+     * Returns the current parent node ID (top of stack).
+     */
+    public Long currentParentNodeId() {
+        return nodeStack.peek();
+    }
+
+    /**
+     * Pushes a node ID onto the stack, making it the current parent for
+     * subsequently created child nodes.
+     *
+     * @param nodeId the node ID to push
+     */
+    public void push(Long nodeId) {
+        nodeStack.push(nodeId);
+    }
+
+    /**
+     * Pops the current parent, returning to the previous level.
+     *
+     * @return the popped node ID
+     */
+    public Long pop() {
+        return nodeStack.pop();
+    }
+}

--- a/core/src/test/java/io/apitomy/axiom/core/tracing/TraceContextTest.java
+++ b/core/src/test/java/io/apitomy/axiom/core/tracing/TraceContextTest.java
@@ -1,0 +1,107 @@
+package io.apitomy.axiom.core.tracing;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TraceContextTest {
+
+    @Test
+    void constructionSetsTraceIdAndRootNode() {
+        UUID traceId = UUID.randomUUID();
+        TraceContext ctx = new TraceContext(traceId, 100L);
+
+        assertEquals(traceId, ctx.traceId());
+        assertEquals(100L, ctx.currentParentNodeId());
+    }
+
+    @Test
+    void pushMakesNewNodeTheCurrentParent() {
+        TraceContext ctx = new TraceContext(UUID.randomUUID(), 1L);
+
+        ctx.push(2L);
+        assertEquals(2L, ctx.currentParentNodeId());
+
+        ctx.push(3L);
+        assertEquals(3L, ctx.currentParentNodeId());
+    }
+
+    @Test
+    void popReturnsToThePreviousLevel() {
+        TraceContext ctx = new TraceContext(UUID.randomUUID(), 1L);
+        ctx.push(2L);
+        ctx.push(3L);
+
+        assertEquals(3L, ctx.pop());
+        assertEquals(2L, ctx.currentParentNodeId());
+
+        assertEquals(2L, ctx.pop());
+        assertEquals(1L, ctx.currentParentNodeId());
+    }
+
+    @Test
+    void popReturnsThePoppedNodeId() {
+        TraceContext ctx = new TraceContext(UUID.randomUUID(), 1L);
+        ctx.push(42L);
+
+        Long popped = ctx.pop();
+        assertEquals(42L, popped);
+    }
+
+    @Test
+    void poppingPastRootThrows() {
+        TraceContext ctx = new TraceContext(UUID.randomUUID(), 1L);
+        ctx.pop();
+
+        assertThrows(NoSuchElementException.class, ctx::pop);
+    }
+
+    @Test
+    void currentParentNodeIdReturnsNullWhenEmpty() {
+        TraceContext ctx = new TraceContext(UUID.randomUUID(), 1L);
+        ctx.pop();
+
+        assertNull(ctx.currentParentNodeId());
+    }
+
+    @Test
+    void traceIdIsImmutable() {
+        UUID traceId = UUID.randomUUID();
+        TraceContext ctx = new TraceContext(traceId, 1L);
+
+        ctx.push(2L);
+        ctx.pop();
+
+        assertEquals(traceId, ctx.traceId());
+    }
+
+    @Test
+    void typicalPipelineFlow() {
+        TraceContext ctx = new TraceContext(UUID.randomUUID(), 1L);
+        assertEquals(1L, ctx.currentParentNodeId());
+
+        // Manager evaluation — child of root
+        ctx.push(10L);
+        assertEquals(10L, ctx.currentParentNodeId());
+        ctx.pop();
+
+        // Decision — child of root
+        ctx.push(20L);
+        assertEquals(20L, ctx.currentParentNodeId());
+
+        // Task — child of decision
+        ctx.push(30L);
+        assertEquals(30L, ctx.currentParentNodeId());
+        ctx.pop();
+
+        // Back to decision level
+        assertEquals(20L, ctx.currentParentNodeId());
+        ctx.pop();
+
+        // Back to root
+        assertEquals(1L, ctx.currentParentNodeId());
+    }
+}


### PR DESCRIPTION
## Summary
- Add three new JPA entities (`TraceEntity`, `TraceNodeEntity`, `ToolExecutionEntity`) as the
  foundation for end-to-end activity tracing (epic #36)
- Add stack-based `TraceContext` class in `core/tracing/` for threading trace context through
  pipeline and report processing
- Add `traceId` UUID field to `EventEntity`, `TaskEntity`, and `ReportEntity` for direct trace
  lookup
- Add Flyway migration V22 creating the three new tables, sequences, indexes, and ALTER TABLEs

## Related Issue
Fixes #45

## Test Plan
- [x] All 249 existing tests pass (0 failures)
- [x] 8 new `TraceContextTest` cases pass (stack push/pop/peek, typical pipeline flow)
- [x] Full build succeeds (`build.sh`)
- [ ] Verify Flyway migration runs cleanly on application startup
- [ ] Verify `TraceEntity` UUID PK works with Panache `findById(UUID)`