### PR TITLE
Tracing: UI integration into detail pages (#51)

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -36,6 +36,8 @@ import { EngineSettingsPage } from "./pages/EngineSettingsPage";
 import { EventSourceDetailPage } from "./pages/EventSourceDetailPage";
 import { AssistantPage } from "./pages/AssistantPage";
 import { AssistantSessionPage } from "./pages/AssistantSessionPage";
+import { TracesPage } from "./pages/TracesPage";
+import { TraceDetailPage } from "./pages/TraceDetailPage";
 import { type StartupCheck, fetchSystemHealth, fetchSystemConfig } from "./config/api";
 import { sseClient } from "./config/sse";
 
@@ -102,6 +104,8 @@ export function App() {
                     <Route path="/logs/events" element={<EventsPage />} />
                     <Route path="/logs/manager" element={<ManagerDecisionsPage />} />
                     <Route path="/logs/tasks" element={<TasksPage />} />
+                    <Route path="/logs/traces" element={<TracesPage />} />
+                    <Route path="/logs/traces/:traceId" element={<TraceDetailPage />} />
                     <Route path="/reports" element={<ReportsPage />} />
                     <Route path="/reports/:reportId" element={<ReportDetailPage />} />
                     <Route path="/report-definitions" element={<ReportDefinitionsPage />} />

--- a/ui/src/components/AppSidebar.tsx
+++ b/ui/src/components/AppSidebar.tsx
@@ -47,6 +47,9 @@ export function AppSidebar() {
                             <NavItem isActive={location.pathname === "/logs/tasks"} onClick={() => navigate("/logs/tasks")}>
                                 Tasks
                             </NavItem>
+                            <NavItem isActive={location.pathname.startsWith("/logs/traces")} onClick={() => navigate("/logs/traces")}>
+                                Traces
+                            </NavItem>
                         </NavExpandable>
                         <NavExpandable title="Metrics"
                             isActive={location.pathname.startsWith("/metrics")}

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -80,6 +80,7 @@ export interface Task {
     createdOn: string;
     completedOn?: string;
     sessionId?: string;
+    traceId?: string;
 }
 
 export interface ThreadEntry {
@@ -878,6 +879,7 @@ export interface Report {
     labels?: string[];
     createdOn: string;
     completedOn?: string;
+    traceId?: string;
 }
 
 export interface ReportAiEditRequest {
@@ -1110,6 +1112,7 @@ export interface AxiomEvent {
     taskId?: number;
     payload?: string;
     receivedAt: string;
+    traceId?: string;
 }
 
 export async function fetchEvent(id: number): Promise<AxiomEvent> {

--- a/ui/src/pages/ProjectDetailPage.tsx
+++ b/ui/src/pages/ProjectDetailPage.tsx
@@ -643,6 +643,8 @@ const EVENT_TYPE_COLORS: Record<string, "blue" | "green" | "orange" | "grey" | "
 };
 
 function EventsTab({ events }: { events: AxiomEvent[] }) {
+    const navigate = useNavigate();
+
     if (events.length === 0) {
         return (
             <EmptyState>
@@ -658,6 +660,7 @@ function EventsTab({ events }: { events: AxiomEvent[] }) {
                     <Th>Time</Th>
                     <Th>Source</Th>
                     <Th>Event Type</Th>
+                    <Th>Trace</Th>
                 </Tr>
             </Thead>
             <Tbody>
@@ -674,6 +677,14 @@ function EventsTab({ events }: { events: AxiomEvent[] }) {
                                 color={EVENT_TYPE_COLORS[event.eventType] || "grey"}>
                                 {event.eventType}
                             </Label>
+                        </Td>
+                        <Td>
+                            {event.traceId ? (
+                                <Button variant="link" isInline
+                                    onClick={() => navigate(`/logs/traces/${event.traceId}`)}>
+                                    View Trace
+                                </Button>
+                            ) : "—"}
                         </Td>
                     </Tr>
                 ))}

--- a/ui/src/pages/ReportDetailPage.tsx
+++ b/ui/src/pages/ReportDetailPage.tsx
@@ -33,6 +33,7 @@ import {
 } from "../config/api";
 import { sseClient, type AxiomSseEvent } from "../config/sse";
 import { RenderedReport } from "../components/RenderedReport";
+import { TraceGraph } from "../components/TraceGraph";
 import { ExecutionLogModal } from "../components/ExecutionLogModal";
 import { LabelDisplay } from "../components/LabelDisplay";
 import { EditLabelsModal } from "../components/EditLabelsModal";
@@ -206,6 +207,15 @@ export function ReportDetailPage() {
                         </If>
                     </EmptyStateBody>
                 </EmptyState>
+            )}
+
+            {report.traceId && (
+                <div style={{ marginTop: "24px" }}>
+                    <Title headingLevel="h3" size="md" style={{ marginBottom: "16px" }}>
+                        Execution Trace
+                    </Title>
+                    <TraceGraph traceId={report.traceId} />
+                </div>
             )}
 
             <ExecutionLogModal

--- a/ui/src/pages/TraceDetailPage.tsx
+++ b/ui/src/pages/TraceDetailPage.tsx
@@ -1,0 +1,25 @@
+import { useParams } from "react-router-dom";
+import {
+    Breadcrumb,
+    BreadcrumbItem,
+    PageSection,
+} from "@patternfly/react-core";
+import { TraceGraph } from "../components/TraceGraph";
+
+export function TraceDetailPage() {
+    const { traceId } = useParams<{ traceId: string }>();
+
+    return (
+        <PageSection>
+            <Breadcrumb style={{ marginBottom: "16px" }}>
+                <BreadcrumbItem to="/logs/traces">Traces</BreadcrumbItem>
+                <BreadcrumbItem isActive>
+                    {traceId?.substring(0, 8)}...
+                </BreadcrumbItem>
+            </Breadcrumb>
+            <div style={{ height: "calc(100vh - 200px)" }}>
+                <TraceGraph traceId={traceId!} />
+            </div>
+        </PageSection>
+    );
+}

--- a/ui/src/pages/TracesPage.tsx
+++ b/ui/src/pages/TracesPage.tsx
@@ -20,54 +20,44 @@ import {
     ChipFilterInput,
     FilterChips,
 } from "@apitomy/common-ui-components";
-import { type AxiomEvent, fetchEvents } from "../config/api";
-import { EventDetailModal } from "../components/EventDetailModal";
-
-const SOURCE_COLORS: Record<string, "blue" | "green" | "orange" | "grey"> = {
-    github: "blue",
-    jira: "green",
-    internal: "orange",
-};
+import { type Trace, fetchTraces } from "../config/api";
+import { STATUS_COLORS, formatDuration } from "../components/TraceGraphNode";
 
 const FILTER_TYPES: ChipFilterType[] = [
-    { value: "source", label: "Source", testId: "event-filter-source" },
-    { value: "eventType", label: "Event Type", testId: "event-filter-eventType" },
-    { value: "repository", label: "Repository", testId: "event-filter-repository" },
+    { value: "traceType", label: "Type", testId: "trace-filter-type" },
+    { value: "status", label: "Status", testId: "trace-filter-status" },
 ];
 
-export function EventsPage() {
+export function TracesPage() {
     const navigate = useNavigate();
-    const [events, setEvents] = useState<AxiomEvent[]>([]);
+    const [traces, setTraces] = useState<Trace[]>([]);
     const [totalCount, setTotalCount] = useState(0);
     const [page, setPage] = useState(1);
     const [perPage, setPerPage] = useState(20);
     const [loading, setLoading] = useState(true);
-
     const [filters, setFilters] = useState<ChipFilterCriteria[]>([]);
 
-    // Payload modal
-    const [selectedEvent, setSelectedEvent] = useState<AxiomEvent | null>(null);
-
-    const filterSource = filters.find((f) => f.filterBy.value === "source")?.filterValue;
-    const filterEventType = filters.find((f) => f.filterBy.value === "eventType")?.filterValue;
-    const filterRepository = filters.find((f) => f.filterBy.value === "repository")?.filterValue;
+    const filterTraceType = filters.find((f) => f.filterBy.value === "traceType")?.filterValue;
+    const filterStatuses = filters
+        .filter((f) => f.filterBy.value === "status")
+        .map((f) => f.filterValue)
+        .join(",");
     const isFiltered = filters.length > 0;
 
     const loadData = useCallback(() => {
         setLoading(true);
-        fetchEvents(
+        fetchTraces(
             page, perPage,
-            filterSource || undefined,
-            filterEventType || undefined,
-            filterRepository || undefined
+            filterTraceType || undefined,
+            filterStatuses || undefined
         )
             .then((results) => {
-                setEvents(results.items);
+                setTraces(results.items);
                 setTotalCount(results.totalCount);
             })
             .catch(console.error)
             .finally(() => setLoading(false));
-    }, [page, perPage, filterSource, filterEventType, filterRepository]);
+    }, [page, perPage, filterTraceType, filterStatuses]);
 
     useEffect(() => { loadData(); }, [loadData]);
 
@@ -75,10 +65,14 @@ export function EventsPage() {
         if (!criteria.filterValue) return;
         const updated = filters.filter((f) =>
             !(f.filterBy.value === criteria.filterBy.value && f.filterValue === criteria.filterValue));
-        // All filter types on this page are single-value
-        const withoutSame = updated.filter((f) => f.filterBy.value !== criteria.filterBy.value);
-        withoutSame.push(criteria);
-        setFilters(withoutSame);
+        if (criteria.filterBy.value === "traceType") {
+            const withoutSame = updated.filter((f) => f.filterBy.value !== criteria.filterBy.value);
+            withoutSame.push(criteria);
+            setFilters(withoutSame);
+        } else {
+            updated.push(criteria);
+            setFilters(updated);
+        }
         setPage(1);
     };
 
@@ -95,11 +89,9 @@ export function EventsPage() {
 
     return (
         <PageSection>
-            <Title headingLevel="h1" size="lg" style={{ marginBottom: "16px" }}>
-                Events
-            </Title>
+            <Title headingLevel="h1" size="lg">Traces</Title>
 
-            <Toolbar>
+            <Toolbar style={{ marginTop: "16px" }}>
                 <ToolbarContent>
                     <ToolbarItem>
                         <ChipFilterInput
@@ -139,68 +131,55 @@ export function EventsPage() {
             <div>
                 {loading ? (
                     <EmptyState>
-                        <EmptyStateBody>Loading events...</EmptyStateBody>
+                        <EmptyStateBody>Loading traces...</EmptyStateBody>
                     </EmptyState>
-                ) : events.length === 0 ? (
+                ) : traces.length === 0 ? (
                     <EmptyState>
                         <EmptyStateBody>
                             {isFiltered
-                                ? "No events match the current filters."
-                                : "No events recorded yet."}
+                                ? "No traces match the current filters."
+                                : "No traces yet."}
                         </EmptyStateBody>
                     </EmptyState>
                 ) : (
-                    <Table aria-label="Events" variant="compact">
+                    <Table aria-label="Traces" variant="compact">
                         <Thead>
                             <Tr>
-                                <Th>#</Th>
-                                <Th>Time</Th>
-                                <Th>Source</Th>
-                                <Th>Event Type</Th>
-                                <Th>Repository</Th>
-                                <Th>Issue</Th>
-                                <Th>Project</Th>
-                                <Th>Trace</Th>
+                                <Th>ID</Th>
+                                <Th>Type</Th>
+                                <Th>Status</Th>
+                                <Th>Summary</Th>
+                                <Th>Started</Th>
+                                <Th>Duration</Th>
                             </Tr>
                         </Thead>
                         <Tbody>
-                            {events.map((event) => (
-                                <Tr key={event.id} isClickable
-                                    onRowClick={() => setSelectedEvent(event)}>
-                                    <Td>{event.id}</Td>
-                                    <Td style={{ whiteSpace: "nowrap" }}>
-                                        {new Date(event.receivedAt).toLocaleString()}
+                            {traces.map((trace) => (
+                                <Tr key={trace.traceId}
+                                    isClickable
+                                    onRowClick={() => navigate(`/logs/traces/${trace.traceId}`)}>
+                                    <Td style={{ fontFamily: "monospace", fontSize: "12px" }}>
+                                        {trace.traceId.substring(0, 8)}...
+                                    </Td>
+                                    <Td>
+                                        <Label isCompact>{trace.traceType}</Label>
                                     </Td>
                                     <Td>
                                         <Label isCompact
-                                            color={SOURCE_COLORS[event.source] || "grey"}
-                                            style={{ cursor: "pointer" }}
-                                            onClick={(e) => {
-                                                e.stopPropagation();
-                                                const sourceType = FILTER_TYPES.find((t) => t.value === "source")!;
-                                                onAddFilterCriteria({ filterBy: sourceType, filterValue: event.source });
-                                            }}>
-                                            {event.source}
+                                            color={STATUS_COLORS[trace.status]}>
+                                            {trace.status}
                                         </Label>
                                     </Td>
-                                    <Td>{event.eventType}</Td>
-                                    <Td>{event.repository || "—"}</Td>
-                                    <Td>{event.issueRef || "—"}</Td>
-                                    <Td>
-                                        {event.projectId
-                                            ? `Project #${event.projectId}`
-                                            : "—"}
+                                    <Td>{trace.summary}</Td>
+                                    <Td style={{ whiteSpace: "nowrap" }}>
+                                        {new Date(trace.startedOn).toLocaleString()}
                                     </Td>
                                     <Td>
-                                        {event.traceId ? (
-                                            <Button variant="link" isInline
-                                                onClick={(e) => {
-                                                    e.stopPropagation();
-                                                    navigate(`/logs/traces/${event.traceId}`);
-                                                }}>
-                                                View Trace
-                                            </Button>
-                                        ) : "—"}
+                                        {trace.completedOn && trace.startedOn
+                                            ? formatDuration(
+                                                new Date(trace.completedOn).getTime()
+                                                    - new Date(trace.startedOn).getTime())
+                                            : "—"}
                                     </Td>
                                 </Tr>
                             ))}
@@ -208,11 +187,6 @@ export function EventsPage() {
                     </Table>
                 )}
             </div>
-
-            <EventDetailModal
-                event={selectedEvent}
-                onClose={() => setSelectedEvent(null)}
-            />
         </PageSection>
     );
 }


### PR DESCRIPTION
## Summary
- Add TracesPage (paginated list with type/status filters) and TraceDetailPage (full-height TraceGraph with breadcrumb) at `/logs/traces`
- Add "Traces" entry to sidebar navigation under Logs section
- Add "View Trace" link column to EventsPage and ProjectDetailPage's EventsTab for events with traceId
- Add inline TraceGraph section to ReportDetailPage below report content
- Add `traceId?: string` to AxiomEvent, Task, and Report TypeScript interfaces

## Related Issue
Fixes #51

This completes the entire tracing epic (#36) — all 7 sub-issues (#45-#51).

## Test Plan
- [ ] `cd ui && npm run build` compiles without errors (zero type errors)
- [ ] `./build.sh` passes (260 backend tests)
- [ ] Navigate to Logs > Traces in sidebar, verify paginated list renders
- [ ] Click a trace row, verify TraceDetailPage shows full-height graph
- [ ] Events page shows "View Trace" link for events with traceId
- [ ] Project detail Events tab shows "View Trace" link
- [ ] Report detail page shows inline execution trace graph when traceId set