### PR TITLE
Tracing: Tool call tracing via MCP server instrumentation (#48)

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/McpConfigGenerator.java
+++ b/app/src/main/java/io/apitomy/axiom/app/McpConfigGenerator.java
@@ -51,7 +51,7 @@ public class McpConfigGenerator {
 
     private static final String MCP_SERVER_DIR_NAME = "mcp-server";
     private static final String[] TEMPLATE_FILES = {
-            "package.json", "sdk-server.js", "tools-server.js" };
+            "package.json", "sdk-server.js", "tools-server.js", "trace-helper.js" };
 
     @ConfigProperty(name = "quarkus.http.port", defaultValue = "9090")
     int httpPort;

--- a/app/src/main/java/io/apitomy/axiom/app/rest/TraceResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/TraceResourceImpl.java
@@ -25,6 +25,7 @@ import io.quarkus.panache.common.Sort;
 import io.smallrye.common.annotation.RunOnVirtualThread;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 import jakarta.ws.rs.WebApplicationException;
 
 import java.math.BigInteger;
@@ -136,6 +137,7 @@ public class TraceResourceImpl implements TracesResource {
     }
 
     @Override
+    @Transactional
     public ToolCallCreated createToolCall(ToolCallRequest data) {
         UUID traceUuid = data.getTraceId();
         TraceEntity trace = TraceEntity.findById(traceUuid);
@@ -168,6 +170,7 @@ public class TraceResourceImpl implements TracesResource {
     }
 
     @Override
+    @Transactional
     public void completeToolCall(BigInteger nodeId, ToolCallCompletion data) {
         TraceNodeEntity node = TraceNodeEntity.findById(nodeId.longValue());
         if (node == null) {

--- a/app/src/main/resources/templates/axiom-mcp-server/sdk-server.js
+++ b/app/src/main/resources/templates/axiom-mcp-server/sdk-server.js
@@ -1,6 +1,7 @@
 const { Server } = require("@modelcontextprotocol/sdk/server/index.js");
 const { StdioServerTransport } = require("@modelcontextprotocol/sdk/server/stdio.js");
 const { ListToolsRequestSchema, CallToolRequestSchema } = require("@modelcontextprotocol/sdk/types.js");
+const { startToolTrace, completeToolTrace } = require(require("path").join(__dirname, "trace-helper.js"));
 
 function log(level, message, data) {
     const entry = {
@@ -367,14 +368,22 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     }
 
     log("INFO", "SDK tool called", { toolName, args: Object.keys(args) });
+    const toolInput = JSON.stringify(args);
+    const traceNodeId = await startToolTrace(toolName, toolInput);
+
+    let result, status = "success";
+    const startTime = Date.now();
     try {
-        const startTime = Date.now();
-        const result = await tool.handler(args);
+        result = await tool.handler(args);
         const durationMs = Date.now() - startTime;
         log("INFO", "SDK tool completed", { toolName, durationMs });
+        await completeToolTrace(traceNodeId, result, status, durationMs);
         return { content: [{ type: "text", text: result || "OK" }] };
     } catch (error) {
+        status = "failure";
+        const durationMs = Date.now() - startTime;
         log("ERROR", "SDK tool failed", { toolName, error: error.message });
+        await completeToolTrace(traceNodeId, error.message, status, durationMs);
         return { content: [{ type: "text", text: error.message }], isError: true };
     }
 });

--- a/app/src/main/resources/templates/axiom-mcp-server/tools-server.js
+++ b/app/src/main/resources/templates/axiom-mcp-server/tools-server.js
@@ -1,6 +1,7 @@
 const { Server } = require("@modelcontextprotocol/sdk/server/index.js");
 const { StdioServerTransport } = require("@modelcontextprotocol/sdk/server/stdio.js");
 const { ListToolsRequestSchema, CallToolRequestSchema } = require("@modelcontextprotocol/sdk/types.js");
+const { startToolTrace, completeToolTrace } = require(require("path").join(__dirname, "trace-helper.js"));
 const { execSync } = require("child_process");
 const fs = require("fs");
 const os = require("os");
@@ -61,6 +62,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     }
 
     log("INFO", "Script tool called", { toolName, args: Object.keys(args) });
+    const toolInput = JSON.stringify(args);
+    const traceNodeId = await startToolTrace(toolName, toolInput);
 
     try {
         let cmd = tool.scriptTemplate;
@@ -93,10 +96,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const durationMs = Date.now() - startTime;
 
         log("INFO", "Script tool completed", { toolName, durationMs, outputLength: (result || "").length });
+        await completeToolTrace(traceNodeId, result, "success", durationMs);
         return { content: [{ type: "text", text: result || "Command completed successfully" }] };
     } catch (error) {
         const msg = error.stderr || error.stdout || error.message || "Command failed";
         log("ERROR", "Script tool failed", { toolName, exitCode: error.status, error: msg.substring(0, 500) });
+        await completeToolTrace(traceNodeId, msg, "failure", 0);
         return { content: [{ type: "text", text: msg }], isError: true };
     }
 });

--- a/app/src/main/resources/templates/axiom-mcp-server/trace-helper.js
+++ b/app/src/main/resources/templates/axiom-mcp-server/trace-helper.js
@@ -1,0 +1,54 @@
+const TRACE_ID = process.env.AXIOM_TRACE_ID;
+const PARENT_NODE_ID = process.env.AXIOM_PARENT_NODE_ID;
+const AXIOM_API_URL = process.env.AXIOM_API_URL;
+
+const MAX_OUTPUT_LENGTH = 10000;
+
+const tracingEnabled = !!(TRACE_ID && PARENT_NODE_ID && AXIOM_API_URL);
+
+async function startToolTrace(toolName, toolInput) {
+    if (!tracingEnabled) return null;
+    try {
+        const resp = await fetch(`${AXIOM_API_URL}/traces/tool-calls`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                traceId: TRACE_ID,
+                parentNodeId: parseInt(PARENT_NODE_ID),
+                toolName: toolName,
+                toolInput: typeof toolInput === "string"
+                    ? toolInput.substring(0, MAX_OUTPUT_LENGTH)
+                    : JSON.stringify(toolInput).substring(0, MAX_OUTPUT_LENGTH)
+            })
+        });
+        if (resp.ok) {
+            const data = await resp.json();
+            return data.nodeId;
+        }
+    } catch (e) {
+        console.error("Trace start failed:", e.message);
+    }
+    return null;
+}
+
+async function completeToolTrace(nodeId, toolOutput, status, durationMs) {
+    if (!nodeId) return;
+    try {
+        const truncatedOutput = typeof toolOutput === "string"
+            ? toolOutput.substring(0, MAX_OUTPUT_LENGTH)
+            : JSON.stringify(toolOutput).substring(0, MAX_OUTPUT_LENGTH);
+        await fetch(`${AXIOM_API_URL}/traces/tool-calls/${nodeId}`, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                toolOutput: truncatedOutput,
+                status: status,
+                durationMs: durationMs
+            })
+        });
+    } catch (e) {
+        console.error("Trace complete failed:", e.message);
+    }
+}
+
+module.exports = { startToolTrace, completeToolTrace, tracingEnabled };


### PR DESCRIPTION
## Summary
- Create shared `trace-helper.js` module with `startToolTrace`/`completeToolTrace` functions for non-fatal trace callbacks with 10K char output truncation
- Wrap `sdk-server.js` and `tools-server.js` `CallToolRequestSchema` handlers to emit trace nodes before/after every tool execution
- Add `trace-helper.js` to `McpConfigGenerator.TEMPLATE_FILES` so it gets copied to the MCP server install directory
- Add `@Transactional` to `TraceResourceImpl.createToolCall()` and `completeToolCall()` to ensure Panache writes are flushed

## Related Issue
Fixes #48

## Test Plan
- [ ] `./build.sh` passes (260 tests, 0 failures) including MCP server integration tests
- [ ] Tool execution works correctly when tracing env vars are absent (graceful no-op)
- [ ] Tool execution works correctly when trace callback fails (non-fatal)
- [ ] Manual: execute a task with MCP tools, verify `trace_node` and `tool_execution` rows created