### PR TITLE
Add documentation for the Tracing feature

### DIFF
--- a/docs/developer-guide/database-and-migrations.md
+++ b/docs/developer-guide/database-and-migrations.md
@@ -55,6 +55,9 @@ record pattern.
 | `ActivityLogEntity` | Unified activity log entries |
 | `ThreadEntryEntity` | Chronological project thread entries |
 | `EventSourceLogEntity` | Per-poll-cycle log for event sources |
+| `TraceEntity` | Root trace record (UUID PK) — one per pipeline run or report generation |
+| `TraceNodeEntity` | A step/span in a trace tree — references a detail entity via `entityType` + `entityId` |
+| `ToolExecutionEntity` | Detailed MCP tool invocation record — stores full JSON input and output |
 
 ### Active Record Pattern
 

--- a/docs/developer-guide/stack-and-architecture.md
+++ b/docs/developer-guide/stack-and-architecture.md
@@ -211,6 +211,32 @@ Configuration objects use builders for clean, immutable construction:
 Actor execution and engine invocations return `CompletableFuture`, keeping the
 scheduled pollers non-blocking.
 
+### Tracing
+
+Every event pipeline run and report generation produces a **trace** — a tree of
+lightweight nodes recording each step. The tracing subsystem follows several key
+design principles:
+
+- **`TraceService` lives in `core`** — both the `app` module (PipelineOrchestrator,
+  TaskExecutionService) and the `manager` module (ManagerService) inject it directly,
+  avoiding circular dependencies
+- **Stack-based context** — `TraceContext` maintains a mutable node stack. Call
+  `push(nodeId)` when descending into a child scope and `pop()` when returning. The
+  current top of the stack is the parent for new nodes.
+- **Independent transactions** — all trace writes use
+  `QuarkusTransaction.requiringNew()`, so trace data persists even if the caller's
+  transaction rolls back
+- **Non-fatal** — all trace operations are wrapped in try/catch. Tracing failures never
+  interrupt the main pipeline
+- **SSE broadcast** — every trace mutation fires `SseEvent.traceUpdated(traceId)` for
+  real-time UI updates
+- **UUID primary key** — `TraceEntity` uses a UUID PK (the only entity in the project
+  to do so). The trace ID doubles as the correlation identifier threaded through
+  environment variables and API callbacks.
+
+See the [Tracing](tracing.md) developer guide for the full data model, service API, and
+REST endpoint reference.
+
 ### Scheduled Pollers
 
 All background processing uses Quarkus `@Scheduled` with

--- a/docs/developer-guide/tracing.md
+++ b/docs/developer-guide/tracing.md
@@ -1,7 +1,7 @@
 # Tracing
 
 Axiom's tracing subsystem records a hierarchical tree of every step that occurs during
-an event pipeline run or report generation. Each trace is a directed graph of lightweight
+an event pipeline run or report generation. Each trace is a tree of lightweight
 **trace nodes** that reference more detailed records elsewhere in the system, keeping
 nodes small and fast to query while providing full drill-down capability.
 
@@ -266,6 +266,26 @@ Returns a paginated list of traces with optional filtering.
   "limit": 20
 }
 ```
+
+### Convenience: List Traces by Entity
+
+The API also provides convenience endpoints that return traces for a specific event,
+project, or report. These return a JSON array of `Trace` objects (not paginated).
+
+```
+GET /api/v1/events/{eventId}/traces
+GET /api/v1/projects/{projectId}/traces
+GET /api/v1/reports/{reportId}/traces
+```
+
+| Endpoint | Path Parameter | Description |
+|----------|----------------|-------------|
+| `GET /events/{eventId}/traces` | `eventId` (integer) | All traces associated with the given event |
+| `GET /projects/{projectId}/traces` | `projectId` (integer) | All traces associated with the given project |
+| `GET /reports/{reportId}/traces` | `reportId` (integer) | All traces associated with the given report |
+
+These are equivalent to calling `GET /traces` with the corresponding filter parameter,
+but are more convenient when you already have the entity ID.
 
 ### Get Trace Detail
 

--- a/docs/developer-guide/tracing.md
+++ b/docs/developer-guide/tracing.md
@@ -1,0 +1,566 @@
+# Tracing
+
+Axiom's tracing subsystem records a hierarchical tree of every step that occurs during
+an event pipeline run or report generation. Each trace is a directed graph of lightweight
+**trace nodes** that reference more detailed records elsewhere in the system, keeping
+nodes small and fast to query while providing full drill-down capability.
+
+This guide covers the data model, service API, REST endpoints, and how to instrument
+new pipeline stages with tracing.
+
+---
+
+## Design Principles
+
+- **Lightweight breadcrumbs** — trace nodes carry a summary, status, and timing, but
+  delegate detail to referenced entities (activity logs, tasks, tool executions, etc.)
+- **Non-fatal** — all trace operations are wrapped in exception handlers. Tracing never
+  interrupts the main pipeline.
+- **Independent transactions** — trace writes use `QuarkusTransaction.requiringNew()`
+  so data persists even if the caller's transaction rolls back
+- **Real-time** — every trace mutation fires an SSE event for live UI updates
+- **Correlation by UUID** — `TraceEntity` uses a UUID primary key that doubles as the
+  correlation identifier threaded through environment variables and API callbacks
+
+---
+
+## Data Model
+
+All trace entities live in `core/src/main/java/io/apitomy/axiom/core/entities/`.
+
+### TraceEntity
+
+Root of a complete execution trace. Extends `PanacheEntityBase` (not `PanacheEntity`)
+because it uses a UUID primary key instead of the standard auto-increment Long.
+
+**Table:** `trace`
+
+| Field | Type | Nullable | Description |
+|-------|------|----------|-------------|
+| `traceId` | `UUID` | No (PK) | Unique trace identifier |
+| `traceType` | `String` | No | Trace category: `"event-pipeline"` or `"report-generation"` |
+| `status` | `String` | No | Current status: `"in-progress"`, `"completed"`, or `"failed"` |
+| `summary` | `String(1024)` | No | Human-readable description (truncated to 1024 chars) |
+| `eventId` | `Long` | Yes | Associated event ID (for event pipeline traces) |
+| `projectId` | `Long` | Yes | Associated project ID |
+| `reportId` | `Long` | Yes | Associated report ID (for report generation traces) |
+| `startedOn` | `Instant` | No | Trace start timestamp |
+| `completedOn` | `Instant` | Yes | Trace completion timestamp |
+
+### TraceNodeEntity
+
+A single step/span within a trace tree. Extends `PanacheEntity` (auto-increment Long PK).
+
+**Table:** `trace_node`
+
+| Field | Type | Nullable | Description |
+|-------|------|----------|-------------|
+| `id` | `Long` | No (PK) | Auto-generated node ID |
+| `traceId` | `UUID` | No | Parent trace UUID |
+| `parentNodeId` | `Long` | Yes | Parent node ID (`null` for root nodes) |
+| `nodeType` | `String` | No | Step type identifier (see Node Types below) |
+| `status` | `String` | No | Current status: `"in-progress"`, `"completed"`, or `"failed"` |
+| `summary` | `String(1024)` | No | Human-readable description |
+| `startedOn` | `Instant` | No | Node start timestamp |
+| `completedOn` | `Instant` | Yes | Node completion timestamp |
+| `durationMs` | `Long` | Yes | Elapsed time in milliseconds (set at completion) |
+| `entityType` | `String` | Yes | Type of the referenced detail entity |
+| `entityId` | `Long` | Yes | ID of the referenced detail entity |
+
+#### Node Types
+
+| Node Type | Meaning | Typical Entity Reference |
+|-----------|---------|--------------------------|
+| `event-ingested` | Event received, processing began | `event` |
+| `manager-evaluation` | AI Manager was invoked | `activity-log` |
+| `decision-processed` | A Manager decision was executed | `activity-log` |
+| `task` | A task was created and assigned | `task` |
+| `tool-execution` | An MCP tool was invoked | `tool-execution` |
+| `escalation` | Decision escalated for human review | `activity-log` |
+| `event-ignored` | Manager decided to ignore the event | `activity-log` |
+| `report-triggered` | Report generation started | `report` |
+| `report-ai-invoked` | AI agent launched for report | `report` |
+
+#### Entity Types
+
+The `entityType` field determines which entity table the `entityId` references:
+
+| Entity Type | Referenced Entity | Detail Content |
+|-------------|-------------------|----------------|
+| `event` | `EventEntity` | Raw event payload |
+| `activity-log` | `ActivityLogEntity` | Log entry with type, summary, execution log |
+| `task` | `TaskEntity` | Task details — action type, actor, status, output |
+| `tool-execution` | `ToolExecutionEntity` | Full JSON input and output |
+| `ai-usage` | `AiUsageEntity` | Token counts, cost, model |
+| `report` | `ReportEntity` | Report metadata and content |
+
+### ToolExecutionEntity
+
+Detailed record of an MCP tool invocation. Stores the full JSON input and output for
+debugging. Referenced by trace nodes via `entityType="tool-execution"`.
+
+**Table:** `tool_execution`
+
+| Field | Type | Nullable | Description |
+|-------|------|----------|-------------|
+| `id` | `Long` | No (PK) | Auto-generated ID |
+| `traceId` | `UUID` | No | Associated trace UUID |
+| `toolName` | `String` | No | Name of the MCP tool |
+| `toolInput` | `String (TEXT)` | Yes | Tool input as JSON |
+| `toolOutput` | `String (TEXT)` | Yes | Tool output as JSON |
+| `status` | `String` | No | Execution status: `"in-progress"`, `"completed"`, or `"failed"` |
+| `durationMs` | `Long` | Yes | Tool execution time in milliseconds |
+| `createdOn` | `Instant` | No | Creation timestamp |
+
+---
+
+## TraceService API
+
+`TraceService` is the central service for creating and managing traces. It lives in
+the `core` module so both `app` and `manager` can use it without circular dependencies.
+
+**Location:** `core/src/main/java/io/apitomy/axiom/core/tracing/TraceService.java`
+
+### createTrace()
+
+Creates a new trace and its root node in a single transaction, then fires an SSE event.
+
+```java
+public TraceContext createTrace(
+    String traceType,        // e.g. "event-pipeline", "report-generation"
+    String summary,          // human-readable trace description
+    Long eventId,            // associated event ID (nullable)
+    Long projectId,          // associated project ID (nullable)
+    Long reportId,           // associated report ID (nullable)
+    String rootNodeType,     // node type for the root node
+    String rootNodeSummary,  // summary for the root node
+    String rootEntityType,   // entity type for the root node (nullable)
+    Long rootEntityId        // entity ID for the root node (nullable)
+)
+```
+
+Returns a `TraceContext` with the root node already pushed onto the stack.
+
+### addNode()
+
+Adds a child node under the current parent (top of the context stack).
+
+```java
+public Long addNode(
+    TraceContext ctx,   // current trace context
+    String nodeType,    // node type identifier
+    String status,      // initial status (e.g. "in-progress", "completed")
+    String summary,     // human-readable description
+    String entityType,  // referenced entity type (nullable)
+    Long entityId       // referenced entity ID (nullable)
+)
+```
+
+Returns the new node's ID. The parent is determined by `ctx.currentParentNodeId()`.
+
+### completeNode()
+
+Marks a node as completed with a final status and calculated duration. Has two overloads:
+
+```java
+// Basic completion
+public void completeNode(Long nodeId, String status)
+
+// Completion with entity reference (when entity isn't known at creation time)
+public void completeNode(Long nodeId, String status,
+    String entityType, Long entityId)
+```
+
+### completeTrace()
+
+Marks the trace itself as completed or failed.
+
+```java
+public void completeTrace(UUID traceId, String status)
+```
+
+---
+
+## TraceContext
+
+`TraceContext` is a mutable context object threaded through pipeline and report
+processing. It tracks the current position in the trace tree using an internal stack.
+
+**Location:** `core/src/main/java/io/apitomy/axiom/core/tracing/TraceContext.java`
+
+| Method | Description |
+|--------|-------------|
+| `UUID traceId()` | Returns the trace UUID |
+| `Long currentParentNodeId()` | Returns the top of the stack (current parent) |
+| `void push(Long nodeId)` | Pushes a node onto the stack, making it the current parent |
+| `Long pop()` | Pops the current parent, returning to the previous level |
+
+### Push/Pop Pattern
+
+When descending into a child scope, push the new node onto the stack so that any nodes
+created within that scope become its children. Pop when returning to the parent level.
+
+```java
+// Create a parent node
+Long parentId = traceService.addNode(traceCtx, "manager-evaluation",
+    "in-progress", "Evaluating event", null, null);
+traceCtx.push(parentId);
+
+try {
+    // Any nodes created here become children of parentId
+    traceService.addNode(traceCtx, "decision-processed",
+        "completed", "Decision: create task", "activity-log", logId);
+} finally {
+    traceCtx.pop();
+    traceService.completeNode(parentId, "completed");
+}
+```
+
+---
+
+## REST API Reference
+
+All trace endpoints are defined in the OpenAPI specification at
+`common/api/src/main/resources/openapi.json` and implemented in
+`app/src/main/java/io/apitomy/axiom/app/rest/TraceResourceImpl.java`.
+
+### List Traces
+
+```
+GET /api/v1/traces
+```
+
+Returns a paginated list of traces with optional filtering.
+
+**Query Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `page` | integer | 1 | Page number (1-indexed) |
+| `limit` | integer | 20 | Page size |
+| `filterTraceType` | string | — | Filter by trace type (e.g. `"event-pipeline"`) |
+| `filterStatus` | string | — | Filter by status (comma-separated, e.g. `"in-progress,completed"`) |
+| `filterEventId` | integer | — | Filter by event ID |
+| `filterProjectId` | integer | — | Filter by project ID |
+| `filterReportId` | integer | — | Filter by report ID |
+
+**Response:** `TraceSearchResults`
+
+```json
+{
+  "items": [
+    {
+      "traceId": "a1b2c3d4-...",
+      "traceType": "event-pipeline",
+      "status": "completed",
+      "summary": "Processing event #42: issue-created",
+      "eventId": 42,
+      "projectId": null,
+      "reportId": null,
+      "startedOn": "2026-06-29T10:00:00Z",
+      "completedOn": "2026-06-29T10:00:05Z"
+    }
+  ],
+  "totalCount": 1,
+  "page": 1,
+  "limit": 20
+}
+```
+
+### Get Trace Detail
+
+```
+GET /api/v1/traces/{traceId}
+```
+
+Returns a trace and all of its nodes.
+
+**Path Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `traceId` | string (UUID) | The trace UUID |
+
+**Response:** `TraceDetail`
+
+```json
+{
+  "trace": {
+    "traceId": "a1b2c3d4-...",
+    "traceType": "event-pipeline",
+    "status": "completed",
+    "summary": "Processing event #42: issue-created",
+    "eventId": 42,
+    "startedOn": "2026-06-29T10:00:00Z",
+    "completedOn": "2026-06-29T10:00:05Z"
+  },
+  "nodes": [
+    {
+      "id": 1,
+      "traceId": "a1b2c3d4-...",
+      "parentNodeId": null,
+      "nodeType": "event-ingested",
+      "status": "completed",
+      "summary": "Event received: issue-created",
+      "startedOn": "2026-06-29T10:00:00Z",
+      "completedOn": "2026-06-29T10:00:00Z",
+      "durationMs": 0,
+      "entityType": "event",
+      "entityId": 42
+    },
+    {
+      "id": 2,
+      "traceId": "a1b2c3d4-...",
+      "parentNodeId": 1,
+      "nodeType": "manager-evaluation",
+      "status": "completed",
+      "summary": "Manager evaluation: issue-created",
+      "startedOn": "2026-06-29T10:00:00Z",
+      "completedOn": "2026-06-29T10:00:03Z",
+      "durationMs": 3000,
+      "entityType": "activity-log",
+      "entityId": 15
+    }
+  ]
+}
+```
+
+### Get Trace Node Detail
+
+```
+GET /api/v1/traces/{traceId}/nodes/{nodeId}
+```
+
+Returns a trace node with its resolved entity detail. The detail object's structure
+depends on the node's `entityType`.
+
+**Path Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `traceId` | string (UUID) | The trace UUID |
+| `nodeId` | integer | The node ID |
+
+**Response:** `TraceNodeDetail`
+
+```json
+{
+  "node": {
+    "id": 5,
+    "traceId": "a1b2c3d4-...",
+    "parentNodeId": 3,
+    "nodeType": "tool-execution",
+    "status": "completed",
+    "summary": "Tool: github_list_issues",
+    "durationMs": 1200,
+    "entityType": "tool-execution",
+    "entityId": 7
+  },
+  "detail": {
+    "toolName": "github_list_issues",
+    "toolInput": "{\"repo\": \"owner/repo\", \"state\": \"open\"}",
+    "toolOutput": "[{\"number\": 1, \"title\": \"Bug report\"}]",
+    "status": "completed",
+    "durationMs": 1200
+  }
+}
+```
+
+### Create Tool Call
+
+```
+POST /api/v1/traces/tool-calls
+```
+
+Creates a new tool-call trace node and its associated `ToolExecutionEntity`. Called by
+MCP tool wrappers during task or report execution.
+
+**Request Body:** `ToolCallRequest`
+
+```json
+{
+  "traceId": "a1b2c3d4-...",
+  "parentNodeId": 3,
+  "toolName": "github_list_issues",
+  "toolInput": "{\"repo\": \"owner/repo\", \"state\": \"open\"}"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `traceId` | string (UUID) | Yes | The parent trace UUID |
+| `parentNodeId` | integer | No | Parent node ID for tree nesting |
+| `toolName` | string | Yes | Name of the MCP tool being invoked |
+| `toolInput` | string | No | Tool input as JSON |
+
+**Response:** `ToolCallCreated`
+
+```json
+{
+  "nodeId": 5
+}
+```
+
+### Complete Tool Call
+
+```
+PUT /api/v1/traces/tool-calls/{nodeId}
+```
+
+Completes a tool-call trace node with the execution result.
+
+**Path Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `nodeId` | integer | The trace node ID returned by the create call |
+
+**Request Body:** `ToolCallCompletion`
+
+```json
+{
+  "toolOutput": "[{\"number\": 1, \"title\": \"Bug report\"}]",
+  "status": "completed",
+  "durationMs": 1200
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `toolOutput` | string | No | Tool output as JSON |
+| `status` | string | No | Final status (`"completed"` or `"failed"`) |
+| `durationMs` | integer | No | Execution duration in milliseconds |
+
+---
+
+## Instrumenting New Pipeline Stages
+
+To add tracing to a new pipeline stage or service:
+
+### Step 1: Inject TraceService
+
+```java
+@Inject
+TraceService traceService;
+```
+
+### Step 2: Create a Trace or Add a Node
+
+If your code is the entry point for a new pipeline (like `PipelineOrchestrator` or
+`ReportExecutionService`), create a new trace:
+
+```java
+TraceContext traceCtx = traceService.createTrace(
+    "my-pipeline",
+    "Processing something: " + description,
+    eventId, projectId, reportId,
+    "my-root-node", "Root: " + description,
+    "event", eventId);
+```
+
+If your code runs within an existing trace (like `ManagerService`), receive the
+`TraceContext` as a parameter and add nodes to it:
+
+```java
+Long nodeId = traceService.addNode(traceCtx, "my-step", "in-progress",
+    "Doing something important", null, null);
+```
+
+### Step 3: Push/Pop for Child Scopes
+
+If your node will have child nodes, push it onto the stack:
+
+```java
+traceCtx.push(nodeId);
+try {
+    // child nodes created here become children of nodeId
+    doWork(traceCtx);
+} finally {
+    traceCtx.pop();
+}
+```
+
+### Step 4: Complete Nodes and the Trace
+
+```java
+// Complete a node
+traceService.completeNode(nodeId, "completed");
+
+// Complete a node and set its entity reference
+traceService.completeNode(nodeId, "completed", "activity-log", logEntry.id);
+
+// Complete the trace
+traceService.completeTrace(traceCtx.traceId(), "completed");
+```
+
+### Step 5: Pass Correlation Data to Subprocesses
+
+If your stage launches a subprocess that should report tool calls back to the trace,
+inject the trace correlation data as environment variables:
+
+```java
+Map<String, String> env = new HashMap<>();
+env.put("AXIOM_TRACE_ID", traceCtx.traceId().toString());
+env.put("AXIOM_PARENT_NODE_ID", String.valueOf(nodeId));
+```
+
+The subprocess (or its MCP tool wrapper) reads these variables and calls back to
+`POST /api/v1/traces/tool-calls` and `PUT /api/v1/traces/tool-calls/{nodeId}`.
+
+### Non-Fatal Pattern
+
+Always wrap trace operations in try/catch when called from the main pipeline:
+
+```java
+Long nodeId = null;
+if (traceCtx != null) {
+    try {
+        nodeId = traceService.addNode(traceCtx, "my-step", "in-progress",
+            "Description", null, null);
+        traceCtx.push(nodeId);
+    } catch (Exception e) {
+        LOG.warnf(e, "Failed to add trace node");
+    }
+}
+
+// ... do the actual work ...
+
+if (traceCtx != null && nodeId != null) {
+    try {
+        traceCtx.pop();
+        traceService.completeNode(nodeId, "completed");
+    } catch (Exception e) {
+        LOG.warnf(e, "Failed to complete trace node");
+    }
+}
+```
+
+---
+
+## MCP Tool Call Integration
+
+When Axiom generates MCP server configurations for AI agent tasks, it includes the trace
+correlation environment variables (`AXIOM_TRACE_ID` and `AXIOM_PARENT_NODE_ID`). The
+generated MCP tool wrappers use these to register tool calls as trace nodes:
+
+```
+AI Agent starts task
+  │
+  ├─ Axiom sets AXIOM_TRACE_ID and AXIOM_PARENT_NODE_ID in subprocess env
+  │
+  ▼
+MCP Tool Wrapper executes
+  │
+  ├─ Reads AXIOM_TRACE_ID and AXIOM_PARENT_NODE_ID from environment
+  ├─ POST /api/v1/traces/tool-calls  →  receives nodeId
+  ├─ Executes the actual tool
+  └─ PUT /api/v1/traces/tool-calls/{nodeId}  →  sends output + status
+```
+
+This flow is implemented in `TaskExecutionService` (for tasks) and
+`ReportExecutionService` (for reports). Both look up the trace node ID for the current
+task or report AI invocation and inject it as `AXIOM_PARENT_NODE_ID` so tool calls
+become children of the correct node in the tree.
+
+If the trace callback fails (network error, missing trace, etc.), the tool execution
+continues normally — tracing is best-effort and never blocks work.

--- a/docs/user-guide/concepts.md
+++ b/docs/user-guide/concepts.md
@@ -519,6 +519,6 @@ Traces are accessible from several places in the UI:
 - **Events page** — click **View Trace** on an event row to jump to its pipeline trace
 - **Report detail page** — click **View Execution Trace** to see the report's trace
 
-The trace detail page renders the node tree as an interactive directed graph. Click any
+The trace detail page renders the node tree as an interactive tree. Click any
 node to view its full detail, including referenced entity data. See
 [Logging and Debugging](logging-and-debugging.md) for a full guide to reading traces.

--- a/docs/user-guide/concepts.md
+++ b/docs/user-guide/concepts.md
@@ -443,3 +443,82 @@ template and tools. No event sources, projects, or actors are required.
 **Event-driven automation** uses the full pipeline — event sources feed events to the
 Manager, which creates projects and assigns tasks to actors using action types. The
 action types determine what tools and prompts the actors use.
+
+---
+
+## Traces
+
+A **Trace** is a hierarchical record of every step that occurred during a single pipeline
+run or report generation. While the [Activity Log](logging-and-debugging.md) shows a flat
+timeline of events across all runs, a trace shows the *tree structure* of one run — which
+steps led to which, how long each took, and whether each succeeded or failed.
+
+### When Traces Are Created
+
+Axiom creates a trace automatically whenever it processes an event or generates a report:
+
+| Trace Type | Trigger | Root Node |
+|------------|---------|-----------|
+| `event-pipeline` | An event is dequeued for processing | `event-ingested` |
+| `report-generation` | A report definition runs (scheduled or ad hoc) | `report-triggered` |
+
+Each trace has a status (`in-progress`, `completed`, or `failed`), timestamps, and a
+human-readable summary. Traces with asynchronous tasks (e.g. AI agent execution) remain
+`in-progress` until all tasks complete.
+
+### Trace Nodes
+
+Each step in the pipeline creates a **trace node** — a lightweight breadcrumb that
+records what happened at that point. Nodes form a parent-child tree: the root node is the
+trigger (event received or report triggered), and child nodes represent subsequent steps
+like manager evaluation, decision processing, task creation, and tool execution.
+
+Every node has:
+
+- **Node type** — identifies the kind of step
+- **Status** — `in-progress`, `completed`, or `failed`
+- **Summary** — a brief description of what happened
+- **Duration** — how long the step took (calculated at completion)
+- **Entity reference** — a pointer to a more detailed record elsewhere in the system
+  (an activity log entry, a task, an event, a tool execution record, etc.)
+
+The entity reference pattern keeps trace nodes small and fast to query. When you click a
+node in the UI, the detail is fetched from the referenced entity on demand.
+
+### Node Types
+
+| Node Type | Meaning | Appears In |
+|-----------|---------|------------|
+| `event-ingested` | An event was received and processing began | Event pipeline (root) |
+| `manager-evaluation` | The AI Manager was invoked to triage the event | Event pipeline |
+| `decision-processed` | A single decision from the Manager was executed | Event pipeline |
+| `task` | A task was created and assigned to an actor | Event pipeline |
+| `tool-execution` | An MCP tool was invoked during task or report execution | Both |
+| `escalation` | The Manager escalated a decision for human review | Event pipeline |
+| `event-ignored` | The Manager decided to ignore the event | Event pipeline |
+| `report-triggered` | A report generation was triggered | Report (root) |
+| `report-ai-invoked` | The AI agent was launched to generate the report | Report |
+
+### Tool Call Tracing
+
+When Axiom launches an AI agent to execute a task or generate a report, it passes trace
+correlation data to the subprocess via environment variables (`AXIOM_TRACE_ID` and
+`AXIOM_PARENT_NODE_ID`). MCP tool servers that Axiom generates for the agent read these
+variables and call back to Axiom's API to register each tool invocation as a trace node.
+This creates a detailed record of every tool the agent called, including the full JSON
+input and output.
+
+Tool call tracing is non-intrusive — if the callback fails, the tool execution continues
+normally. Tracing never interrupts the agent's work.
+
+### Viewing Traces
+
+Traces are accessible from several places in the UI:
+
+- **Logs > Traces** — browse and filter all traces
+- **Events page** — click **View Trace** on an event row to jump to its pipeline trace
+- **Report detail page** — click **View Execution Trace** to see the report's trace
+
+The trace detail page renders the node tree as an interactive directed graph. Click any
+node to view its full detail, including referenced entity data. See
+[Logging and Debugging](logging-and-debugging.md) for a full guide to reading traces.

--- a/docs/user-guide/logging-and-debugging.md
+++ b/docs/user-guide/logging-and-debugging.md
@@ -39,6 +39,8 @@ the pipeline things went wrong and examining the logs at that stage.
 | Task completed but result is wrong | Project detail page > Tasks tab > **View Log** |
 | Report failed | Report detail page > **View Log** |
 | Report content is wrong or incomplete | Report detail page > **View Log** — check tool output |
+| Want to see the full pipeline tree for one event | **Logs > Traces** or click **View Trace** on an event row |
+| Want to see what tools a report agent called | Report detail page > **View Execution Trace** |
 | Don't know where to start | **Logs > All Activity** — scan the timeline |
 
 ---
@@ -246,6 +248,83 @@ number of AI invocations, and input/output token counts.
 
 ---
 
+## Using Traces
+
+While the activity log, events page, and task log each show one dimension of what
+happened, a **trace** shows the complete tree structure of a single pipeline run or
+report generation. Traces answer the question: "What exactly happened, in what order,
+and how long did each step take?"
+
+### When to Use Traces vs. the Activity Log
+
+- Use the **Activity Log** when you want a timeline view across multiple events and
+  projects — "what has the system been doing?"
+- Use a **Trace** when you want to drill into one specific event or report — "what
+  happened step by step when this event was processed?"
+
+### Accessing Traces
+
+There are three ways to view a trace:
+
+1. **Logs > Traces** — browse all traces with filtering by trace type
+   (`event-pipeline` or `report-generation`), status, event ID, project ID, or report ID
+2. **Events page** — click **View Trace** on any event row that has been processed
+3. **Report detail page** — click **View Execution Trace** on a completed or failed
+   report
+
+### Reading the Trace Graph
+
+The trace detail page renders the node tree as a left-to-right directed graph:
+
+- **Nodes** represent pipeline steps — each shows an icon, a status label, a summary,
+  and timing information
+- **Edges** connect parent nodes to their children, showing the execution flow
+
+#### Node Colors
+
+| Color | Status |
+|-------|--------|
+| Green | `completed` / `success` — the step finished successfully |
+| Blue | `in-progress` — the step is still running |
+| Red | `failed` / `failure` — the step encountered an error |
+| Orange | `escalation` — the Manager escalated a decision for human review |
+| Grey | `skipped` — the step was skipped |
+
+Edges to failed nodes are drawn in red. Edges to in-progress nodes are animated.
+
+#### Node Icons
+
+Each node type has a distinctive icon to help you quickly identify what kind of step it
+represents — event received, manager evaluation, task creation, tool execution, etc.
+
+### Viewing Node Details
+
+Click any node in the graph to open a detail modal. The content of the modal depends on
+the node's entity type:
+
+| Entity Type | What the Modal Shows |
+|-------------|---------------------|
+| `event` | The raw event payload JSON |
+| `activity-log` | The activity log entry — type, summary, and execution log (if available) |
+| `task` | Task details — action type, actor, status, and execution output |
+| `tool-execution` | The MCP tool name, full JSON input, and full JSON output |
+| `ai-usage` | Token counts, cost, and model information |
+| `report` | Report metadata and content |
+
+The tool execution detail is especially useful for debugging — you can see exactly what
+data each tool received and returned.
+
+### Real-Time Updates
+
+When a trace is still in progress, the graph updates automatically as new nodes are
+added. You don't need to refresh the page — the UI receives server-sent events (SSE)
+and re-renders the graph when the trace changes.
+
+You can also click the **Refresh** button in the page header to manually reload the
+trace.
+
+---
+
 ## Debugging Checklist
 
 When something isn't working, work through the pipeline in order:
@@ -265,3 +344,9 @@ When something isn't working, work through the pipeline in order:
 8. **Were secrets available?** If a tool needs API credentials, verify the secret exists
    under **Configuration > Secrets** and the action type's environment is configured
    correctly.
+
+!!! tip "Use a Trace for the Full Picture"
+    For any event or report, clicking **View Trace** gives you the entire pipeline tree
+    in one view — every step, every tool call, every decision. This is often faster than
+    checking each log page individually, especially when you need to understand the
+    relationship between steps.

--- a/docs/user-guide/logging-and-debugging.md
+++ b/docs/user-guide/logging-and-debugging.md
@@ -274,7 +274,7 @@ There are three ways to view a trace:
 
 ### Reading the Trace Graph
 
-The trace detail page renders the node tree as a left-to-right directed graph:
+The trace detail page renders the node tree as a left-to-right interactive tree:
 
 - **Nodes** represent pipeline steps — each shows an icon, a status label, a summary,
   and timing information
@@ -289,6 +289,12 @@ The trace detail page renders the node tree as a left-to-right directed graph:
 | Red | `failed` / `failure` — the step encountered an error |
 | Orange | `escalation` — the Manager escalated a decision for human review |
 | Grey | `skipped` — the step was skipped |
+
+!!! note
+    Colors are determined by a combination of node status and node type. The data model
+    defines three statuses (`in-progress`, `completed`, `failed`), but the UI uses node
+    type to apply additional colors — for example, `escalation` nodes are rendered in
+    orange and `event-ignored` nodes in grey, regardless of their underlying status.
 
 Edges to failed nodes are drawn in red. Edges to in-progress nodes are animated.
 

--- a/docs/user-guide/navigating-the-ui.md
+++ b/docs/user-guide/navigating-the-ui.md
@@ -82,8 +82,23 @@ activity:
 | **Events** | Raw events received from event sources (GitHub issues, PRs, comments) |
 | **Manager Decisions** | The AI Manager's triage results — what action it chose for each event and its confidence score |
 | **Tasks** | Task execution history — which actor ran what action type, duration, cost, and outcome |
+| **Traces** | Visual graph of pipeline execution — shows every step from event ingestion through manager evaluation, decision processing, and task execution |
 
 Each log page supports filtering and pagination.
+
+The **Traces** page deserves special mention. While the other log pages show tabular data,
+traces render as an interactive directed graph. Each node in the graph represents a step
+in the pipeline (event received, manager evaluated, task created, tool executed, etc.).
+Nodes are color-coded by status — green for completed, blue for in-progress, red for
+failed. Click any node to open a detail modal showing the full data for that step,
+including tool input/output for tool executions and AI reasoning for manager evaluations.
+
+You can also navigate to a trace directly from:
+
+- An **event row** on the Events page — click **View Trace** to see the full pipeline
+  trace for that event
+- A **report detail page** — click **View Execution Trace** to see the report generation
+  trace
 
 ### Metrics
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
     - How to Contribute: developer-guide/how-to-contribute.md
     - API-First Development: developer-guide/api-first-development.md
     - Database & Migrations: developer-guide/database-and-migrations.md
+    - Tracing: developer-guide/tracing.md
     - UI Development: developer-guide/ui-development.md
     - Extending Axiom: developer-guide/extending-axiom.md
 


### PR DESCRIPTION
## Summary

- Add full documentation for the end-to-end activity tracing subsystem (Epic #36)
- Update 5 existing doc pages and create 1 new dedicated developer guide page
- Add mkdocs nav entry for the new tracing page

## Changes

**User Guide:**
- `concepts.md` — new "Traces" section: trace types, node types, tool call tracing, viewing traces
- `navigating-the-ui.md` — add Traces to the Logs sub-pages table with graph UI description
- `logging-and-debugging.md` — new "Using Traces" section, updated quick reference table and debugging checklist

**Developer Guide:**
- `stack-and-architecture.md` — new "Tracing" subsection under Key Design Patterns
- `database-and-migrations.md` — add TraceEntity, TraceNodeEntity, ToolExecutionEntity to Key Entities table
- `tracing.md` (new) — comprehensive developer reference: data model, TraceService API, REST API reference with example JSON, instrumentation guide, MCP tool call integration

**Config:**
- `mkdocs.yml` — add Tracing nav entry under Developer Guide

## Test plan

- [ ] Verify `mkdocs serve` renders all pages without errors
- [ ] Check internal cross-links resolve correctly
- [ ] Review tables and code blocks render properly
- [ ] Read through each page for tone/style consistency with existing docs