### PR TITLE
Add real-time SSE updates to Trace Detail page

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/rest/TraceResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/TraceResourceImpl.java
@@ -20,10 +20,12 @@ import io.apitomy.axiom.core.entities.TaskEntity;
 import io.apitomy.axiom.core.entities.ToolExecutionEntity;
 import io.apitomy.axiom.core.entities.TraceEntity;
 import io.apitomy.axiom.core.entities.TraceNodeEntity;
+import io.apitomy.axiom.core.events.SseEvent;
 import io.quarkus.panache.common.Page;
 import io.quarkus.panache.common.Sort;
 import io.smallrye.common.annotation.RunOnVirtualThread;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Event;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.WebApplicationException;
@@ -45,6 +47,9 @@ public class TraceResourceImpl implements TracesResource {
 
     @Inject
     ObjectMapper objectMapper;
+
+    @Inject
+    Event<SseEvent> sseEvents;
 
     @Override
     public TraceSearchResults listTraces(BigInteger page, BigInteger limit,
@@ -164,6 +169,8 @@ public class TraceResourceImpl implements TracesResource {
         node.entityId = toolExec.id;
         node.persist();
 
+        sseEvents.fire(SseEvent.traceUpdated(traceUuid));
+
         ToolCallCreated response = new ToolCallCreated();
         response.setNodeId(node.id);
         return response;
@@ -191,6 +198,8 @@ public class TraceResourceImpl implements TracesResource {
                 toolExec.durationMs = data.getDurationMs();
             }
         }
+
+        sseEvents.fire(SseEvent.traceUpdated(node.traceId));
     }
 
     /**

--- a/app/src/main/java/io/apitomy/axiom/app/rest/TraceResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/TraceResourceImpl.java
@@ -21,13 +21,13 @@ import io.apitomy.axiom.core.entities.ToolExecutionEntity;
 import io.apitomy.axiom.core.entities.TraceEntity;
 import io.apitomy.axiom.core.entities.TraceNodeEntity;
 import io.apitomy.axiom.core.events.SseEvent;
+import io.quarkus.narayana.jta.QuarkusTransaction;
 import io.quarkus.panache.common.Page;
 import io.quarkus.panache.common.Sort;
 import io.smallrye.common.annotation.RunOnVirtualThread;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Event;
 import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
 import jakarta.ws.rs.WebApplicationException;
 
 import java.math.BigInteger;
@@ -142,64 +142,70 @@ public class TraceResourceImpl implements TracesResource {
     }
 
     @Override
-    @Transactional
     public ToolCallCreated createToolCall(ToolCallRequest data) {
         UUID traceUuid = data.getTraceId();
-        TraceEntity trace = TraceEntity.findById(traceUuid);
-        if (trace == null) {
-            throw new WebApplicationException("Trace not found: " + traceUuid, 404);
-        }
 
-        ToolExecutionEntity toolExec = new ToolExecutionEntity();
-        toolExec.traceId = traceUuid;
-        toolExec.toolName = data.getToolName();
-        toolExec.toolInput = data.getToolInput();
-        toolExec.status = "in-progress";
-        toolExec.createdOn = java.time.Instant.now();
-        toolExec.persist();
+        ToolCallCreated response = QuarkusTransaction.requiringNew().call(() -> {
+            TraceEntity trace = TraceEntity.findById(traceUuid);
+            if (trace == null) {
+                throw new WebApplicationException("Trace not found: " + traceUuid, 404);
+            }
 
-        TraceNodeEntity node = new TraceNodeEntity();
-        node.traceId = traceUuid;
-        node.parentNodeId = data.getParentNodeId();
-        node.nodeType = "tool-execution";
-        node.status = "in-progress";
-        node.summary = "Tool: " + data.getToolName();
-        node.startedOn = java.time.Instant.now();
-        node.entityType = "tool-execution";
-        node.entityId = toolExec.id;
-        node.persist();
+            ToolExecutionEntity toolExec = new ToolExecutionEntity();
+            toolExec.traceId = traceUuid;
+            toolExec.toolName = data.getToolName();
+            toolExec.toolInput = data.getToolInput();
+            toolExec.status = "in-progress";
+            toolExec.createdOn = java.time.Instant.now();
+            toolExec.persist();
+
+            TraceNodeEntity node = new TraceNodeEntity();
+            node.traceId = traceUuid;
+            node.parentNodeId = data.getParentNodeId();
+            node.nodeType = "tool-execution";
+            node.status = "in-progress";
+            node.summary = "Tool: " + data.getToolName();
+            node.startedOn = java.time.Instant.now();
+            node.entityType = "tool-execution";
+            node.entityId = toolExec.id;
+            node.persist();
+
+            ToolCallCreated result = new ToolCallCreated();
+            result.setNodeId(node.id);
+            return result;
+        });
 
         sseEvents.fire(SseEvent.traceUpdated(traceUuid));
-
-        ToolCallCreated response = new ToolCallCreated();
-        response.setNodeId(node.id);
         return response;
     }
 
     @Override
-    @Transactional
     public void completeToolCall(BigInteger nodeId, ToolCallCompletion data) {
-        TraceNodeEntity node = TraceNodeEntity.findById(nodeId.longValue());
-        if (node == null) {
-            throw new WebApplicationException("Trace node not found: " + nodeId, 404);
-        }
-
-        java.time.Instant now = java.time.Instant.now();
-        node.completedOn = now;
-        node.durationMs = data.getDurationMs();
-        node.status = data.getStatus() != null ? data.getStatus() : "completed";
-
-        if (node.entityType != null && "tool-execution".equals(node.entityType)
-                && node.entityId != null) {
-            ToolExecutionEntity toolExec = ToolExecutionEntity.findById(node.entityId);
-            if (toolExec != null) {
-                toolExec.toolOutput = data.getToolOutput();
-                toolExec.status = node.status;
-                toolExec.durationMs = data.getDurationMs();
+        UUID traceId = QuarkusTransaction.requiringNew().call(() -> {
+            TraceNodeEntity node = TraceNodeEntity.findById(nodeId.longValue());
+            if (node == null) {
+                throw new WebApplicationException("Trace node not found: " + nodeId, 404);
             }
-        }
 
-        sseEvents.fire(SseEvent.traceUpdated(node.traceId));
+            java.time.Instant now = java.time.Instant.now();
+            node.completedOn = now;
+            node.durationMs = data.getDurationMs();
+            node.status = data.getStatus() != null ? data.getStatus() : "completed";
+
+            if (node.entityType != null && "tool-execution".equals(node.entityType)
+                    && node.entityId != null) {
+                ToolExecutionEntity toolExec = ToolExecutionEntity.findById(node.entityId);
+                if (toolExec != null) {
+                    toolExec.toolOutput = data.getToolOutput();
+                    toolExec.status = node.status;
+                    toolExec.durationMs = data.getDurationMs();
+                }
+            }
+
+            return node.traceId;
+        });
+
+        sseEvents.fire(SseEvent.traceUpdated(traceId));
     }
 
     /**

--- a/app/src/main/resources/templates/axiom-mcp-server/trace-helper.js
+++ b/app/src/main/resources/templates/axiom-mcp-server/trace-helper.js
@@ -2,7 +2,7 @@ const TRACE_ID = process.env.AXIOM_TRACE_ID;
 const PARENT_NODE_ID = process.env.AXIOM_PARENT_NODE_ID;
 const AXIOM_API_URL = process.env.AXIOM_API_URL;
 
-const MAX_OUTPUT_LENGTH = 10000;
+const MAX_OUTPUT_LENGTH = 100000;
 
 const tracingEnabled = !!(TRACE_ID && PARENT_NODE_ID && AXIOM_API_URL);
 

--- a/core/src/main/java/io/apitomy/axiom/core/events/SseEvent.java
+++ b/core/src/main/java/io/apitomy/axiom/core/events/SseEvent.java
@@ -93,6 +93,17 @@ public record SseEvent(
                         + ",\"status\":\"" + status + "\"}");
     }
 
+    /**
+     * Creates a trace-updated event.
+     *
+     * @param traceId the trace that changed
+     * @return a new SSE event
+     */
+    public static SseEvent traceUpdated(java.util.UUID traceId) {
+        return new SseEvent("trace-updated",
+                "{\"traceId\":\"" + traceId + "\"}");
+    }
+
     private static String escapeJson(String s) {
         if (s == null) return "";
         return s.replace("\\", "\\\\")

--- a/core/src/main/java/io/apitomy/axiom/core/events/SseEvent.java
+++ b/core/src/main/java/io/apitomy/axiom/core/events/SseEvent.java
@@ -1,5 +1,7 @@
 package io.apitomy.axiom.core.events;
 
+import java.util.UUID;
+
 /**
  * Represents an event to be sent to connected SSE clients.
  * Fired as a CDI event within the application and broadcast to all SSE subscribers.
@@ -99,7 +101,7 @@ public record SseEvent(
      * @param traceId the trace that changed
      * @return a new SSE event
      */
-    public static SseEvent traceUpdated(java.util.UUID traceId) {
+    public static SseEvent traceUpdated(UUID traceId) {
         return new SseEvent("trace-updated",
                 "{\"traceId\":\"" + traceId + "\"}");
     }

--- a/core/src/main/java/io/apitomy/axiom/core/tracing/TraceService.java
+++ b/core/src/main/java/io/apitomy/axiom/core/tracing/TraceService.java
@@ -122,18 +122,21 @@ public class TraceService {
      * @param status final status (e.g. "completed", "failed")
      */
     public void completeNode(Long nodeId, String status) {
-        QuarkusTransaction.requiringNew().run(() -> {
+        UUID traceId = QuarkusTransaction.requiringNew().call(() -> {
             TraceNodeEntity node = TraceNodeEntity.findById(nodeId);
             if (node == null) {
                 LOG.warnf("Trace node %d not found for completion", nodeId);
-                return;
+                return null;
             }
             Instant now = Instant.now();
             node.completedOn = now;
             node.durationMs = Duration.between(node.startedOn, now).toMillis();
             node.status = status;
-            sseEvents.fire(SseEvent.traceUpdated(node.traceId));
+            return node.traceId;
         });
+        if (traceId != null) {
+            sseEvents.fire(SseEvent.traceUpdated(traceId));
+        }
     }
 
     /**
@@ -147,11 +150,11 @@ public class TraceService {
      */
     public void completeNode(Long nodeId, String status,
             String entityType, Long entityId) {
-        QuarkusTransaction.requiringNew().run(() -> {
+        UUID traceId = QuarkusTransaction.requiringNew().call(() -> {
             TraceNodeEntity node = TraceNodeEntity.findById(nodeId);
             if (node == null) {
                 LOG.warnf("Trace node %d not found for completion", nodeId);
-                return;
+                return null;
             }
             Instant now = Instant.now();
             node.completedOn = now;
@@ -159,8 +162,11 @@ public class TraceService {
             node.status = status;
             node.entityType = entityType;
             node.entityId = entityId;
-            sseEvents.fire(SseEvent.traceUpdated(node.traceId));
+            return node.traceId;
         });
+        if (traceId != null) {
+            sseEvents.fire(SseEvent.traceUpdated(traceId));
+        }
     }
 
     /**
@@ -180,8 +186,8 @@ public class TraceService {
             trace.completedOn = Instant.now();
             trace.status = status;
             LOG.debugf("Completed trace %s with status %s", traceId, status);
-            sseEvents.fire(SseEvent.traceUpdated(traceId));
         });
+        sseEvents.fire(SseEvent.traceUpdated(traceId));
     }
 
     private static String truncate(String value, int maxLength) {

--- a/core/src/main/java/io/apitomy/axiom/core/tracing/TraceService.java
+++ b/core/src/main/java/io/apitomy/axiom/core/tracing/TraceService.java
@@ -8,8 +8,11 @@ import org.jboss.logging.Logger;
 
 import io.apitomy.axiom.core.entities.TraceEntity;
 import io.apitomy.axiom.core.entities.TraceNodeEntity;
+import io.apitomy.axiom.core.events.SseEvent;
 import io.quarkus.narayana.jta.QuarkusTransaction;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Event;
+import jakarta.inject.Inject;
 
 /**
  * Central service for creating and managing execution traces. All write
@@ -20,6 +23,9 @@ import jakarta.enterprise.context.ApplicationScoped;
 public class TraceService {
 
     private static final Logger LOG = Logger.getLogger(TraceService.class);
+
+    @Inject
+    Event<SseEvent> sseEvents;
 
     /**
      * Creates a new trace and its root node.
@@ -39,7 +45,7 @@ public class TraceService {
             Long eventId, Long projectId, Long reportId,
             String rootNodeType, String rootNodeSummary,
             String rootEntityType, Long rootEntityId) {
-        return QuarkusTransaction.requiringNew().call(() -> {
+        TraceContext ctx = QuarkusTransaction.requiringNew().call(() -> {
             Instant now = Instant.now();
 
             TraceEntity trace = new TraceEntity();
@@ -70,6 +76,8 @@ public class TraceService {
                     trace.traceId, traceType, rootNode.id);
             return new TraceContext(trace.traceId, rootNode.id);
         });
+        sseEvents.fire(SseEvent.traceUpdated(ctx.traceId()));
+        return ctx;
     }
 
     /**
@@ -86,7 +94,7 @@ public class TraceService {
      */
     public Long addNode(TraceContext ctx, String nodeType, String status,
             String summary, String entityType, Long entityId) {
-        return QuarkusTransaction.requiringNew().call(() -> {
+        Long nodeId = QuarkusTransaction.requiringNew().call(() -> {
             TraceNodeEntity node = new TraceNodeEntity();
             node.traceId = ctx.traceId();
             node.parentNodeId = ctx.currentParentNodeId();
@@ -102,6 +110,8 @@ public class TraceService {
                     node.id, nodeType, ctx.traceId(), node.parentNodeId);
             return node.id;
         });
+        sseEvents.fire(SseEvent.traceUpdated(ctx.traceId()));
+        return nodeId;
     }
 
     /**
@@ -122,6 +132,7 @@ public class TraceService {
             node.completedOn = now;
             node.durationMs = Duration.between(node.startedOn, now).toMillis();
             node.status = status;
+            sseEvents.fire(SseEvent.traceUpdated(node.traceId));
         });
     }
 
@@ -148,6 +159,7 @@ public class TraceService {
             node.status = status;
             node.entityType = entityType;
             node.entityId = entityId;
+            sseEvents.fire(SseEvent.traceUpdated(node.traceId));
         });
     }
 
@@ -168,6 +180,7 @@ public class TraceService {
             trace.completedOn = Instant.now();
             trace.status = status;
             LOG.debugf("Completed trace %s with status %s", traceId, status);
+            sseEvents.fire(SseEvent.traceUpdated(traceId));
         });
     }
 

--- a/ui/src/components/TraceNodeDetailModal.tsx
+++ b/ui/src/components/TraceNodeDetailModal.tsx
@@ -236,6 +236,7 @@ function ToolExecutionDetail({ detail }: { detail: Record<string, unknown> }) {
                             language={Language.json}
                             isReadOnly
                             height="300px"
+                            options={{ wordWrap: "on" }}
                         />
                     </div>
                 </Tab>
@@ -246,6 +247,7 @@ function ToolExecutionDetail({ detail }: { detail: Record<string, unknown> }) {
                             language={Language.json}
                             isReadOnly
                             height="300px"
+                            options={{ wordWrap: "on" }}
                         />
                     </div>
                 </Tab>

--- a/ui/src/pages/TraceDetailPage.tsx
+++ b/ui/src/pages/TraceDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useParams, Link } from "react-router-dom";
 import {
     Breadcrumb,
@@ -10,10 +10,23 @@ import {
 } from "@patternfly/react-core";
 import SyncAltIcon from "@patternfly/react-icons/dist/esm/icons/sync-alt-icon";
 import { TraceGraph } from "../components/TraceGraph";
+import { sseClient, type AxiomSseEvent } from "../config/sse";
 
 export function TraceDetailPage() {
     const { traceId } = useParams<{ traceId: string }>();
     const [refreshKey, setRefreshKey] = useState(0);
+
+    useEffect(() => {
+        const unsubscribe = sseClient.subscribe((event: AxiomSseEvent) => {
+            if (event.type === "trace-updated") {
+                const data = event.data as { traceId?: string };
+                if (data.traceId === traceId) {
+                    setRefreshKey((k) => k + 1);
+                }
+            }
+        });
+        return unsubscribe;
+    }, [traceId]);
 
     return (
         <PageSection>

--- a/ui/src/pages/TraceDetailPage.tsx
+++ b/ui/src/pages/TraceDetailPage.tsx
@@ -17,15 +17,17 @@ export function TraceDetailPage() {
     const [refreshKey, setRefreshKey] = useState(0);
 
     useEffect(() => {
+        let timeout: ReturnType<typeof setTimeout>;
         const unsubscribe = sseClient.subscribe((event: AxiomSseEvent) => {
             if (event.type === "trace-updated") {
                 const data = event.data as { traceId?: string };
                 if (data.traceId === traceId) {
-                    setRefreshKey((k) => k + 1);
+                    clearTimeout(timeout);
+                    timeout = setTimeout(() => setRefreshKey((k) => k + 1), 300);
                 }
             }
         });
-        return unsubscribe;
+        return () => { clearTimeout(timeout); unsubscribe(); };
     }, [traceId]);
 
     return (


### PR DESCRIPTION
## Summary

- Fire `trace-updated` SSE events from `TraceService` and `TraceResourceImpl` whenever a trace or
  trace node is created, updated, or completed
- `TraceDetailPage` subscribes to these events and auto-refreshes the directed graph in real-time
- Enable word wrap on tool execution Input/Output code editors in the trace node detail modal
- Increase MCP tool output capture limit from 10K to 100K characters to avoid truncation

## Test plan

- [ ] Start app with `dev.sh`, trigger a report, navigate to its execution trace — graph should
      update in real-time as nodes appear and complete
- [ ] Open a tool execution node detail modal — Output tab content should word-wrap instead of
      being clipped
- [ ] Verify `[SSE] Event received: trace-updated` messages appear in browser console