### PR TITLE
Split pipeline transaction to avoid holding DB connection during AI call (#44)

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/PipelineOrchestrator.java
+++ b/app/src/main/java/io/apitomy/axiom/app/PipelineOrchestrator.java
@@ -191,6 +191,12 @@ public class PipelineOrchestrator {
     private void persistFailure(Long queueEntryId, Long eventId,
             String errorMessage, TraceContext traceCtx) {
         QuarkusTransaction.requiringNew().run(() -> {
+            if (traceCtx != null) {
+                EventEntity event = EventEntity.findById(eventId);
+                if (event != null) {
+                    event.traceId = traceCtx.traceId();
+                }
+            }
             logActivity(null, null, eventId, "pipeline-error",
                     "Pipeline error: " + errorMessage);
             completeTraceFailed(traceCtx);

--- a/app/src/main/java/io/apitomy/axiom/app/PipelineOrchestrator.java
+++ b/app/src/main/java/io/apitomy/axiom/app/PipelineOrchestrator.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.apitomy.axiom.core.tracing.TraceContext;
 import io.apitomy.axiom.core.tracing.TraceService;
-import io.apitomy.axiom.core.entities.ActionTypeEntity;
 import io.apitomy.axiom.core.entities.ActivityLogEntity;
 import io.apitomy.axiom.core.entities.EventEntity;
 import io.apitomy.axiom.core.entities.EventQueueEntity;
@@ -20,7 +19,7 @@ import io.quarkus.scheduler.Scheduled;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Event;
 import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
+import io.quarkus.narayana.jta.QuarkusTransaction;
 import org.jboss.logging.Logger;
 
 import java.time.Instant;
@@ -62,8 +61,15 @@ public class PipelineOrchestrator {
     /**
      * Polls the event queue every 5 seconds and processes one pending event at a time.
      * Events are processed sequentially to avoid race conditions in the Manager.
+     *
+     * <p>The pipeline is split into three transactional phases so that the AI engine
+     * call in {@code ManagerService.evaluate()} does not hold a database connection:</p>
+     * <ol>
+     *   <li><b>Dequeue</b> — short transaction to mark the next pending event as "processing"</li>
+     *   <li><b>AI call</b> — no transaction held while the Manager evaluates the event</li>
+     *   <li><b>Persist results</b> — short transaction to process decisions and mark completion</li>
+     * </ol>
      */
-    @Transactional
     @Scheduled(every = "${axiom.pipeline.poll-interval:5s}",
                concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
     void processNextEvent() {
@@ -75,33 +81,49 @@ public class PipelineOrchestrator {
         processEvent(queueEntry);
     }
 
-    // @Transactional is redundant here (runs inside processNextEvent's transaction via
-    // self-invocation) but retained so it takes effect if called through the CDI proxy.
-    @Transactional
+    /**
+     * Finds the next pending event in the queue and marks it as "processing" in a
+     * short independent transaction. Returns {@code null} if the queue is empty.
+     */
     EventQueueEntity findNextPendingEvent() {
-        EventQueueEntity entry = EventQueueEntity.find(
-                "status = 'pending' order by enqueuedAt asc").firstResult();
-        if (entry != null) {
-            entry.status = "processing";
-        }
-        return entry;
+        return QuarkusTransaction.requiringNew().call(() -> {
+            EventQueueEntity entry = EventQueueEntity.find(
+                    "status = 'pending' order by enqueuedAt asc").firstResult();
+            if (entry != null) {
+                entry.status = "processing";
+            }
+            return entry;
+        });
     }
 
-    // @Transactional is redundant here (runs inside processNextEvent's transaction via
-    // self-invocation) but retained so it takes effect if called through the CDI proxy.
-    @Transactional
+    /**
+     * Processes a single queued event through the full pipeline: load the event,
+     * invoke the AI Manager, and persist the resulting decisions.
+     *
+     * <p>The method is intentionally <b>not</b> {@code @Transactional} — each phase
+     * uses a short programmatic transaction so the AI engine call runs without
+     * holding a database connection.</p>
+     *
+     * @param queueEntry the dequeued event (may be detached)
+     */
     void processEvent(EventQueueEntity queueEntry) {
-        EventEntity event = EventEntity.findById(queueEntry.eventId);
+        Long eventId = queueEntry.eventId;
+        Long queueEntryId = queueEntry.id;
+
+        // Phase 1: Load event (short transaction)
+        EventEntity event = QuarkusTransaction.requiringNew().call(() ->
+                EventEntity.findById(eventId));
         if (event == null) {
-            LOG.warnf("Event %d not found for queue entry %d", queueEntry.eventId, queueEntry.id);
-            markQueueEntry(queueEntry.id, "failed");
+            LOG.warnf("Event %d not found for queue entry %d", eventId, queueEntryId);
+            QuarkusTransaction.requiringNew().run(() ->
+                    markQueueEntry(queueEntryId, "failed"));
             return;
         }
 
         LOG.infof("Processing event %d: %s [%s] from %s",
                 event.id, event.eventType, event.issueRef, event.source);
 
-        // Create trace context (non-fatal — pipeline continues if tracing fails)
+        // Trace creation (TraceService manages its own transactions)
         TraceContext traceCtx = null;
         try {
             traceCtx = traceService.createTrace("event-pipeline",
@@ -109,14 +131,35 @@ public class PipelineOrchestrator {
                     event.id, null, null,
                     "event-ingested", "Event received: " + event.eventType,
                     "event", event.id);
-            event.traceId = traceCtx.traceId();
         } catch (Exception e) {
             LOG.warnf(e, "Failed to create trace for event %d", event.id);
         }
 
+        // Phase 2: AI call (no transaction held — database connection released)
         try {
-            // Invoke the Manager
             List<ManagerDecision> decisions = managerService.evaluate(event, traceCtx);
+
+            // Phase 3: Persist results (short transaction)
+            persistResults(queueEntryId, event, decisions, traceCtx);
+
+        } catch (Exception e) {
+            LOG.errorf(e, "Pipeline failed for event %d", event.id);
+            persistFailure(queueEntryId, event.id, e.getMessage(), traceCtx);
+        }
+    }
+
+    /**
+     * Persists the Manager's evaluation results in a single short transaction.
+     * Re-loads the event as a managed entity so that field updates (traceId,
+     * projectId) are tracked by JPA dirty checking.
+     */
+    private void persistResults(Long queueEntryId, EventEntity detachedEvent,
+            List<ManagerDecision> decisions, TraceContext traceCtx) {
+        QuarkusTransaction.requiringNew().run(() -> {
+            EventEntity event = EventEntity.findById(detachedEvent.id);
+            if (traceCtx != null) {
+                event.traceId = traceCtx.traceId();
+            }
 
             if (decisions.isEmpty()) {
                 LOG.infof("Manager returned no decisions for event %d", event.id);
@@ -124,11 +167,10 @@ public class PipelineOrchestrator {
                         "Manager returned no decisions for " + event.eventType);
                 popEvalNode(traceCtx);
                 completeTraceIfSync(traceCtx, false);
-                markQueueEntry(queueEntry.id, "completed");
+                markQueueEntry(queueEntryId, "completed");
                 return;
             }
 
-            // Process each decision (created as children of the manager evaluation node)
             boolean hasAsyncTask = false;
             for (ManagerDecision decision : decisions) {
                 boolean isAsync = processDecision(event, decision, traceCtx);
@@ -139,15 +181,21 @@ public class PipelineOrchestrator {
             popEvalNode(traceCtx);
 
             completeTraceIfSync(traceCtx, hasAsyncTask);
-            markQueueEntry(queueEntry.id, "completed");
+            markQueueEntry(queueEntryId, "completed");
+        });
+    }
 
-        } catch (Exception e) {
-            LOG.errorf(e, "Pipeline failed for event %d", event.id);
-            logActivity(null, null, event.id, "pipeline-error",
-                    "Pipeline error: " + e.getMessage());
+    /**
+     * Persists pipeline failure state in a single short transaction.
+     */
+    private void persistFailure(Long queueEntryId, Long eventId,
+            String errorMessage, TraceContext traceCtx) {
+        QuarkusTransaction.requiringNew().run(() -> {
+            logActivity(null, null, eventId, "pipeline-error",
+                    "Pipeline error: " + errorMessage);
             completeTraceFailed(traceCtx);
-            markQueueEntry(queueEntry.id, "failed");
-        }
+            markQueueEntry(queueEntryId, "failed");
+        });
     }
 
     /**

--- a/app/src/test/java/io/apitomy/axiom/app/PipelineOrchestratorTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/PipelineOrchestratorTest.java
@@ -6,16 +6,19 @@ import io.apitomy.axiom.core.entities.EventQueueEntity;
 import io.apitomy.axiom.core.entities.ProjectEntity;
 import io.apitomy.axiom.core.entities.TaskEntity;
 import io.apitomy.axiom.core.entities.ThreadEntryEntity;
+import io.apitomy.axiom.core.entities.TraceEntity;
+import io.apitomy.axiom.core.entities.TraceNodeEntity;
 import io.apitomy.axiom.core.services.WorkspaceService;
 import io.apitomy.axiom.manager.ManagerDecision;
 import io.apitomy.axiom.manager.ManagerService;
+import io.quarkus.narayana.jta.QuarkusTransaction;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.InjectMock;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.time.Instant;
 import java.util.Collections;
@@ -23,7 +26,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * Integration tests for the PipelineOrchestrator.
@@ -50,10 +53,22 @@ class PipelineOrchestratorTest {
         when(workspaceService.getWorkspacePath(any())).thenReturn(java.nio.file.Path.of("/tmp/test-workspace"));
     }
 
+    @AfterEach
+    @Transactional
+    void cleanup() {
+        ThreadEntryEntity.deleteAll();
+        TraceNodeEntity.deleteAll();
+        TraceEntity.deleteAll();
+        ActivityLogEntity.deleteAll();
+        TaskEntity.deleteAll();
+        ProjectEntity.deleteAll();
+        EventQueueEntity.deleteAll();
+        EventEntity.deleteAll();
+    }
+
     // ── Create Task Decision ──────────────────────────────────────────
 
     @Test
-    @Transactional
     void testCreateTaskDecisionAutoCreatesProject() {
         EventQueueEntity queueEntry = createEventAndEnqueue(
                 "github", "issue-created", "TestOrg/pipeline-test#1",
@@ -91,7 +106,6 @@ class PipelineOrchestratorTest {
     }
 
     @Test
-    @Transactional
     void testCreateTaskOnExistingProject() {
         // Create project first
         ProjectEntity project = createProject("TestOrg/pipeline-test#2", "TestOrg/pipeline-test");
@@ -119,7 +133,6 @@ class PipelineOrchestratorTest {
     }
 
     @Test
-    @Transactional
     void testCreateProjectFromPrEventSetsPullRequestType() {
         EventQueueEntity queueEntry = createEventAndEnqueue(
                 "github", "pr-created", "TestOrg/pipeline-test#10",
@@ -140,7 +153,6 @@ class PipelineOrchestratorTest {
     }
 
     @Test
-    @Transactional
     void testCreateProjectFromUnknownEventSetsOtherType() {
         EventQueueEntity queueEntry = createEventAndEnqueue(
                 "github", "task-completed", "TestOrg/pipeline-test#11",
@@ -160,7 +172,6 @@ class PipelineOrchestratorTest {
     }
 
     @Test
-    @Transactional
     void testMultipleDecisionsFromSingleEvent() {
         EventQueueEntity queueEntry = createEventAndEnqueue(
                 "github", "issue-created", "TestOrg/pipeline-test#3",
@@ -187,7 +198,6 @@ class PipelineOrchestratorTest {
     // ── Ignore Decision ───────────────────────────────────────────────
 
     @Test
-    @Transactional
     void testIgnoreDecision() {
         EventQueueEntity queueEntry = createEventAndEnqueue(
                 "github", "comment-added", "TestOrg/pipeline-test#10",
@@ -215,10 +225,8 @@ class PipelineOrchestratorTest {
     // ── System Action Decisions ───────────────────────────────────────
 
     @Test
-    @Transactional
     void testCloseProjectScriptAction() {
-        ProjectEntity project = createProject("TestOrg/pipeline-test#20", "TestOrg/pipeline-test");
-        project.status = "Idle";
+        ProjectEntity project = createProject("TestOrg/pipeline-test#20", "TestOrg/pipeline-test", "Idle");
 
         EventQueueEntity queueEntry = createEventAndEnqueue(
                 "github", "issue-closed", "TestOrg/pipeline-test#20",
@@ -240,10 +248,8 @@ class PipelineOrchestratorTest {
     }
 
     @Test
-    @Transactional
     void testReopenProjectScriptAction() {
-        ProjectEntity project = createProject("TestOrg/pipeline-test#21", "TestOrg/pipeline-test");
-        project.status = "Completed";
+        ProjectEntity project = createProject("TestOrg/pipeline-test#21", "TestOrg/pipeline-test", "Completed");
 
         EventQueueEntity queueEntry = createEventAndEnqueue(
                 "github", "issue-reopened", "TestOrg/pipeline-test#21",
@@ -263,7 +269,6 @@ class PipelineOrchestratorTest {
     // ── Escalation ────────────────────────────────────────────────────
 
     @Test
-    @Transactional
     void testEscalationDecision() {
         EventQueueEntity queueEntry = createEventAndEnqueue(
                 "github", "issue-updated", "TestOrg/pipeline-test#30",
@@ -282,7 +287,6 @@ class PipelineOrchestratorTest {
     }
 
     @Test
-    @Transactional
     void testLowConfidenceAutoEscalation() {
         ProjectEntity project = createProject("TestOrg/pipeline-test#31", "TestOrg/pipeline-test");
 
@@ -317,7 +321,6 @@ class PipelineOrchestratorTest {
     // ── No Decisions ──────────────────────────────────────────────────
 
     @Test
-    @Transactional
     void testManagerReturnsNoDecisions() {
         EventQueueEntity queueEntry = createEventAndEnqueue(
                 "github", "issue-updated", "TestOrg/pipeline-test#40",
@@ -339,7 +342,6 @@ class PipelineOrchestratorTest {
     // ── Activity Log & Thread Entries ─────────────────────────────────
 
     @Test
-    @Transactional
     void testActivityLogAndThreadEntries() {
         EventQueueEntity queueEntry = createEventAndEnqueue(
                 "github", "issue-created", "TestOrg/pipeline-test#50",
@@ -375,35 +377,43 @@ class PipelineOrchestratorTest {
     private EventQueueEntity createEventAndEnqueue(String source, String eventType,
                                                     String issueRef, String repository,
                                                     String payload) {
-        EventEntity event = new EventEntity();
-        event.source = source;
-        event.eventType = eventType;
-        event.issueRef = issueRef;
-        event.repository = repository;
-        event.payload = payload;
-        event.receivedAt = Instant.now();
-        event.persist();
+        return QuarkusTransaction.requiringNew().call(() -> {
+            EventEntity event = new EventEntity();
+            event.source = source;
+            event.eventType = eventType;
+            event.issueRef = issueRef;
+            event.repository = repository;
+            event.payload = payload;
+            event.receivedAt = Instant.now();
+            event.persist();
 
-        EventQueueEntity queueEntry = new EventQueueEntity();
-        queueEntry.eventId = event.id;
-        queueEntry.status = "pending";
-        queueEntry.enqueuedAt = Instant.now();
-        queueEntry.persist();
+            EventQueueEntity queueEntry = new EventQueueEntity();
+            queueEntry.eventId = event.id;
+            queueEntry.status = "pending";
+            queueEntry.enqueuedAt = Instant.now();
+            queueEntry.persist();
 
-        return queueEntry;
+            return queueEntry;
+        });
     }
 
     private ProjectEntity createProject(String issueRef, String repository) {
-        ProjectEntity project = new ProjectEntity();
-        project.name = issueRef;
-        project.type = "other";
-        project.status = "Created";
-        project.issueSource = "github";
-        project.issueRef = issueRef;
-        project.repository = repository;
-        project.createdOn = Instant.now();
-        project.updatedOn = Instant.now();
-        project.persist();
-        return project;
+        return createProject(issueRef, repository, "Created");
+    }
+
+    private ProjectEntity createProject(String issueRef, String repository, String status) {
+        return QuarkusTransaction.requiringNew().call(() -> {
+            ProjectEntity project = new ProjectEntity();
+            project.name = issueRef;
+            project.type = "other";
+            project.status = status;
+            project.issueSource = "github";
+            project.issueRef = issueRef;
+            project.repository = repository;
+            project.createdOn = Instant.now();
+            project.updatedOn = Instant.now();
+            project.persist();
+            return project;
+        });
     }
 }

--- a/manager/src/main/java/io/apitomy/axiom/manager/ManagerService.java
+++ b/manager/src/main/java/io/apitomy/axiom/manager/ManagerService.java
@@ -61,7 +61,11 @@ public class ManagerService {
     /**
      * Evaluates an event and returns the Manager's decisions.
      *
-     * @param event    the event to evaluate
+     * <p>Context loading (action types, actors, project data, config) runs in a short
+     * independent transaction so the subsequent AI engine call does not hold a database
+     * connection.</p>
+     *
+     * @param event    the event to evaluate (may be detached)
      * @param traceCtx the current trace context (nullable — tracing is non-fatal)
      * @return a list of decisions (may be empty if the Manager fails)
      */
@@ -80,39 +84,42 @@ public class ManagerService {
             }
         }
 
-        // Load context
-        List<ActionTypeEntity> actionTypes = ActionTypeEntity.list("managerTriggerable", true);
-        List<ActorEntity> actors = ActorEntity.listAll();
+        // Load context (short transaction — releases connection before AI call)
+        EvalContext ctx = QuarkusTransaction.requiringNew().call(() -> {
+            List<ActionTypeEntity> actionTypes = ActionTypeEntity.list("managerTriggerable", true);
+            List<ActorEntity> actors = ActorEntity.listAll();
 
-        // Find existing project for this issue
-        ProjectEntity project = null;
-        List<TaskEntity> recentTasks = Collections.emptyList();
-        if (event.issueRef != null) {
-            project = ProjectEntity.find("issueRef", event.issueRef).firstResult();
-            if (project != null) {
-                recentTasks = TaskEntity.find(
-                        "projectId = ?1 order by createdOn desc",
-                        project.id).page(0, 10).list();
+            ProjectEntity project = null;
+            List<TaskEntity> recentTasks = Collections.emptyList();
+            if (event.issueRef != null) {
+                project = ProjectEntity.find("issueRef", event.issueRef).firstResult();
+                if (project != null) {
+                    recentTasks = TaskEntity.find(
+                            "projectId = ?1 order by createdOn desc",
+                            project.id).page(0, 10).list();
+                }
             }
-        }
 
-        // Load manager configuration (system prompt + prompt template)
+            ManagerConfigEntity config = ManagerConfigEntity.<ManagerConfigEntity>findAll()
+                    .firstResult();
+            return new EvalContext(actionTypes, actors, project, recentTasks, config);
+        });
+
+        // Build prompts from detached context (no transaction needed)
         String systemPrompt = ManagerPromptBuilder.DEFAULT_SYSTEM_PROMPT;
         String promptTemplate = ManagerPromptBuilder.DEFAULT_PROMPT_TEMPLATE;
-        ManagerConfigEntity config = ManagerConfigEntity.<ManagerConfigEntity>findAll()
-                .firstResult();
-        if (config != null) {
-            if (config.systemPrompt != null && !config.systemPrompt.isBlank()) {
-                systemPrompt = config.systemPrompt;
+        if (ctx.config() != null) {
+            if (ctx.config().systemPrompt != null && !ctx.config().systemPrompt.isBlank()) {
+                systemPrompt = ctx.config().systemPrompt;
             }
-            if (config.promptTemplate != null && !config.promptTemplate.isBlank()) {
-                promptTemplate = config.promptTemplate;
+            if (ctx.config().promptTemplate != null && !ctx.config().promptTemplate.isBlank()) {
+                promptTemplate = ctx.config().promptTemplate;
             }
         }
 
-        // Build user prompt from template with placeholder substitution
         String userPrompt = ManagerPromptBuilder.buildUserPrompt(
-                promptTemplate, event, actionTypes, actors, project, recentTasks);
+                promptTemplate, event, ctx.actionTypes(), ctx.actors(),
+                ctx.project(), ctx.recentTasks());
         String jsonSchema = ManagerPromptBuilder.getResponseJsonSchema();
 
         // Build engine-agnostic config
@@ -130,7 +137,7 @@ public class ManagerService {
 
             // Record AI usage for this Manager evaluation
             try {
-                recordAiUsage(event.id, project != null ? project.id : null,
+                recordAiUsage(event.id, ctx.project() != null ? ctx.project().id : null,
                         result.costUsd(), result.inputTokens(), result.outputTokens());
             } catch (Exception e) {
                 LOG.warnf(e, "Failed to record AI usage for event %d", event.id);
@@ -177,6 +184,17 @@ public class ManagerService {
             return Collections.emptyList();
         }
     }
+
+    /**
+     * Holds context data loaded in a short transaction before the AI engine call.
+     */
+    private record EvalContext(
+            List<ActionTypeEntity> actionTypes,
+            List<ActorEntity> actors,
+            ProjectEntity project,
+            List<TaskEntity> recentTasks,
+            ManagerConfigEntity config
+    ) {}
 
     /**
      * Completes the manager-evaluation trace node (non-fatal).


### PR DESCRIPTION
## Summary

- **PipelineOrchestrator**: Removed the single `@Transactional` wrapping the entire pipeline
  and replaced it with three short programmatic transactions using
  `QuarkusTransaction.requiringNew()`: (1) dequeue, (2) AI call with no transaction held,
  (3) persist results. Extracted `persistResults()` and `persistFailure()` helper methods.
- **ManagerService**: Wrapped the context-loading JPA reads at the start of `evaluate()`
  in their own short transaction via a new `EvalContext` record, so the database connection
  is released before the AI engine call blocks.
- **PipelineOrchestratorTest**: Adapted to the new transaction model — test data is now
  committed via `QuarkusTransaction.requiringNew()` (matching the `TraceServiceTest` pattern)
  with `@AfterEach` cleanup instead of implicit `@Transactional` rollback.

## Related Issue

Fixes #44

## Test Plan

- [ ] Run `PipelineOrchestratorTest` — all 11 existing tests pass with the refactored transaction
      boundaries
- [ ] Run the full test suite to check for regressions
- [ ] Verify structurally: `processNextEvent()` no longer has `@Transactional`, and the AI call in
      `evaluate()` runs between committed short transactions with no connection held