### PR TITLE
Tracing: REST API endpoints (#49)

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/rest/EventsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/EventsResourceImpl.java
@@ -4,6 +4,8 @@ import io.apitomy.axiom.api.EventsResource;
 import io.apitomy.axiom.api.beans.Event;
 import io.apitomy.axiom.api.beans.EventSearchResults;
 import io.apitomy.axiom.api.beans.NewEvent;
+import io.apitomy.axiom.api.beans.Trace;
+import io.apitomy.axiom.core.entities.TraceEntity;
 import io.apitomy.axiom.core.entities.EventEntity;
 import io.apitomy.axiom.events.core.EventService;
 import io.quarkus.panache.common.Page;
@@ -99,6 +101,18 @@ public class EventsResourceImpl implements EventsResource {
         return toBean(entity);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Trace> listEventTraces(BigInteger eventId) {
+        return TraceEntity.<TraceEntity>list("eventId", Sort.descending("startedOn"),
+                eventId.longValue())
+                .stream()
+                .map(TraceMapper::toTraceBean)
+                .toList();
+    }
+
     private Event toBean(EventEntity entity) {
         Event event = new Event();
         event.setId(entity.id);
@@ -111,6 +125,9 @@ public class EventsResourceImpl implements EventsResource {
         event.setTaskId(entity.taskId);
         event.setPayload(entity.payload);
         event.setReceivedAt(Date.from(entity.receivedAt));
+        if (entity.traceId != null) {
+            event.setTraceId(entity.traceId);
+        }
         return event;
     }
 }

--- a/app/src/main/java/io/apitomy/axiom/app/rest/ProjectsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/ProjectsResourceImpl.java
@@ -3,6 +3,8 @@ package io.apitomy.axiom.app.rest;
 import io.apitomy.axiom.actors.human.HumanActor;
 import io.apitomy.axiom.api.ProjectsResource;
 import io.apitomy.axiom.api.beans.Event;
+import io.apitomy.axiom.api.beans.Trace;
+import io.apitomy.axiom.core.entities.TraceEntity;
 import io.apitomy.axiom.api.beans.NewProject;
 import io.apitomy.axiom.api.beans.NewThreadEntry;
 import io.apitomy.axiom.api.beans.ProjectMetrics;
@@ -420,6 +422,18 @@ public class ProjectsResourceImpl implements ProjectsResource {
 
     // ── Helpers ───────────────────────────────────────────────────────
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Trace> listProjectTraces(BigInteger projectId) {
+        return TraceEntity.<TraceEntity>list("projectId", Sort.descending("startedOn"),
+                projectId.longValue())
+                .stream()
+                .map(TraceMapper::toTraceBean)
+                .toList();
+    }
+
     private ProjectEntity findProjectOrThrow(long id) {
         ProjectEntity entity = ProjectEntity.findById(id);
         if (entity == null) {
@@ -460,6 +474,9 @@ public class ProjectsResourceImpl implements ProjectsResource {
             task.setCompletedOn(Date.from(entity.completedOn));
         }
         task.setSessionId(entity.sessionId);
+        if (entity.traceId != null) {
+            task.setTraceId(entity.traceId);
+        }
         return task;
     }
 
@@ -485,6 +502,9 @@ public class ProjectsResourceImpl implements ProjectsResource {
         event.setProjectId(entity.projectId);
         event.setTaskId(entity.taskId);
         event.setReceivedAt(Date.from(entity.receivedAt));
+        if (entity.traceId != null) {
+            event.setTraceId(entity.traceId);
+        }
         return event;
     }
 }

--- a/app/src/main/java/io/apitomy/axiom/app/rest/ReportsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/ReportsResourceImpl.java
@@ -1,6 +1,8 @@
 package io.apitomy.axiom.app.rest;
 
 import io.apitomy.axiom.api.ReportsResource;
+import io.apitomy.axiom.api.beans.Trace;
+import io.apitomy.axiom.core.entities.TraceEntity;
 import io.apitomy.axiom.api.beans.NewReportDefinition;
 import io.apitomy.axiom.api.beans.Report;
 import io.apitomy.axiom.api.beans.ReportAiEditRequest;
@@ -298,6 +300,18 @@ public class ReportsResourceImpl implements ReportsResource {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Trace> listReportTraces(BigInteger reportId) {
+        return TraceEntity.<TraceEntity>list("reportId", Sort.descending("startedOn"),
+                reportId.longValue())
+                .stream()
+                .map(TraceMapper::toTraceBean)
+                .toList();
+    }
+
     private ReportDefinitionValidator.KnownNames getKnownNames() {
         Set<String> secrets = SecretEntity.<SecretEntity>listAll().stream()
                 .map(s -> s.name)
@@ -401,6 +415,9 @@ public class ReportsResourceImpl implements ReportsResource {
         report.setCreatedOn(Date.from(entity.createdOn));
         if (entity.completedOn != null) report.setCompletedOn(Date.from(entity.completedOn));
         report.setLabels(entity.labels);
+        if (entity.traceId != null) {
+            report.setTraceId(entity.traceId);
+        }
         return report;
     }
 

--- a/app/src/main/java/io/apitomy/axiom/app/rest/TasksResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/TasksResourceImpl.java
@@ -83,6 +83,9 @@ public class TasksResourceImpl implements TasksResource {
             task.setCompletedOn(Date.from(entity.completedOn));
         }
         task.setSessionId(entity.sessionId);
+        if (entity.traceId != null) {
+            task.setTraceId(entity.traceId);
+        }
         return task;
     }
 }

--- a/app/src/main/java/io/apitomy/axiom/app/rest/TraceMapper.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/TraceMapper.java
@@ -1,0 +1,35 @@
+package io.apitomy.axiom.app.rest;
+
+import io.apitomy.axiom.api.beans.Trace;
+import io.apitomy.axiom.core.entities.TraceEntity;
+
+import java.util.Date;
+
+/**
+ * Shared mapper for converting {@link TraceEntity} to the API {@link Trace} bean.
+ * Used by entity-scoped trace endpoints across multiple resource implementations.
+ */
+final class TraceMapper {
+
+    private TraceMapper() {
+    }
+
+    /**
+     * Converts a {@link TraceEntity} to an API {@link Trace} bean.
+     */
+    static Trace toTraceBean(TraceEntity entity) {
+        Trace bean = new Trace();
+        bean.setTraceId(entity.traceId);
+        bean.setTraceType(entity.traceType);
+        bean.setStatus(entity.status);
+        bean.setSummary(entity.summary);
+        bean.setEventId(entity.eventId);
+        bean.setProjectId(entity.projectId);
+        bean.setReportId(entity.reportId);
+        bean.setStartedOn(Date.from(entity.startedOn));
+        if (entity.completedOn != null) {
+            bean.setCompletedOn(Date.from(entity.completedOn));
+        }
+        return bean;
+    }
+}

--- a/app/src/main/java/io/apitomy/axiom/app/rest/TraceResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/TraceResourceImpl.java
@@ -1,0 +1,283 @@
+package io.apitomy.axiom.app.rest;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.apitomy.axiom.api.TracesResource;
+import io.apitomy.axiom.api.beans.Detail;
+import io.apitomy.axiom.api.beans.ToolCallCompletion;
+import io.apitomy.axiom.api.beans.ToolCallCreated;
+import io.apitomy.axiom.api.beans.ToolCallRequest;
+import io.apitomy.axiom.api.beans.Trace;
+import io.apitomy.axiom.api.beans.TraceDetail;
+import io.apitomy.axiom.api.beans.TraceNode;
+import io.apitomy.axiom.api.beans.TraceNodeDetail;
+import io.apitomy.axiom.api.beans.TraceSearchResults;
+import io.apitomy.axiom.core.entities.ActivityLogEntity;
+import io.apitomy.axiom.core.entities.AiUsageEntity;
+import io.apitomy.axiom.core.entities.EventEntity;
+import io.apitomy.axiom.core.entities.ReportEntity;
+import io.apitomy.axiom.core.entities.TaskEntity;
+import io.apitomy.axiom.core.entities.ToolExecutionEntity;
+import io.apitomy.axiom.core.entities.TraceEntity;
+import io.apitomy.axiom.core.entities.TraceNodeEntity;
+import io.quarkus.panache.common.Page;
+import io.quarkus.panache.common.Sort;
+import io.smallrye.common.annotation.RunOnVirtualThread;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.WebApplicationException;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * REST resource for querying and managing execution traces.
+ */
+@ApplicationScoped
+@RunOnVirtualThread
+public class TraceResourceImpl implements TracesResource {
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @Override
+    public TraceSearchResults listTraces(BigInteger page, BigInteger limit,
+            String filterTraceType, String filterStatus,
+            BigInteger filterEventId, BigInteger filterProjectId,
+            BigInteger filterReportId) {
+        int pageNum = page != null ? page.intValue() : 1;
+        int pageSize = limit != null ? limit.intValue() : 20;
+
+        StringBuilder hql = new StringBuilder("1=1");
+        Map<String, Object> params = new HashMap<>();
+
+        if (filterTraceType != null && !filterTraceType.isBlank()) {
+            hql.append(" and traceType = :traceType");
+            params.put("traceType", filterTraceType);
+        }
+        if (filterStatus != null && !filterStatus.isBlank()) {
+            List<String> statuses = Arrays.stream(filterStatus.split(","))
+                    .map(String::trim).filter(s -> !s.isEmpty()).toList();
+            if (statuses.size() == 1) {
+                hql.append(" and status = :status");
+                params.put("status", statuses.getFirst());
+            } else {
+                hql.append(" and status in :statuses");
+                params.put("statuses", statuses);
+            }
+        }
+        if (filterEventId != null) {
+            hql.append(" and eventId = :eventId");
+            params.put("eventId", filterEventId.longValue());
+        }
+        if (filterProjectId != null) {
+            hql.append(" and projectId = :projectId");
+            params.put("projectId", filterProjectId.longValue());
+        }
+        if (filterReportId != null) {
+            hql.append(" and reportId = :reportId");
+            params.put("reportId", filterReportId.longValue());
+        }
+
+        long totalCount = TraceEntity.count(hql.toString(), params);
+        List<Trace> items = TraceEntity
+                .<TraceEntity>find(hql.toString(), Sort.descending("startedOn"), params)
+                .page(Page.of(pageNum - 1, pageSize))
+                .list()
+                .stream()
+                .map(this::toTraceBean)
+                .toList();
+
+        TraceSearchResults results = new TraceSearchResults();
+        results.setItems(items);
+        results.setTotalCount(totalCount);
+        results.setPage(pageNum);
+        results.setLimit(pageSize);
+        return results;
+    }
+
+    @Override
+    public TraceDetail getTrace(String traceId) {
+        UUID uuid = parseUuid(traceId);
+        TraceEntity trace = TraceEntity.findById(uuid);
+        if (trace == null) {
+            throw new WebApplicationException("Trace not found: " + traceId, 404);
+        }
+
+        List<TraceNode> nodes = TraceNodeEntity
+                .<TraceNodeEntity>find("traceId = ?1 order by startedOn asc", uuid)
+                .list()
+                .stream()
+                .map(this::toNodeBean)
+                .toList();
+
+        TraceDetail detail = new TraceDetail();
+        detail.setTrace(toTraceBean(trace));
+        detail.setNodes(nodes);
+        return detail;
+    }
+
+    @Override
+    public TraceNodeDetail getTraceNodeDetail(String traceId, BigInteger nodeId) {
+        TraceNodeEntity node = TraceNodeEntity.findById(nodeId.longValue());
+        if (node == null || !node.traceId.toString().equals(traceId)) {
+            throw new WebApplicationException("Trace node not found: " + nodeId, 404);
+        }
+
+        TraceNodeDetail result = new TraceNodeDetail();
+        result.setNode(toNodeBean(node));
+        result.setDetail(resolveDetail(node.entityType, node.entityId));
+        return result;
+    }
+
+    @Override
+    public ToolCallCreated createToolCall(ToolCallRequest data) {
+        UUID traceUuid = data.getTraceId();
+        TraceEntity trace = TraceEntity.findById(traceUuid);
+        if (trace == null) {
+            throw new WebApplicationException("Trace not found: " + traceUuid, 404);
+        }
+
+        ToolExecutionEntity toolExec = new ToolExecutionEntity();
+        toolExec.traceId = traceUuid;
+        toolExec.toolName = data.getToolName();
+        toolExec.toolInput = data.getToolInput();
+        toolExec.status = "in-progress";
+        toolExec.createdOn = java.time.Instant.now();
+        toolExec.persist();
+
+        TraceNodeEntity node = new TraceNodeEntity();
+        node.traceId = traceUuid;
+        node.parentNodeId = data.getParentNodeId();
+        node.nodeType = "tool-execution";
+        node.status = "in-progress";
+        node.summary = "Tool: " + data.getToolName();
+        node.startedOn = java.time.Instant.now();
+        node.entityType = "tool-execution";
+        node.entityId = toolExec.id;
+        node.persist();
+
+        ToolCallCreated response = new ToolCallCreated();
+        response.setNodeId(node.id);
+        return response;
+    }
+
+    @Override
+    public void completeToolCall(BigInteger nodeId, ToolCallCompletion data) {
+        TraceNodeEntity node = TraceNodeEntity.findById(nodeId.longValue());
+        if (node == null) {
+            throw new WebApplicationException("Trace node not found: " + nodeId, 404);
+        }
+
+        java.time.Instant now = java.time.Instant.now();
+        node.completedOn = now;
+        node.durationMs = data.getDurationMs();
+        node.status = data.getStatus() != null ? data.getStatus() : "completed";
+
+        if (node.entityType != null && "tool-execution".equals(node.entityType)
+                && node.entityId != null) {
+            ToolExecutionEntity toolExec = ToolExecutionEntity.findById(node.entityId);
+            if (toolExec != null) {
+                toolExec.toolOutput = data.getToolOutput();
+                toolExec.status = node.status;
+                toolExec.durationMs = data.getDurationMs();
+            }
+        }
+    }
+
+    /**
+     * Resolves the detail entity for a trace node based on its entityType.
+     */
+    @SuppressWarnings("unchecked")
+    private Detail resolveDetail(String entityType, Long entityId) {
+        if (entityType == null || entityId == null) {
+            return null;
+        }
+
+        Object entity = switch (entityType) {
+            case "activity-log" -> ActivityLogEntity.findById(entityId);
+            case "event" -> EventEntity.findById(entityId);
+            case "ai-usage" -> AiUsageEntity.findById(entityId);
+            case "tool-execution" -> ToolExecutionEntity.findById(entityId);
+            case "task" -> TaskEntity.findById(entityId);
+            case "report" -> ReportEntity.findById(entityId);
+            default -> null;
+        };
+
+        if (entity == null) {
+            return null;
+        }
+
+        Map<String, Object> properties = objectMapper.convertValue(entity, Map.class);
+        return new DynamicDetail(properties);
+    }
+
+    private Trace toTraceBean(TraceEntity entity) {
+        Trace bean = new Trace();
+        bean.setTraceId(entity.traceId);
+        bean.setTraceType(entity.traceType);
+        bean.setStatus(entity.status);
+        bean.setSummary(entity.summary);
+        bean.setEventId(entity.eventId);
+        bean.setProjectId(entity.projectId);
+        bean.setReportId(entity.reportId);
+        bean.setStartedOn(Date.from(entity.startedOn));
+        if (entity.completedOn != null) {
+            bean.setCompletedOn(Date.from(entity.completedOn));
+        }
+        return bean;
+    }
+
+    private TraceNode toNodeBean(TraceNodeEntity entity) {
+        TraceNode bean = new TraceNode();
+        bean.setId(entity.id);
+        bean.setTraceId(entity.traceId);
+        bean.setParentNodeId(entity.parentNodeId);
+        bean.setNodeType(entity.nodeType);
+        bean.setStatus(entity.status);
+        bean.setSummary(entity.summary);
+        bean.setStartedOn(Date.from(entity.startedOn));
+        if (entity.completedOn != null) {
+            bean.setCompletedOn(Date.from(entity.completedOn));
+        }
+        bean.setDurationMs(entity.durationMs);
+        bean.setEntityType(entity.entityType);
+        bean.setEntityId(entity.entityId);
+        return bean;
+    }
+
+    private UUID parseUuid(String traceId) {
+        try {
+            return UUID.fromString(traceId);
+        } catch (IllegalArgumentException e) {
+            throw new WebApplicationException("Invalid trace ID format: " + traceId, 400);
+        }
+    }
+
+    /**
+     * Extends the generated Detail bean to carry dynamic properties via
+     * Jackson's {@code @JsonAnyGetter}, allowing arbitrary entity fields
+     * to be serialized into the detail object.
+     */
+    private static class DynamicDetail extends Detail {
+
+        private final Map<String, Object> properties;
+
+        DynamicDetail(Map<String, Object> properties) {
+            this.properties = properties;
+        }
+
+        /**
+         * Exposes all entity fields as top-level JSON properties.
+         */
+        @JsonAnyGetter
+        public Map<String, Object> getProperties() {
+            return properties;
+        }
+    }
+}

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -3302,6 +3302,354 @@
           }
         }
       }
+    },
+    "/traces": {
+      "get": {
+        "tags": [
+          "traces"
+        ],
+        "summary": "List traces with pagination and filtering",
+        "operationId": "listTraces",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number (1-indexed)",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Items per page",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "filterTraceType",
+            "in": "query",
+            "description": "Filter by trace type (exact match)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filterStatus",
+            "in": "query",
+            "description": "Filter by status (exact match or comma-separated)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filterEventId",
+            "in": "query",
+            "description": "Filter by event ID",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "filterProjectId",
+            "in": "query",
+            "description": "Filter by project ID",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "filterReportId",
+            "in": "query",
+            "description": "Filter by report ID",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of traces",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TraceSearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/traces/{traceId}": {
+      "get": {
+        "tags": [
+          "traces"
+        ],
+        "summary": "Get a trace with all its nodes",
+        "operationId": "getTrace",
+        "responses": {
+          "200": {
+            "description": "Trace with all nodes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TraceDetail"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Trace not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "traceId",
+          "in": "path",
+          "description": "Trace UUID",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/traces/{traceId}/nodes/{nodeId}": {
+      "get": {
+        "tags": [
+          "traces"
+        ],
+        "summary": "Get a trace node with its referenced detail record",
+        "operationId": "getTraceNodeDetail",
+        "responses": {
+          "200": {
+            "description": "Trace node with detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TraceNodeDetail"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Node not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "traceId",
+          "in": "path",
+          "description": "Trace UUID",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "nodeId",
+          "in": "path",
+          "description": "Trace node ID",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/traces/tool-calls": {
+      "post": {
+        "tags": [
+          "traces"
+        ],
+        "summary": "Record a tool call execution (MCP callback)",
+        "operationId": "createToolCall",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ToolCallRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Tool call recorded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ToolCallCreated"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/traces/tool-calls/{nodeId}": {
+      "put": {
+        "tags": [
+          "traces"
+        ],
+        "summary": "Complete a tool call execution (MCP callback)",
+        "operationId": "completeToolCall",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ToolCallCompletion"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Tool call completed"
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "nodeId",
+          "in": "path",
+          "description": "Tool call node ID",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/events/{eventId}/traces": {
+      "get": {
+        "tags": [
+          "traces"
+        ],
+        "summary": "List traces for an event",
+        "operationId": "listEventTraces",
+        "responses": {
+          "200": {
+            "description": "Traces for event",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Trace"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "eventId",
+          "in": "path",
+          "description": "Event ID",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/projects/{projectId}/traces": {
+      "get": {
+        "tags": [
+          "traces"
+        ],
+        "summary": "List traces for a project",
+        "operationId": "listProjectTraces",
+        "responses": {
+          "200": {
+            "description": "Traces for project",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Trace"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "projectId",
+          "in": "path",
+          "description": "Project ID",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/reports/{reportId}/traces": {
+      "get": {
+        "tags": [
+          "traces"
+        ],
+        "summary": "List traces for a report",
+        "operationId": "listReportTraces",
+        "responses": {
+          "200": {
+            "description": "Traces for report",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Trace"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "reportId",
+          "in": "path",
+          "description": "Report ID",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
     }
   },
   "components": {
@@ -3609,6 +3957,10 @@
           },
           "sessionId": {
             "description": "Claude Code session ID",
+            "type": "string"
+          },
+          "traceId": {
+            "format": "uuid",
             "type": "string"
           }
         }
@@ -3978,6 +4330,10 @@
             "format": "int64",
             "description": "ID of the Event Source that produced this event, if applicable",
             "type": "integer"
+          },
+          "traceId": {
+            "format": "uuid",
+            "type": "string"
           }
         }
       },
@@ -4256,6 +4612,10 @@
             "items": {
               "type": "string"
             }
+          },
+          "traceId": {
+            "format": "uuid",
+            "type": "string"
           }
         }
       },
@@ -5398,6 +5758,239 @@
             }
           }
         }
+      },
+      "Trace": {
+        "required": [
+          "traceId",
+          "traceType",
+          "status",
+          "summary",
+          "startedOn"
+        ],
+        "type": "object",
+        "properties": {
+          "traceId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "traceType": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "eventId": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "projectId": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "reportId": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "startedOn": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "completedOn": {
+            "format": "date-time",
+            "type": "string"
+          }
+        }
+      },
+      "TraceNode": {
+        "required": [
+          "id",
+          "traceId",
+          "nodeType",
+          "status",
+          "summary",
+          "startedOn"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "traceId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "parentNodeId": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "nodeType": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "startedOn": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "completedOn": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "durationMs": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "entityType": {
+            "type": "string"
+          },
+          "entityId": {
+            "format": "int64",
+            "type": "integer"
+          }
+        }
+      },
+      "ToolExecution": {
+        "required": [
+          "id",
+          "traceId",
+          "toolName",
+          "status",
+          "createdOn"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "traceId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "toolName": {
+            "type": "string"
+          },
+          "toolInput": {
+            "type": "string"
+          },
+          "toolOutput": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "durationMs": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "createdOn": {
+            "format": "date-time",
+            "type": "string"
+          }
+        }
+      },
+      "TraceSearchResults": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Trace"
+            }
+          },
+          "totalCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "page": {
+            "type": "integer"
+          },
+          "limit": {
+            "type": "integer"
+          }
+        }
+      },
+      "TraceDetail": {
+        "description": "Trace with all its nodes in tree order",
+        "type": "object",
+        "properties": {
+          "trace": {
+            "$ref": "#/components/schemas/Trace"
+          },
+          "nodes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TraceNode"
+            }
+          }
+        }
+      },
+      "TraceNodeDetail": {
+        "type": "object",
+        "properties": {
+          "node": {
+            "$ref": "#/components/schemas/TraceNode"
+          },
+          "detail": {
+            "description": "The referenced detail record, type depends on entityType",
+            "type": "object"
+          }
+        }
+      },
+      "ToolCallRequest": {
+        "required": [
+          "traceId",
+          "toolName"
+        ],
+        "type": "object",
+        "properties": {
+          "traceId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "parentNodeId": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "toolName": {
+            "type": "string"
+          },
+          "toolInput": {
+            "type": "string"
+          }
+        }
+      },
+      "ToolCallCreated": {
+        "type": "object",
+        "properties": {
+          "nodeId": {
+            "format": "int64",
+            "type": "integer"
+          }
+        }
+      },
+      "ToolCallCompletion": {
+        "type": "object",
+        "properties": {
+          "toolOutput": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "durationMs": {
+            "format": "int64",
+            "type": "integer"
+          }
+        }
       }
     },
     "responses": {
@@ -5513,6 +6106,10 @@
     {
       "name": "Assistant",
       "description": "Interactive AI assistant session management"
+    },
+    {
+      "name": "traces",
+      "description": "Activity tracing and execution lineage"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add 9 new OpenAPI schemas (Trace, TraceNode, ToolExecution, TraceSearchResults, TraceDetail, TraceNodeDetail, ToolCallRequest, ToolCallCreated, ToolCallCompletion) and 8 endpoints for trace querying and tool call callbacks
- Add `traceId` (uuid) property to existing Event, Task, and Report schemas
- Implement `TraceResourceImpl` with paginated/filterable trace listing, trace detail with nodes, node detail with dynamic entity resolution, and tool call callback endpoints
- Add entity-scoped trace endpoints to EventsResourceImpl, ProjectsResourceImpl, and ReportsResourceImpl
- Update all `toBean()` mappers to include `traceId` in API responses

## Related Issue
Fixes #49

## Test Plan
- [ ] `./build.sh` passes (260 tests, 0 failures)
- [ ] Generated JAX-RS interfaces compile with all new schemas and endpoints
- [ ] `GET /api/v1/traces` returns paginated results with filtering support
- [ ] `GET /api/v1/traces/{uuid}` returns trace detail with nodes in chronological order
- [ ] `GET /api/v1/traces/{uuid}/nodes/{id}` returns node with resolved detail entity
- [ ] Entity-scoped endpoints (`/events/{id}/traces`, `/projects/{id}/traces`, `/reports/{id}/traces`) return trace arrays
- [ ] `POST /api/v1/traces/tool-calls` and `PUT /api/v1/traces/tool-calls/{id}` accept expected payloads
- [ ] Event, Task, and Report API responses now include `traceId` when present