### PR TITLE
Tracing: Backend instrumentation — Pipeline and manager tracing (#46)

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/PipelineOrchestrator.java
+++ b/app/src/main/java/io/apitomy/axiom/app/PipelineOrchestrator.java
@@ -2,6 +2,8 @@ package io.apitomy.axiom.app;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.apitomy.axiom.core.tracing.TraceContext;
+import io.apitomy.axiom.core.tracing.TraceService;
 import io.apitomy.axiom.core.entities.ActionTypeEntity;
 import io.apitomy.axiom.core.entities.ActivityLogEntity;
 import io.apitomy.axiom.core.entities.EventEntity;
@@ -54,6 +56,9 @@ public class PipelineOrchestrator {
     @Inject
     ScriptExecutionService scriptExecutionService;
 
+    @Inject
+    TraceService traceService;
+
     /**
      * Polls the event queue every 5 seconds and processes one pending event at a time.
      * Events are processed sequentially to avoid race conditions in the Manager.
@@ -96,57 +101,107 @@ public class PipelineOrchestrator {
         LOG.infof("Processing event %d: %s [%s] from %s",
                 event.id, event.eventType, event.issueRef, event.source);
 
+        // Create trace context (non-fatal — pipeline continues if tracing fails)
+        TraceContext traceCtx = null;
+        try {
+            traceCtx = traceService.createTrace("event-pipeline",
+                    "Processing event #" + event.id + ": " + event.eventType,
+                    event.id, null, null,
+                    "event-ingested", "Event received: " + event.eventType);
+            event.traceId = traceCtx.traceId();
+        } catch (Exception e) {
+            LOG.warnf(e, "Failed to create trace for event %d", event.id);
+        }
+
         try {
             // Invoke the Manager
-            List<ManagerDecision> decisions = managerService.evaluate(event);
+            List<ManagerDecision> decisions = managerService.evaluate(event, traceCtx);
 
             if (decisions.isEmpty()) {
                 LOG.infof("Manager returned no decisions for event %d", event.id);
                 logActivity(null, null, event.id, "manager-no-decision",
                         "Manager returned no decisions for " + event.eventType);
+                completeTraceIfSync(traceCtx, false);
                 markQueueEntry(queueEntry.id, "completed");
                 return;
             }
 
             // Process each decision
+            boolean hasAsyncTask = false;
             for (ManagerDecision decision : decisions) {
-                processDecision(event, decision);
+                boolean isAsync = processDecision(event, decision, traceCtx);
+                if (isAsync) {
+                    hasAsyncTask = true;
+                }
             }
 
+            completeTraceIfSync(traceCtx, hasAsyncTask);
             markQueueEntry(queueEntry.id, "completed");
 
         } catch (Exception e) {
             LOG.errorf(e, "Pipeline failed for event %d", event.id);
             logActivity(null, null, event.id, "pipeline-error",
                     "Pipeline error: " + e.getMessage());
+            completeTraceFailed(traceCtx);
             markQueueEntry(queueEntry.id, "failed");
         }
     }
 
-    private void processDecision(EventEntity event, ManagerDecision decision) {
-        if (!managerService.meetsConfidenceThreshold(decision)) {
-            LOG.infof("Decision below confidence threshold (%.2f): %s — escalating",
-                    decision.confidence(), decision.decision());
-            handleEscalation(event, decision,
-                    "Low confidence (" + String.format("%.0f%%", decision.confidence() * 100)
-                            + "): " + decision.reasoning());
-            return;
+    /**
+     * Processes a single manager decision, returning {@code true} if the decision
+     * involves an async task (create_task or script_action).
+     */
+    private boolean processDecision(EventEntity event, ManagerDecision decision,
+            TraceContext traceCtx) {
+        Long decisionNodeId = null;
+        if (traceCtx != null) {
+            try {
+                decisionNodeId = traceService.addNode(traceCtx, "decision-processed", "in-progress",
+                        decision.decision() + ": " + decision.actionType(),
+                        null, null);
+                traceCtx.push(decisionNodeId);
+            } catch (Exception e) {
+                LOG.warnf(e, "Failed to add decision trace node");
+            }
         }
 
-        if (decision.isCreateTask()) {
-            handleCreateTask(event, decision);
-        } else if (decision.isIgnore()) {
-            handleIgnore(event, decision);
-        } else if (decision.isScriptAction()) {
-            handleScriptAction(event, decision);
-        } else if (decision.isEscalate()) {
-            handleEscalation(event, decision, decision.reasoning());
-        } else {
-            LOG.warnf("Unknown decision type: %s", decision.decision());
+        boolean isAsync = false;
+        try {
+            if (!managerService.meetsConfidenceThreshold(decision)) {
+                LOG.infof("Decision below confidence threshold (%.2f): %s — escalating",
+                        decision.confidence(), decision.decision());
+                handleEscalation(event, decision,
+                        "Low confidence (" + String.format("%.0f%%", decision.confidence() * 100)
+                                + "): " + decision.reasoning(), traceCtx);
+            } else if (decision.isCreateTask()) {
+                handleCreateTask(event, decision, traceCtx);
+                isAsync = true;
+            } else if (decision.isIgnore()) {
+                handleIgnore(event, decision, traceCtx);
+            } else if (decision.isScriptAction()) {
+                handleScriptAction(event, decision, traceCtx);
+                isAsync = true;
+            } else if (decision.isEscalate()) {
+                handleEscalation(event, decision, decision.reasoning(), traceCtx);
+            } else {
+                LOG.warnf("Unknown decision type: %s", decision.decision());
+            }
+        } finally {
+            if (traceCtx != null && decisionNodeId != null) {
+                try {
+                    traceService.completeNode(decisionNodeId, "completed");
+                    traceCtx.pop();
+                } catch (Exception e) {
+                    LOG.warnf(e, "Failed to complete decision trace node");
+                }
+            }
         }
+
+        return isAsync;
     }
 
-    private void handleCreateTask(EventEntity event, ManagerDecision decision) {
+    private void handleCreateTask(EventEntity event, ManagerDecision decision,
+            TraceContext traceCtx) {
         // Find or create the project
         ProjectEntity project = findOrCreateProject(event);
 
@@ -159,6 +214,9 @@ public class PipelineOrchestrator {
         task.status = "Pending";
         task.input = decision.inputContext();
         task.createdOn = Instant.now();
+        if (traceCtx != null) {
+            task.traceId = traceCtx.traceId();
+        }
         task.persist();
 
         LOG.infof("Created task %d (%s) for project %d from event %d",
@@ -171,6 +229,16 @@ public class PipelineOrchestrator {
         logActivity(project.id, task.id, event.id, "task-created",
                 "Manager created task: " + task.actionType + " — " + decision.reasoning());
 
+        // Add trace node for task creation
+        if (traceCtx != null) {
+            try {
+                traceService.addNode(traceCtx, "task-created", "completed",
+                        "Created task: " + task.actionType, "task", task.id);
+            } catch (Exception e) {
+                LOG.warnf(e, "Failed to add task-created trace node");
+            }
+        }
+
         // Log to thread
         addThreadEntry(project.id, "manager", "decision",
                 "Created task: " + task.actionType + "\n\nReasoning: " + decision.reasoning());
@@ -181,13 +249,24 @@ public class PipelineOrchestrator {
         sseEvents.fire(SseEvent.threadEntry(project.id));
     }
 
-    private void handleIgnore(EventEntity event, ManagerDecision decision) {
+    private void handleIgnore(EventEntity event, ManagerDecision decision,
+            TraceContext traceCtx) {
         LOG.infof("Ignoring event %d: %s", event.id, decision.reasoning());
         logActivity(null, null, event.id, "event-ignored",
                 "Event ignored: " + event.eventType + " — " + decision.reasoning());
+
+        if (traceCtx != null) {
+            try {
+                traceService.addNode(traceCtx, "event-ignored", "completed",
+                        "Ignored: " + decision.reasoning(), null, null);
+            } catch (Exception e) {
+                LOG.warnf(e, "Failed to add event-ignored trace node");
+            }
+        }
     }
 
-    private void handleScriptAction(EventEntity event, ManagerDecision decision) {
+    private void handleScriptAction(EventEntity event, ManagerDecision decision,
+            TraceContext traceCtx) {
         ProjectEntity project = findOrCreateProject(event);
 
         TaskEntity task = new TaskEntity();
@@ -198,6 +277,9 @@ public class PipelineOrchestrator {
         task.status = "Pending";
         task.input = decision.inputContext();
         task.createdOn = Instant.now();
+        if (traceCtx != null) {
+            task.traceId = traceCtx.traceId();
+        }
         task.persist();
 
         LOG.infof("Created script task %d (%s) for project %d from event %d",
@@ -208,6 +290,17 @@ public class PipelineOrchestrator {
         logActivity(project.id, task.id, event.id, "task-created",
                 "Manager created script task: " + task.actionType
                         + " — " + decision.reasoning());
+
+        // Add trace node for task creation
+        if (traceCtx != null) {
+            try {
+                traceService.addNode(traceCtx, "task-created", "completed",
+                        "Created script task: " + task.actionType, "task", task.id);
+            } catch (Exception e) {
+                LOG.warnf(e, "Failed to add task-created trace node");
+            }
+        }
+
         addThreadEntry(project.id, "manager", "decision",
                 "Script action: " + task.actionType
                         + "\n\nReasoning: " + decision.reasoning());
@@ -219,10 +312,20 @@ public class PipelineOrchestrator {
         scriptExecutionService.executeScript(task);
     }
 
-    private void handleEscalation(EventEntity event, ManagerDecision decision, String reason) {
+    private void handleEscalation(EventEntity event, ManagerDecision decision,
+            String reason, TraceContext traceCtx) {
         LOG.infof("Escalating event %d to user: %s", event.id, reason);
         logActivity(null, null, event.id, "manager-escalation",
                 "Manager escalation: " + reason);
+
+        if (traceCtx != null) {
+            try {
+                traceService.addNode(traceCtx, "escalation", "completed",
+                        "Escalated: " + reason, null, null);
+            } catch (Exception e) {
+                LOG.warnf(e, "Failed to add escalation trace node");
+            }
+        }
 
         // If there's a project, add to its thread
         ProjectEntity project = findProjectForEvent(event);
@@ -359,5 +462,35 @@ public class PipelineOrchestrator {
         entry.content = content;
         entry.createdOn = Instant.now();
         entry.persist();
+    }
+
+    /**
+     * Completes the trace synchronously if no async tasks were created.
+     */
+    private void completeTraceIfSync(TraceContext traceCtx, boolean hasAsyncTask) {
+        if (traceCtx == null || hasAsyncTask) {
+            return;
+        }
+        try {
+            traceService.completeNode(traceCtx.currentParentNodeId(), "completed");
+            traceService.completeTrace(traceCtx.traceId(), "completed");
+        } catch (Exception e) {
+            LOG.warnf(e, "Failed to complete trace %s", traceCtx.traceId());
+        }
+    }
+
+    /**
+     * Completes the trace with a failed status on pipeline error.
+     */
+    private void completeTraceFailed(TraceContext traceCtx) {
+        if (traceCtx == null) {
+            return;
+        }
+        try {
+            traceService.completeNode(traceCtx.currentParentNodeId(), "failed");
+            traceService.completeTrace(traceCtx.traceId(), "failed");
+        } catch (Exception e) {
+            LOG.warnf(e, "Failed to complete trace %s on error", traceCtx.traceId());
+        }
     }
 }

--- a/app/src/main/java/io/apitomy/axiom/app/ScriptExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ScriptExecutionService.java
@@ -1,5 +1,8 @@
 package io.apitomy.axiom.app;
 
+import io.apitomy.axiom.core.entities.TraceNodeEntity;
+import io.apitomy.axiom.core.tracing.TraceContext;
+import io.apitomy.axiom.core.tracing.TraceService;
 import io.apitomy.axiom.core.entities.ActionTypeEntity;
 import io.apitomy.axiom.core.entities.ActivityLogEntity;
 import io.apitomy.axiom.core.entities.ProjectEntity;
@@ -43,6 +46,9 @@ public class ScriptExecutionService {
     @Inject
     EnvironmentResolver environmentResolver;
 
+    @Inject
+    TraceService traceService;
+
     @ConfigProperty(name = "quarkus.http.port", defaultValue = "9090")
     int httpPort;
 
@@ -60,6 +66,22 @@ public class ScriptExecutionService {
         CompletableFuture.runAsync(() -> {
             Arc.container().requestContext().activate();
             try {
+                // Create task-started trace node
+                if (task.traceId != null) {
+                    try {
+                        TraceNodeEntity taskCreatedNode = TraceNodeEntity.find(
+                                "traceId = ?1 and nodeType = 'task-created' and entityType = 'task' and entityId = ?2",
+                                task.traceId, task.id).firstResult();
+                        if (taskCreatedNode != null) {
+                            TraceContext traceCtx = new TraceContext(task.traceId, taskCreatedNode.id);
+                            traceService.addNode(traceCtx, "task-started", "in-progress",
+                                    "Script execution started: " + task.actionType, "task", task.id);
+                        }
+                    } catch (Exception e) {
+                        LOG.warnf(e, "Failed to create task-started trace node for script task %d", task.id);
+                    }
+                }
+
                 RunResult result = runScript(task);
                 completeTask(task.id, result.output, result.exitCode == 0,
                         result.executionLog);
@@ -242,6 +264,33 @@ public class ScriptExecutionService {
         if (!success) {
             sseEvents.fire(SseEvent.notification(
                     "Script task failed: " + task.actionType, "error"));
+        }
+
+        // Complete the trace (async traces are finalized here)
+        if (task.traceId != null) {
+            try {
+                // Complete the task-started node
+                TraceNodeEntity taskStartedNode = TraceNodeEntity.find(
+                        "traceId = ?1 and nodeType = 'task-started' and entityType = 'task' and entityId = ?2",
+                        task.traceId, task.id).firstResult();
+                if (taskStartedNode != null) {
+                    traceService.completeNode(taskStartedNode.id, statusText);
+                }
+
+                // Add task-completed/task-failed node
+                TraceNodeEntity taskCreatedNode = TraceNodeEntity.find(
+                        "traceId = ?1 and nodeType = 'task-created' and entityType = 'task' and entityId = ?2",
+                        task.traceId, task.id).firstResult();
+                if (taskCreatedNode != null) {
+                    TraceContext traceCtx = new TraceContext(task.traceId, taskCreatedNode.id);
+                    traceService.addNode(traceCtx, "task-" + statusText, "completed",
+                            "Script task " + statusText + ": " + task.actionType, "task", task.id);
+                }
+
+                traceService.completeTrace(task.traceId, success ? "completed" : "failed");
+            } catch (Exception e) {
+                LOG.warnf(e, "Failed to complete trace for script task %d", taskId);
+            }
         }
 
         updateProjectStatusAfterTask(task.projectId);

--- a/app/src/main/java/io/apitomy/axiom/app/TaskExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/TaskExecutionService.java
@@ -3,6 +3,9 @@ package io.apitomy.axiom.app;
 import io.apitomy.axiom.actors.spi.Actor;
 import io.apitomy.axiom.actors.spi.ActorContext;
 import io.apitomy.axiom.actors.spi.TaskResult;
+import io.apitomy.axiom.core.entities.TraceNodeEntity;
+import io.apitomy.axiom.core.tracing.TraceContext;
+import io.apitomy.axiom.core.tracing.TraceService;
 import io.apitomy.axiom.core.entities.ActionTypeEntity;
 import io.apitomy.axiom.core.entities.AiUsageEntity;
 import io.apitomy.axiom.core.entities.ActivityLogEntity;
@@ -71,6 +74,9 @@ public class TaskExecutionService {
 
     @Inject
     EnvironmentResolver environmentResolver;
+
+    @Inject
+    TraceService traceService;
 
     /**
      * Attempts to execute the next pending task for the given project.
@@ -148,6 +154,24 @@ public class TaskExecutionService {
         Path workspace = workspaceService.getWorkspacePath(project);
         Map<String, String> env = buildEnvironment(
                 actionTypeEntity != null ? actionTypeEntity.environment : null);
+
+        // Create task-started trace node and inject trace env vars for MCP tool callbacks
+        if (task.traceId != null) {
+            try {
+                TraceNodeEntity taskCreatedNode = TraceNodeEntity.find(
+                        "traceId = ?1 and nodeType = 'task-created' and entityType = 'task' and entityId = ?2",
+                        task.traceId, task.id).firstResult();
+                Long parentNodeId = taskCreatedNode != null ? taskCreatedNode.id : null;
+                TraceContext traceCtx = new TraceContext(task.traceId,
+                        parentNodeId != null ? parentNodeId : 0L);
+                Long taskStartedNodeId = traceService.addNode(traceCtx, "task-started", "in-progress",
+                        "Task execution started: " + task.actionType, "task", task.id);
+                env.put("AXIOM_TRACE_ID", task.traceId.toString());
+                env.put("AXIOM_PARENT_NODE_ID", String.valueOf(taskStartedNodeId));
+            } catch (Exception e) {
+                LOG.warnf(e, "Failed to create task-started trace node for task %d", task.id);
+            }
+        }
 
         // Generate MCP config filtered to only the tools allowed by this action type
         List<String> allowedTools = getToolsFromActionType(task.actionType);
@@ -419,6 +443,33 @@ public class TaskExecutionService {
         if (!result.isSuccess()) {
             sseEvents.fire(SseEvent.notification(
                     "Task failed: " + task.actionType, "error"));
+        }
+
+        // Complete the trace (async traces are finalized here)
+        if (task.traceId != null) {
+            try {
+                // Complete the task-started node
+                TraceNodeEntity taskStartedNode = TraceNodeEntity.find(
+                        "traceId = ?1 and nodeType = 'task-started' and entityType = 'task' and entityId = ?2",
+                        task.traceId, task.id).firstResult();
+                if (taskStartedNode != null) {
+                    traceService.completeNode(taskStartedNode.id, statusText);
+                }
+
+                // Add task-completed/task-failed node
+                TraceNodeEntity taskCreatedNode = TraceNodeEntity.find(
+                        "traceId = ?1 and nodeType = 'task-created' and entityType = 'task' and entityId = ?2",
+                        task.traceId, task.id).firstResult();
+                if (taskCreatedNode != null) {
+                    TraceContext traceCtx = new TraceContext(task.traceId, taskCreatedNode.id);
+                    traceService.addNode(traceCtx, "task-" + statusText, "completed",
+                            "Task " + statusText + ": " + task.actionType, "task", task.id);
+                }
+
+                traceService.completeTrace(task.traceId, result.isSuccess() ? "completed" : "failed");
+            } catch (Exception e) {
+                LOG.warnf(e, "Failed to complete trace for task %d", task.id);
+            }
         }
 
         // Clean up temporary MCP config files

--- a/app/src/main/java/io/apitomy/axiom/app/rest/ManagerResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/ManagerResourceImpl.java
@@ -72,6 +72,6 @@ public class ManagerResourceImpl implements ManagerResource {
         if (event == null) {
             throw new WebApplicationException("Event not found: " + eventId, 404);
         }
-        return Response.ok(managerService.evaluate(event)).build();
+        return Response.ok(managerService.evaluate(event, null)).build();
     }
 }

--- a/app/src/test/java/io/apitomy/axiom/app/PipelineOrchestratorTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/PipelineOrchestratorTest.java
@@ -63,7 +63,7 @@ class PipelineOrchestratorTest {
         ManagerDecision decision = new ManagerDecision(
                 "create_task", "analyze", null,
                 "Analyze this new issue", 0.9, "New issue needs analysis");
-        when(managerService.evaluate(any())).thenReturn(List.of(decision));
+        when(managerService.evaluate(any(), any())).thenReturn(List.of(decision));
 
         orchestrator.processEvent(queueEntry);
 
@@ -104,7 +104,7 @@ class PipelineOrchestratorTest {
         ManagerDecision decision = new ManagerDecision(
                 "create_task", "answer-question", null,
                 "Answer the user's question", 0.85, "User asked a question");
-        when(managerService.evaluate(any())).thenReturn(List.of(decision));
+        when(managerService.evaluate(any(), any())).thenReturn(List.of(decision));
 
         orchestrator.processEvent(queueEntry);
 
@@ -129,7 +129,7 @@ class PipelineOrchestratorTest {
         ManagerDecision decision = new ManagerDecision(
                 "create_task", "review", null,
                 "Review this PR", 0.9, "New PR needs review");
-        when(managerService.evaluate(any())).thenReturn(List.of(decision));
+        when(managerService.evaluate(any(), any())).thenReturn(List.of(decision));
 
         orchestrator.processEvent(queueEntry);
 
@@ -150,7 +150,7 @@ class PipelineOrchestratorTest {
         ManagerDecision decision = new ManagerDecision(
                 "create_task", "analyze", null,
                 "Analyze this", 0.9, "Needs analysis");
-        when(managerService.evaluate(any())).thenReturn(List.of(decision));
+        when(managerService.evaluate(any(), any())).thenReturn(List.of(decision));
 
         orchestrator.processEvent(queueEntry);
 
@@ -173,7 +173,7 @@ class PipelineOrchestratorTest {
                 new ManagerDecision("create_task", "analyze", null,
                         "Analyze this issue", 0.88, "New issue needs analysis")
         );
-        when(managerService.evaluate(any())).thenReturn(decisions);
+        when(managerService.evaluate(any(), any())).thenReturn(decisions);
 
         orchestrator.processEvent(queueEntry);
 
@@ -196,7 +196,7 @@ class PipelineOrchestratorTest {
 
         ManagerDecision decision = new ManagerDecision(
                 "ignore", null, null, null, 0.98, "Bot comment, ignoring");
-        when(managerService.evaluate(any())).thenReturn(List.of(decision));
+        when(managerService.evaluate(any(), any())).thenReturn(List.of(decision));
 
         orchestrator.processEvent(queueEntry);
 
@@ -227,7 +227,7 @@ class PipelineOrchestratorTest {
 
         ManagerDecision decision = new ManagerDecision(
                 "script_action", "close-project", null, null, 0.9, "Issue closed");
-        when(managerService.evaluate(any())).thenReturn(List.of(decision));
+        when(managerService.evaluate(any(), any())).thenReturn(List.of(decision));
 
         orchestrator.processEvent(queueEntry);
 
@@ -252,7 +252,7 @@ class PipelineOrchestratorTest {
 
         ManagerDecision decision = new ManagerDecision(
                 "script_action", "reopen-project", null, null, 0.85, "Issue reopened");
-        when(managerService.evaluate(any())).thenReturn(List.of(decision));
+        when(managerService.evaluate(any(), any())).thenReturn(List.of(decision));
 
         orchestrator.processEvent(queueEntry);
 
@@ -272,7 +272,7 @@ class PipelineOrchestratorTest {
 
         ManagerDecision decision = new ManagerDecision(
                 "escalate", null, null, null, 0.4, "Not sure what to do");
-        when(managerService.evaluate(any())).thenReturn(List.of(decision));
+        when(managerService.evaluate(any(), any())).thenReturn(List.of(decision));
 
         orchestrator.processEvent(queueEntry);
 
@@ -295,7 +295,7 @@ class PipelineOrchestratorTest {
         ManagerDecision decision = new ManagerDecision(
                 "create_task", "implement", null,
                 "Implement something", 0.3, "Low confidence guess");
-        when(managerService.evaluate(any())).thenReturn(List.of(decision));
+        when(managerService.evaluate(any(), any())).thenReturn(List.of(decision));
         when(managerService.meetsConfidenceThreshold(any())).thenReturn(false);
 
         orchestrator.processEvent(queueEntry);
@@ -324,7 +324,7 @@ class PipelineOrchestratorTest {
                 "TestOrg/pipeline-test",
                 "{\"action\":\"edited\"}");
 
-        when(managerService.evaluate(any())).thenReturn(Collections.emptyList());
+        when(managerService.evaluate(any(), any())).thenReturn(Collections.emptyList());
 
         orchestrator.processEvent(queueEntry);
 
@@ -349,7 +349,7 @@ class PipelineOrchestratorTest {
         ManagerDecision decision = new ManagerDecision(
                 "create_task", "analyze", null,
                 "Analyze this", 0.95, "Testing activity logging");
-        when(managerService.evaluate(any())).thenReturn(List.of(decision));
+        when(managerService.evaluate(any(), any())).thenReturn(List.of(decision));
 
         orchestrator.processEvent(queueEntry);
 

--- a/app/src/test/java/io/apitomy/axiom/app/TraceServiceTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/TraceServiceTest.java
@@ -1,0 +1,262 @@
+package io.apitomy.axiom.app;
+
+import io.apitomy.axiom.core.entities.TraceEntity;
+import io.apitomy.axiom.core.entities.TraceNodeEntity;
+import io.apitomy.axiom.core.tracing.TraceContext;
+import io.apitomy.axiom.core.tracing.TraceService;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link TraceService}. Verifies trace and node lifecycle operations
+ * including creation, completion, and parent-child relationships.
+ */
+@QuarkusTest
+class TraceServiceTest {
+
+    @Inject
+    TraceService traceService;
+
+    @AfterEach
+    @Transactional
+    void cleanup() {
+        TraceNodeEntity.deleteAll();
+        TraceEntity.deleteAll();
+    }
+
+    @Test
+    void createTraceCreatesTraceAndRootNode() {
+        TraceContext ctx = traceService.createTrace("event-pipeline",
+                "Processing test event", 1L, null, null,
+                "event-ingested", "Event received: test-event");
+
+        assertNotNull(ctx);
+        assertNotNull(ctx.traceId());
+        assertNotNull(ctx.currentParentNodeId());
+
+        TraceEntity trace = TraceEntity.findById(ctx.traceId());
+        assertNotNull(trace);
+        assertEquals("event-pipeline", trace.traceType);
+        assertEquals("in-progress", trace.status);
+        assertEquals("Processing test event", trace.summary);
+        assertEquals(1L, trace.eventId);
+        assertNull(trace.projectId);
+        assertNull(trace.reportId);
+        assertNotNull(trace.startedOn);
+        assertNull(trace.completedOn);
+
+        TraceNodeEntity rootNode = TraceNodeEntity.findById(ctx.currentParentNodeId());
+        assertNotNull(rootNode);
+        assertEquals(ctx.traceId(), rootNode.traceId);
+        assertNull(rootNode.parentNodeId);
+        assertEquals("event-ingested", rootNode.nodeType);
+        assertEquals("completed", rootNode.status);
+        assertEquals("Event received: test-event", rootNode.summary);
+        assertNotNull(rootNode.startedOn);
+        assertNotNull(rootNode.completedOn);
+        assertEquals(0L, rootNode.durationMs);
+    }
+
+    @Test
+    void addNodeCreatesChildWithCorrectParent() {
+        TraceContext ctx = traceService.createTrace("test", "test trace",
+                null, null, null, "root", "root node");
+
+        Long childId = traceService.addNode(ctx, "manager-evaluation", "in-progress",
+                "Evaluating event", "activity-log", 42L);
+
+        assertNotNull(childId);
+
+        TraceNodeEntity child = TraceNodeEntity.findById(childId);
+        assertNotNull(child);
+        assertEquals(ctx.traceId(), child.traceId);
+        assertEquals(ctx.currentParentNodeId(), child.parentNodeId);
+        assertEquals("manager-evaluation", child.nodeType);
+        assertEquals("in-progress", child.status);
+        assertEquals("Evaluating event", child.summary);
+        assertEquals("activity-log", child.entityType);
+        assertEquals(42L, child.entityId);
+        assertNotNull(child.startedOn);
+        assertNull(child.completedOn);
+    }
+
+    @Test
+    void addNodeRespectsStackForNestedChildren() {
+        TraceContext ctx = traceService.createTrace("test", "test trace",
+                null, null, null, "root", "root node");
+        Long rootNodeId = ctx.currentParentNodeId();
+
+        Long decisionId = traceService.addNode(ctx, "decision", "in-progress",
+                "Decision 1", null, null);
+        ctx.push(decisionId);
+
+        Long taskId = traceService.addNode(ctx, "task-created", "completed",
+                "Task created", "task", 10L);
+
+        // Verify parent chain
+        TraceNodeEntity decisionNode = TraceNodeEntity.findById(decisionId);
+        assertEquals(rootNodeId, decisionNode.parentNodeId);
+
+        TraceNodeEntity taskNode = TraceNodeEntity.findById(taskId);
+        assertEquals(decisionId, taskNode.parentNodeId);
+
+        ctx.pop();
+
+        // After pop, next child is under root again
+        Long secondDecisionId = traceService.addNode(ctx, "decision", "in-progress",
+                "Decision 2", null, null);
+        TraceNodeEntity secondDecision = TraceNodeEntity.findById(secondDecisionId);
+        assertEquals(rootNodeId, secondDecision.parentNodeId);
+    }
+
+    @Test
+    void completeNodeSetsTimingAndStatus() {
+        TraceContext ctx = traceService.createTrace("test", "test trace",
+                null, null, null, "root", "root node");
+        Long nodeId = traceService.addNode(ctx, "work-item", "in-progress",
+                "Doing work", null, null);
+
+        traceService.completeNode(nodeId, "completed");
+
+        TraceNodeEntity node = TraceNodeEntity.findById(nodeId);
+        assertNotNull(node);
+        assertEquals("completed", node.status);
+        assertNotNull(node.completedOn);
+        assertNotNull(node.durationMs);
+        assertTrue(node.durationMs >= 0);
+    }
+
+    @Test
+    void completeNodeWithEntityRefSetsEntityFields() {
+        TraceContext ctx = traceService.createTrace("test", "test trace",
+                null, null, null, "root", "root node");
+        Long nodeId = traceService.addNode(ctx, "manager-evaluation", "in-progress",
+                "Evaluating", null, null);
+
+        traceService.completeNode(nodeId, "completed", "activity-log", 99L);
+
+        TraceNodeEntity node = TraceNodeEntity.findById(nodeId);
+        assertNotNull(node);
+        assertEquals("completed", node.status);
+        assertEquals("activity-log", node.entityType);
+        assertEquals(99L, node.entityId);
+        assertNotNull(node.completedOn);
+    }
+
+    @Test
+    void completeTraceSetsCompletionFields() {
+        TraceContext ctx = traceService.createTrace("test", "test trace",
+                null, null, null, "root", "root node");
+
+        traceService.completeTrace(ctx.traceId(), "completed");
+
+        TraceEntity trace = TraceEntity.findById(ctx.traceId());
+        assertNotNull(trace);
+        assertEquals("completed", trace.status);
+        assertNotNull(trace.completedOn);
+    }
+
+    @Test
+    void completeTraceWithFailedStatus() {
+        TraceContext ctx = traceService.createTrace("test", "test trace",
+                null, null, null, "root", "root node");
+
+        traceService.completeTrace(ctx.traceId(), "failed");
+
+        TraceEntity trace = TraceEntity.findById(ctx.traceId());
+        assertEquals("failed", trace.status);
+    }
+
+    @Test
+    void completeNodeHandlesMissingNodeGracefully() {
+        // Should not throw — just logs a warning
+        traceService.completeNode(999999L, "completed");
+        traceService.completeNode(999999L, "completed", "task", 1L);
+    }
+
+    @Test
+    void completeTraceHandlesMissingTraceGracefully() {
+        // Should not throw — just logs a warning
+        traceService.completeTrace(UUID.randomUUID(), "completed");
+    }
+
+    @Test
+    void fullPipelineFlow() {
+        // Simulate a complete event pipeline trace
+        TraceContext ctx = traceService.createTrace("event-pipeline",
+                "Processing event #1", 1L, null, null,
+                "event-ingested", "Event received: issue-opened");
+
+        // Manager evaluation
+        Long evalNodeId = traceService.addNode(ctx, "manager-evaluation", "in-progress",
+                "Manager evaluating event", null, null);
+        traceService.completeNode(evalNodeId, "completed", "activity-log", 10L);
+
+        // Decision 1: create_task
+        Long decisionNodeId = traceService.addNode(ctx, "decision-processed", "in-progress",
+                "create_task: implement-feature", null, null);
+        ctx.push(decisionNodeId);
+
+        Long taskCreatedId = traceService.addNode(ctx, "task-created", "completed",
+                "Created task: implement-feature", "task", 100L);
+        traceService.completeNode(decisionNodeId, "completed");
+        ctx.pop();
+
+        // Don't complete trace (async task pending)
+
+        // Verify the tree structure
+        List<TraceNodeEntity> nodes = TraceNodeEntity.list(
+                "traceId = ?1 order by id asc", ctx.traceId());
+        assertEquals(4, nodes.size());
+
+        TraceNodeEntity root = nodes.get(0);
+        assertNull(root.parentNodeId);
+        assertEquals("event-ingested", root.nodeType);
+
+        TraceNodeEntity eval = nodes.get(1);
+        assertEquals(root.id, eval.parentNodeId);
+        assertEquals("manager-evaluation", eval.nodeType);
+        assertEquals("activity-log", eval.entityType);
+        assertEquals(10L, eval.entityId);
+
+        TraceNodeEntity decision = nodes.get(2);
+        assertEquals(root.id, decision.parentNodeId);
+        assertEquals("decision-processed", decision.nodeType);
+
+        TraceNodeEntity taskCreated = nodes.get(3);
+        assertEquals(decisionNodeId, taskCreated.parentNodeId);
+        assertEquals("task-created", taskCreated.nodeType);
+        assertEquals("task", taskCreated.entityType);
+        assertEquals(100L, taskCreated.entityId);
+
+        // Trace is still in-progress (async task) — use HQL query to bypass L1 cache
+        assertEquals(1, TraceEntity.count("traceId = ?1 and status = 'in-progress'", ctx.traceId()));
+
+        // Simulate async task completion
+        traceService.completeTrace(ctx.traceId(), "completed");
+        assertEquals(1, TraceEntity.count("traceId = ?1 and status = 'completed'", ctx.traceId()));
+    }
+
+    @Test
+    void createTraceTruncatesLongSummary() {
+        String longSummary = "A".repeat(2000);
+        TraceContext ctx = traceService.createTrace("test", longSummary,
+                null, null, null, "root", longSummary);
+
+        TraceEntity trace = TraceEntity.findById(ctx.traceId());
+        assertTrue(trace.summary.length() <= 1024);
+        assertTrue(trace.summary.endsWith("..."));
+
+        TraceNodeEntity rootNode = TraceNodeEntity.findById(ctx.currentParentNodeId());
+        assertTrue(rootNode.summary.length() <= 1024);
+        assertTrue(rootNode.summary.endsWith("..."));
+    }
+}

--- a/core/src/main/java/io/apitomy/axiom/core/tracing/TraceService.java
+++ b/core/src/main/java/io/apitomy/axiom/core/tracing/TraceService.java
@@ -1,0 +1,175 @@
+package io.apitomy.axiom.core.tracing;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
+import org.jboss.logging.Logger;
+
+import io.apitomy.axiom.core.entities.TraceEntity;
+import io.apitomy.axiom.core.entities.TraceNodeEntity;
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Central service for creating and managing execution traces. All write
+ * operations use {@code QuarkusTransaction.requiringNew()} so trace data
+ * is persisted even if the caller's transaction rolls back.
+ */
+@ApplicationScoped
+public class TraceService {
+
+    private static final Logger LOG = Logger.getLogger(TraceService.class);
+
+    /**
+     * Creates a new trace and its root node.
+     *
+     * @param traceType       trace category (e.g. "event-pipeline")
+     * @param summary         human-readable trace summary
+     * @param eventId         associated event ID (nullable)
+     * @param projectId       associated project ID (nullable)
+     * @param reportId        associated report ID (nullable)
+     * @param rootNodeType    node type for the root node
+     * @param rootNodeSummary summary for the root node
+     * @return a {@link TraceContext} with the root node on the stack
+     */
+    public TraceContext createTrace(String traceType, String summary,
+            Long eventId, Long projectId, Long reportId,
+            String rootNodeType, String rootNodeSummary) {
+        return QuarkusTransaction.requiringNew().call(() -> {
+            Instant now = Instant.now();
+
+            TraceEntity trace = new TraceEntity();
+            trace.traceId = UUID.randomUUID();
+            trace.traceType = traceType;
+            trace.status = "in-progress";
+            trace.summary = truncate(summary, 1024);
+            trace.eventId = eventId;
+            trace.projectId = projectId;
+            trace.reportId = reportId;
+            trace.startedOn = now;
+            trace.persist();
+
+            TraceNodeEntity rootNode = new TraceNodeEntity();
+            rootNode.traceId = trace.traceId;
+            rootNode.parentNodeId = null;
+            rootNode.nodeType = rootNodeType;
+            rootNode.status = "completed";
+            rootNode.summary = truncate(rootNodeSummary, 1024);
+            rootNode.startedOn = now;
+            rootNode.completedOn = now;
+            rootNode.durationMs = 0L;
+            rootNode.persist();
+
+            LOG.debugf("Created trace %s (%s) with root node %d",
+                    trace.traceId, traceType, rootNode.id);
+            return new TraceContext(trace.traceId, rootNode.id);
+        });
+    }
+
+    /**
+     * Adds a child node to an existing trace. The parent is determined by
+     * {@code ctx.currentParentNodeId()} (top of the context stack).
+     *
+     * @param ctx        current trace context
+     * @param nodeType   node type identifier
+     * @param status     initial status (e.g. "in-progress", "completed")
+     * @param summary    human-readable node summary
+     * @param entityType type of the referenced detail entity (nullable)
+     * @param entityId   ID of the referenced detail entity (nullable)
+     * @return the new node's ID
+     */
+    public Long addNode(TraceContext ctx, String nodeType, String status,
+            String summary, String entityType, Long entityId) {
+        return QuarkusTransaction.requiringNew().call(() -> {
+            TraceNodeEntity node = new TraceNodeEntity();
+            node.traceId = ctx.traceId();
+            node.parentNodeId = ctx.currentParentNodeId();
+            node.nodeType = nodeType;
+            node.status = status;
+            node.summary = truncate(summary, 1024);
+            node.startedOn = Instant.now();
+            node.entityType = entityType;
+            node.entityId = entityId;
+            node.persist();
+
+            LOG.debugf("Added trace node %d (%s) to trace %s under parent %d",
+                    node.id, nodeType, ctx.traceId(), node.parentNodeId);
+            return node.id;
+        });
+    }
+
+    /**
+     * Completes a trace node by setting its completion timestamp, duration,
+     * and final status.
+     *
+     * @param nodeId the node to complete
+     * @param status final status (e.g. "completed", "failed")
+     */
+    public void completeNode(Long nodeId, String status) {
+        QuarkusTransaction.requiringNew().run(() -> {
+            TraceNodeEntity node = TraceNodeEntity.findById(nodeId);
+            if (node == null) {
+                LOG.warnf("Trace node %d not found for completion", nodeId);
+                return;
+            }
+            Instant now = Instant.now();
+            node.completedOn = now;
+            node.durationMs = Duration.between(node.startedOn, now).toMillis();
+            node.status = status;
+        });
+    }
+
+    /**
+     * Completes a trace node and sets its entity reference. Use this overload
+     * when the referenced entity is not known at node creation time.
+     *
+     * @param nodeId     the node to complete
+     * @param status     final status
+     * @param entityType type of the referenced detail entity
+     * @param entityId   ID of the referenced detail entity
+     */
+    public void completeNode(Long nodeId, String status,
+            String entityType, Long entityId) {
+        QuarkusTransaction.requiringNew().run(() -> {
+            TraceNodeEntity node = TraceNodeEntity.findById(nodeId);
+            if (node == null) {
+                LOG.warnf("Trace node %d not found for completion", nodeId);
+                return;
+            }
+            Instant now = Instant.now();
+            node.completedOn = now;
+            node.durationMs = Duration.between(node.startedOn, now).toMillis();
+            node.status = status;
+            node.entityType = entityType;
+            node.entityId = entityId;
+        });
+    }
+
+    /**
+     * Completes the trace itself by setting its completion timestamp and
+     * final status.
+     *
+     * @param traceId the trace to complete
+     * @param status  final status (e.g. "completed", "failed")
+     */
+    public void completeTrace(UUID traceId, String status) {
+        QuarkusTransaction.requiringNew().run(() -> {
+            TraceEntity trace = TraceEntity.findById(traceId);
+            if (trace == null) {
+                LOG.warnf("Trace %s not found for completion", traceId);
+                return;
+            }
+            trace.completedOn = Instant.now();
+            trace.status = status;
+            LOG.debugf("Completed trace %s with status %s", traceId, status);
+        });
+    }
+
+    private static String truncate(String value, int maxLength) {
+        if (value == null || value.length() <= maxLength) {
+            return value;
+        }
+        return value.substring(0, maxLength - 3) + "...";
+    }
+}

--- a/manager/src/main/java/io/apitomy/axiom/manager/ManagerService.java
+++ b/manager/src/main/java/io/apitomy/axiom/manager/ManagerService.java
@@ -2,6 +2,8 @@ package io.apitomy.axiom.manager;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.apitomy.axiom.core.tracing.TraceContext;
+import io.apitomy.axiom.core.tracing.TraceService;
 import io.apitomy.axiom.core.entities.ActionTypeEntity;
 import io.apitomy.axiom.core.entities.ActivityLogEntity;
 import io.apitomy.axiom.core.entities.AiUsageEntity;
@@ -41,6 +43,9 @@ public class ManagerService {
     @Inject
     AiEngine aiEngine;
 
+    @Inject
+    TraceService traceService;
+
     @ConfigProperty(name = "axiom.manager.confidence-threshold", defaultValue = "0.7")
     double confidenceThreshold;
 
@@ -56,11 +61,23 @@ public class ManagerService {
     /**
      * Evaluates an event and returns the Manager's decisions.
      *
-     * @param event the event to evaluate
+     * @param event    the event to evaluate
+     * @param traceCtx the current trace context (nullable — tracing is non-fatal)
      * @return a list of decisions (may be empty if the Manager fails)
      */
-    public List<ManagerDecision> evaluate(EventEntity event) {
+    public List<ManagerDecision> evaluate(EventEntity event, TraceContext traceCtx) {
         LOG.infof("Manager evaluating event %d: %s [%s]", event.id, event.eventType, event.issueRef);
+
+        // Add manager-evaluation trace node
+        Long evalNodeId = null;
+        if (traceCtx != null) {
+            try {
+                evalNodeId = traceService.addNode(traceCtx, "manager-evaluation", "in-progress",
+                        "Manager evaluating event: " + event.eventType, null, null);
+            } catch (Exception e) {
+                LOG.warnf(e, "Failed to add manager-evaluation trace node for event %d", event.id);
+            }
+        }
 
         // Load context
         List<ActionTypeEntity> actionTypes = ActionTypeEntity.list("managerTriggerable", true);
@@ -123,6 +140,7 @@ public class ManagerService {
                 logManagerActivity(event.id, "manager-error",
                         "Manager failed to evaluate event: " + result.result(),
                         executionLog);
+                completeEvalNode(evalNodeId, "failed", null);
                 return Collections.emptyList();
             }
 
@@ -144,7 +162,9 @@ public class ManagerService {
             String summaryText = decisions.isEmpty()
                     ? "Manager returned no decisions for event " + event.id
                     : "Manager decisions for event " + event.id + ": " + summary;
-            logManagerActivity(event.id, "manager-evaluated", summaryText, executionLog);
+            Long activityLogId = logManagerActivity(event.id, "manager-evaluated",
+                    summaryText, executionLog);
+            completeEvalNode(evalNodeId, "completed", activityLogId);
 
             return decisions;
 
@@ -152,7 +172,26 @@ public class ManagerService {
             LOG.errorf(e, "Manager evaluation failed for event %d", event.id);
             logManagerActivity(event.id, "manager-error",
                     "Manager evaluation error: " + e.getMessage(), null);
+            completeEvalNode(evalNodeId, "failed", null);
             return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Completes the manager-evaluation trace node (non-fatal).
+     */
+    private void completeEvalNode(Long evalNodeId, String status, Long activityLogId) {
+        if (evalNodeId == null) {
+            return;
+        }
+        try {
+            if (activityLogId != null) {
+                traceService.completeNode(evalNodeId, status, "activity-log", activityLogId);
+            } else {
+                traceService.completeNode(evalNodeId, status);
+            }
+        } catch (Exception e) {
+            LOG.warnf(e, "Failed to complete manager-evaluation trace node %d", evalNodeId);
         }
     }
 
@@ -213,13 +252,14 @@ public class ManagerService {
     /**
      * Logs a manager activity entry with optional execution log details.
      *
-     * @param eventId the event ID
+     * @param eventId   the event ID
      * @param entryType the activity log entry type
-     * @param summary a brief summary
-     * @param details the full execution log (may be null)
+     * @param summary   a brief summary
+     * @param details   the full execution log (may be null)
+     * @return the persisted activity log entry ID
      */
-    void logManagerActivity(Long eventId, String entryType, String summary, String details) {
-        QuarkusTransaction.requiringNew().run(() -> {
+    Long logManagerActivity(Long eventId, String entryType, String summary, String details) {
+        return QuarkusTransaction.requiringNew().call(() -> {
             ActivityLogEntity log = new ActivityLogEntity();
             log.eventId = eventId;
             log.entryType = entryType;
@@ -229,6 +269,7 @@ public class ManagerService {
             log.details = details;
             log.createdOn = Instant.now();
             log.persist();
+            return log.id;
         });
     }
 


### PR DESCRIPTION
## Summary
- Create `TraceService` in core module with `createTrace`, `addNode`, `completeNode`, and `completeTrace` methods, all using `QuarkusTransaction.requiringNew()` for transaction isolation
- Instrument `PipelineOrchestrator` to create end-to-end traces, threading `TraceContext` through all decision handlers and tracking async vs sync completion
- Instrument `ManagerService.evaluate()` to emit "manager-evaluation" trace nodes linked to activity log entries
- Instrument `TaskExecutionService` to create "task-started" nodes and inject `AXIOM_TRACE_ID`/`AXIOM_PARENT_NODE_ID` env vars into MCP config for downstream tool call tracing
- Instrument `ScriptExecutionService` to produce trace nodes for script execution start/completion
- Add 11 unit tests for TraceService covering creation, nesting, completion, and full pipeline flow

## Related Issue
Fixes #46

## Test Plan
- [ ] `./build.sh` passes (260 tests, 0 failures)
- [ ] TraceService unit tests verify trace/node creation, parent-child relationships, completion timing, and entity references
- [ ] Full pipeline flow test simulates event processing and verifies correct trace tree structure
- [ ] Trace data persists even when pipeline processing fails (transaction isolation via `requiringNew()`)
- [ ] Manual verification: process an event and query `trace`/`trace_node` tables to confirm tree structure