### PR TITLE
Extract reusable UI components to reduce duplication

### DIFF
--- a/ui/src/components/ConfirmDeleteModal.tsx
+++ b/ui/src/components/ConfirmDeleteModal.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+import {
+    Button,
+    Modal,
+    ModalBody,
+    ModalFooter,
+    ModalHeader,
+} from "@patternfly/react-core";
+
+/**
+ * Reusable confirmation modal for destructive actions (delete, cancel, etc.).
+ */
+export function ConfirmDeleteModal({ isOpen, title, children, onConfirm, onCancel, confirmLabel = "Delete" }: {
+    isOpen: boolean;
+    title: string;
+    children: ReactNode;
+    onConfirm: () => void;
+    onCancel: () => void;
+    confirmLabel?: string;
+}) {
+    return (
+        <Modal isOpen={isOpen} onClose={onCancel} variant="small">
+            <ModalHeader title={title} />
+            <ModalBody>{children}</ModalBody>
+            <ModalFooter>
+                <Button variant="danger" onClick={onConfirm}>{confirmLabel}</Button>
+                <Button variant="link" onClick={onCancel}>Cancel</Button>
+            </ModalFooter>
+        </Modal>
+    );
+}

--- a/ui/src/components/EnvironmentTab.tsx
+++ b/ui/src/components/EnvironmentTab.tsx
@@ -1,0 +1,122 @@
+import { useState } from "react";
+import {
+    Button,
+    EmptyState,
+    EmptyStateBody,
+    Flex,
+    FlexItem,
+    FormGroup,
+    TextInput,
+} from "@patternfly/react-core";
+import PlusCircleIcon from "@patternfly/react-icons/dist/esm/icons/plus-circle-icon";
+import TimesIcon from "@patternfly/react-icons/dist/esm/icons/times-icon";
+
+/**
+ * Editable key-value table for environment variables.
+ *
+ * Used by ActionTypeDetailPage and ReportDefinitionDetailPage.
+ */
+export function EnvironmentTab({ envVars, onChange }: {
+    envVars: Record<string, string>;
+    onChange: (updated: Record<string, string>) => void;
+}) {
+    const [newName, setNewName] = useState("");
+    const [newValue, setNewValue] = useState("");
+
+    const entries = Object.entries(envVars);
+
+    const handleAdd = () => {
+        const trimmed = newName.trim();
+        if (!trimmed || trimmed in envVars) return;
+        onChange({ ...envVars, [trimmed]: newValue });
+        setNewName("");
+        setNewValue("");
+    };
+
+    const handleRemove = (key: string) => {
+        const updated = { ...envVars };
+        delete updated[key];
+        onChange(updated);
+    };
+
+    const handleValueChange = (key: string, value: string) => {
+        onChange({ ...envVars, [key]: value });
+    };
+
+    return (
+        <div style={{ maxWidth: "700px" }}>
+            <p style={{ color: "#6a6e73", marginBottom: "16px" }}>
+                Custom environment variables injected into the subprocess. When configured,
+                these replace the default all-secrets injection. Reference an encrypted secret
+                using <code>{"${secret:SECRET_NAME}"}</code> syntax.
+            </p>
+
+            <Flex alignItems={{ default: "alignItemsFlexEnd" }}
+                style={{ marginBottom: "16px", gap: "8px" }}>
+                <FlexItem style={{ flex: 1 }}>
+                    <FormGroup label="Name" fieldId="env-new-name">
+                        <TextInput id="env-new-name" value={newName}
+                            onChange={(_e, v) => setNewName(v)}
+                            placeholder="e.g. GH_TOKEN"
+                            onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); handleAdd(); } }}
+                        />
+                    </FormGroup>
+                </FlexItem>
+                <FlexItem style={{ flex: 2 }}>
+                    <FormGroup label="Value" fieldId="env-new-value">
+                        <TextInput id="env-new-value" value={newValue}
+                            onChange={(_e, v) => setNewValue(v)}
+                            placeholder="e.g. ${secret:GH_TOKEN}"
+                            onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); handleAdd(); } }}
+                        />
+                    </FormGroup>
+                </FlexItem>
+                <FlexItem>
+                    <Button variant="secondary" icon={<PlusCircleIcon />}
+                        onClick={handleAdd}
+                        isDisabled={!newName.trim() || newName.trim() in envVars}
+                        style={{ marginBottom: "1px" }}>
+                        Add
+                    </Button>
+                </FlexItem>
+            </Flex>
+
+            {entries.length === 0 ? (
+                <EmptyState>
+                    <EmptyStateBody>
+                        No custom environment configured. All secrets will be injected automatically.
+                    </EmptyStateBody>
+                </EmptyState>
+            ) : (
+                <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+                    {entries.map(([key, value]) => (
+                        <Flex key={key} alignItems={{ default: "alignItemsCenter" }}
+                            style={{
+                                padding: "8px 12px",
+                                backgroundColor: "var(--pf-t--global--background--color--secondary--default)",
+                                borderRadius: "4px",
+                            }}>
+                            <FlexItem style={{ minWidth: "160px" }}>
+                                <code style={{ fontSize: "13px", fontWeight: 600 }}>{key}</code>
+                            </FlexItem>
+                            <FlexItem grow={{ default: "grow" }}>
+                                <TextInput value={value}
+                                    onChange={(_e, v) => handleValueChange(key, v)}
+                                    aria-label={`Value for ${key}`}
+                                    style={{ fontSize: "13px" }}
+                                />
+                            </FlexItem>
+                            <FlexItem>
+                                <Button variant="plain" size="sm"
+                                    onClick={() => handleRemove(key)}
+                                    aria-label={`Remove ${key}`}>
+                                    <TimesIcon />
+                                </Button>
+                            </FlexItem>
+                        </Flex>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/ui/src/components/ToolListEditor.tsx
+++ b/ui/src/components/ToolListEditor.tsx
@@ -1,0 +1,78 @@
+import type { ReactNode } from "react";
+import {
+    Button,
+    Flex,
+    FlexItem,
+} from "@patternfly/react-core";
+import TimesIcon from "@patternfly/react-icons/dist/esm/icons/times-icon";
+import { AddToolInput } from "./AddToolInput";
+
+/**
+ * Editable list of tool patterns with add/remove and @-prefix toolset styling.
+ *
+ * Used by ActionTypeDetailPage, ReportDefinitionDetailPage, and ToolsetDetailPage.
+ */
+export function ToolListEditor({ tools, onAdd, onRemove, onReplace, helpText, emptyContent }: {
+    tools: string[];
+    onAdd: (tool: string) => void;
+    onRemove: (tool: string) => void;
+    onReplace: (tools: string[]) => void;
+    helpText?: ReactNode;
+    emptyContent?: ReactNode;
+}) {
+    return (
+        <div style={{ maxWidth: "700px" }}>
+            {helpText && (
+                <p style={{ color: "#6a6e73", marginBottom: "16px" }}>
+                    {helpText}
+                </p>
+            )}
+
+            <div style={{ marginBottom: "16px" }}>
+                <AddToolInput onAdd={onAdd} onReplace={onReplace} existingTools={tools} />
+            </div>
+
+            {tools.length === 0 ? (
+                emptyContent ?? null
+            ) : (
+                <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+                    {tools.map((tool) => (
+                        <Flex
+                            key={tool}
+                            alignItems={{ default: "alignItemsCenter" }}
+                            style={{
+                                padding: "8px 12px",
+                                backgroundColor: tool.startsWith("@")
+                                    ? "var(--pf-t--global--background--color--primary--default)"
+                                    : "var(--pf-t--global--background--color--secondary--default)",
+                                borderRadius: "4px",
+                                border: tool.startsWith("@")
+                                    ? "1px solid var(--pf-t--global--border--color--default)"
+                                    : "none",
+                            }}
+                        >
+                            <FlexItem grow={{ default: "grow" }}>
+                                <code style={{
+                                    fontSize: "13px",
+                                    color: tool.startsWith("@")
+                                        ? "var(--pf-t--global--color--brand--default)"
+                                        : "inherit",
+                                }}>{tool}</code>
+                            </FlexItem>
+                            <FlexItem>
+                                <Button
+                                    variant="plain"
+                                    size="sm"
+                                    onClick={() => onRemove(tool)}
+                                    aria-label={`Remove ${tool}`}
+                                >
+                                    <TimesIcon />
+                                </Button>
+                            </FlexItem>
+                        </Flex>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/ui/src/components/ValidationProblemsPanel.tsx
+++ b/ui/src/components/ValidationProblemsPanel.tsx
@@ -1,0 +1,42 @@
+import ExclamationCircleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon";
+import ExclamationTriangleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon";
+import type { ToolValidationMessage } from "../config/api";
+
+/**
+ * Renders a list of validation messages with severity-based styling.
+ *
+ * Used by ActionTypeDetailPage, ToolDetailPage, and ReportDefinitionDetailPage.
+ */
+export function ValidationProblemsPanel({ messages }: {
+    messages: ToolValidationMessage[];
+}) {
+    return (
+        <div style={{ maxWidth: "700px" }}>
+            {messages.map((msg, i) => (
+                <div key={i} style={{
+                    display: "flex",
+                    alignItems: "flex-start",
+                    gap: 8,
+                    padding: "10px 12px",
+                    marginBottom: 4,
+                    borderRadius: 4,
+                    backgroundColor: msg.severity === "error"
+                        ? "#fef3f2" : "#fdf7e7",
+                    border: `1px solid ${msg.severity === "error"
+                        ? "#c9190b" : "#f0ab00"}`,
+                }}>
+                    {msg.severity === "error"
+                        ? <ExclamationCircleIcon style={{ color: "#c9190b", marginTop: 2 }} />
+                        : <ExclamationTriangleIcon style={{ color: "#f0ab00", marginTop: 2 }} />
+                    }
+                    <div>
+                        <div style={{ fontSize: "13px" }}>{msg.message}</div>
+                        <div style={{ fontSize: "12px", color: "#6a6e73", marginTop: 2 }}>
+                            Field: <code>{msg.field}</code>
+                        </div>
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/ui/src/pages/ActionTypeDetailPage.tsx
+++ b/ui/src/pages/ActionTypeDetailPage.tsx
@@ -25,13 +25,13 @@ import {
 } from "@patternfly/react-core";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import { registerPlaceholderCompletions, ACTION_TYPE_PLACEHOLDERS } from "../components/PlaceholderCompletionProvider";
-import { AddToolInput } from "../components/AddToolInput";
+import { EnvironmentTab } from "../components/EnvironmentTab";
+import { ToolListEditor } from "../components/ToolListEditor";
 import { ScriptAiModal } from "../components/ScriptAiModal";
 import { ActionTypeAiModal } from "../components/ActionTypeAiModal";
+import { ValidationProblemsPanel } from "../components/ValidationProblemsPanel";
 import SaveIcon from "@patternfly/react-icons/dist/esm/icons/save-icon";
 import MagicIcon from "@patternfly/react-icons/dist/esm/icons/magic-icon";
-import TimesIcon from "@patternfly/react-icons/dist/esm/icons/times-icon";
-import PlusCircleIcon from "@patternfly/react-icons/dist/esm/icons/plus-circle-icon";
 import {
     type ActionType,
     type NewActionType,
@@ -236,11 +236,25 @@ export function ActionTypeDetailPage() {
                 {form.executionMode === "actor" && (
                     <Tab eventKey={1} title={<TabTitleText>Allowed Tools ({tools.length})</TabTitleText>}>
                         <TabContent id="tools-tab" eventKey={1} activeKey={activeTab} style={{ marginTop: "24px" }}>
-                            <AllowedToolsTab
+                            <ToolListEditor
                                 tools={tools}
-                                addTool={addTool}
-                                removeTool={removeTool}
-                                replaceTool={replaceTools}
+                                onAdd={addTool}
+                                onRemove={removeTool}
+                                onReplace={replaceTools}
+                                helpText={<>
+                                    Define which tools the AI agent is allowed to use when performing this
+                                    action type. Use patterns like <code>Bash(git log *)</code> to allow
+                                    specific shell commands. Reference a toolset using{" "}
+                                    <code>@ToolsetName</code> (e.g. <code>@Read-Only Tools</code>) to include
+                                    all tools from that collection. Tools not in this list will be denied.
+                                </>}
+                                emptyContent={
+                                    <EmptyState>
+                                        <EmptyStateBody>
+                                            No tools configured. The actor will use minimal read-only defaults.
+                                        </EmptyStateBody>
+                                    </EmptyState>
+                                }
                             />
                         </TabContent>
                     </Tab>
@@ -290,33 +304,7 @@ export function ActionTypeDetailPage() {
                         </TabTitleText>
                     }>
                         <TabContent id="problems-tab" eventKey={5} activeKey={activeTab} style={{ marginTop: "24px" }}>
-                            <div style={{ maxWidth: "700px" }}>
-                                {validationMessages.map((msg, i) => (
-                                    <div key={i} style={{
-                                        display: "flex",
-                                        alignItems: "flex-start",
-                                        gap: 8,
-                                        padding: "10px 12px",
-                                        marginBottom: 4,
-                                        borderRadius: 4,
-                                        backgroundColor: msg.severity === "error"
-                                            ? "#fef3f2" : "#fdf7e7",
-                                        border: `1px solid ${msg.severity === "error"
-                                            ? "#c9190b" : "#f0ab00"}`,
-                                    }}>
-                                        {msg.severity === "error"
-                                            ? <ExclamationCircleIcon style={{ color: "#c9190b", marginTop: 2 }} />
-                                            : <ExclamationTriangleIcon style={{ color: "#f0ab00", marginTop: 2 }} />
-                                        }
-                                        <div>
-                                            <div style={{ fontSize: "13px" }}>{msg.message}</div>
-                                            <div style={{ fontSize: "12px", color: "#6a6e73", marginTop: 2 }}>
-                                                Field: <code>{msg.field}</code>
-                                            </div>
-                                        </div>
-                                    </div>
-                                ))}
-                            </div>
+                            <ValidationProblemsPanel messages={validationMessages} />
                         </TabContent>
                     </Tab>
                 )}
@@ -472,75 +460,6 @@ function InfoTab({ form, updateForm, availableModels, availableEngines }: {
     );
 }
 
-function AllowedToolsTab({ tools, addTool, removeTool, replaceTool }: {
-    tools: string[];
-    addTool: (tool: string) => void;
-    removeTool: (tool: string) => void;
-    replaceTool: (tools: string[]) => void;
-}) {
-    return (
-        <div style={{ maxWidth: "700px" }}>
-            <p style={{ color: "#6a6e73", marginBottom: "16px" }}>
-                Define which tools the AI agent is allowed to use when performing this
-                action type. Use patterns like <code>Bash(git log *)</code> to allow
-                specific shell commands. Reference a toolset using{" "}
-                <code>@ToolsetName</code> (e.g. <code>@Read-Only Tools</code>) to include
-                all tools from that collection. Tools not in this list will be denied.
-            </p>
-
-            <div style={{ marginBottom: "16px" }}>
-                <AddToolInput onAdd={addTool} onReplace={replaceTool} existingTools={tools} />
-            </div>
-
-            {tools.length === 0 ? (
-                <EmptyState>
-                    <EmptyStateBody>
-                        No tools configured. The actor will use minimal read-only defaults.
-                    </EmptyStateBody>
-                </EmptyState>
-            ) : (
-                <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
-                    {tools.map((tool) => (
-                        <Flex
-                            key={tool}
-                            alignItems={{ default: "alignItemsCenter" }}
-                            style={{
-                                padding: "8px 12px",
-                                backgroundColor: tool.startsWith("@")
-                                    ? "var(--pf-t--global--background--color--primary--default)"
-                                    : "var(--pf-t--global--background--color--secondary--default)",
-                                borderRadius: "4px",
-                                border: tool.startsWith("@")
-                                    ? "1px solid var(--pf-t--global--border--color--default)"
-                                    : "none",
-                            }}
-                        >
-                            <FlexItem grow={{ default: "grow" }}>
-                                <code style={{
-                                    fontSize: "13px",
-                                    color: tool.startsWith("@")
-                                        ? "var(--pf-t--global--color--brand--default)"
-                                        : "inherit",
-                                }}>{tool}</code>
-                            </FlexItem>
-                            <FlexItem>
-                                <Button
-                                    variant="plain"
-                                    size="sm"
-                                    onClick={() => removeTool(tool)}
-                                    aria-label={`Remove ${tool}`}
-                                >
-                                    <TimesIcon />
-                                </Button>
-                            </FlexItem>
-                        </Flex>
-                    ))}
-                </div>
-            )}
-        </div>
-    );
-}
-
 function PromptTemplateTab({ value, onChange }: {
     value: string;
     onChange: (v: string) => void;
@@ -598,107 +517,3 @@ function ScriptTab({ value, onChange }: {
     );
 }
 
-function EnvironmentTab({ envVars, onChange }: {
-    envVars: Record<string, string>;
-    onChange: (updated: Record<string, string>) => void;
-}) {
-    const [newName, setNewName] = useState("");
-    const [newValue, setNewValue] = useState("");
-
-    const entries = Object.entries(envVars);
-
-    const handleAdd = () => {
-        const trimmed = newName.trim();
-        if (!trimmed || trimmed in envVars) return;
-        onChange({ ...envVars, [trimmed]: newValue });
-        setNewName("");
-        setNewValue("");
-    };
-
-    const handleRemove = (key: string) => {
-        const updated = { ...envVars };
-        delete updated[key];
-        onChange(updated);
-    };
-
-    const handleValueChange = (key: string, value: string) => {
-        onChange({ ...envVars, [key]: value });
-    };
-
-    return (
-        <div style={{ maxWidth: "700px" }}>
-            <p style={{ color: "#6a6e73", marginBottom: "16px" }}>
-                Custom environment variables injected into the subprocess. When configured,
-                these replace the default all-secrets injection. Reference an encrypted secret
-                using <code>{"${secret:SECRET_NAME}"}</code> syntax.
-            </p>
-
-            <Flex alignItems={{ default: "alignItemsFlexEnd" }}
-                style={{ marginBottom: "16px", gap: "8px" }}>
-                <FlexItem style={{ flex: 1 }}>
-                    <FormGroup label="Name" fieldId="env-new-name">
-                        <TextInput id="env-new-name" value={newName}
-                            onChange={(_e, v) => setNewName(v)}
-                            placeholder="e.g. GH_TOKEN"
-                            onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); handleAdd(); } }}
-                        />
-                    </FormGroup>
-                </FlexItem>
-                <FlexItem style={{ flex: 2 }}>
-                    <FormGroup label="Value" fieldId="env-new-value">
-                        <TextInput id="env-new-value" value={newValue}
-                            onChange={(_e, v) => setNewValue(v)}
-                            placeholder="e.g. ${secret:GH_TOKEN}"
-                            onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); handleAdd(); } }}
-                        />
-                    </FormGroup>
-                </FlexItem>
-                <FlexItem>
-                    <Button variant="secondary" icon={<PlusCircleIcon />}
-                        onClick={handleAdd}
-                        isDisabled={!newName.trim() || newName.trim() in envVars}
-                        style={{ marginBottom: "1px" }}>
-                        Add
-                    </Button>
-                </FlexItem>
-            </Flex>
-
-            {entries.length === 0 ? (
-                <EmptyState>
-                    <EmptyStateBody>
-                        No custom environment configured. All secrets will be injected automatically.
-                    </EmptyStateBody>
-                </EmptyState>
-            ) : (
-                <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
-                    {entries.map(([key, value]) => (
-                        <Flex key={key} alignItems={{ default: "alignItemsCenter" }}
-                            style={{
-                                padding: "8px 12px",
-                                backgroundColor: "var(--pf-t--global--background--color--secondary--default)",
-                                borderRadius: "4px",
-                            }}>
-                            <FlexItem style={{ minWidth: "160px" }}>
-                                <code style={{ fontSize: "13px", fontWeight: 600 }}>{key}</code>
-                            </FlexItem>
-                            <FlexItem grow={{ default: "grow" }}>
-                                <TextInput value={value}
-                                    onChange={(_e, v) => handleValueChange(key, v)}
-                                    aria-label={`Value for ${key}`}
-                                    style={{ fontSize: "13px" }}
-                                />
-                            </FlexItem>
-                            <FlexItem>
-                                <Button variant="plain" size="sm"
-                                    onClick={() => handleRemove(key)}
-                                    aria-label={`Remove ${key}`}>
-                                    <TimesIcon />
-                                </Button>
-                            </FlexItem>
-                        </Flex>
-                    ))}
-                </div>
-            )}
-        </div>
-    );
-}

--- a/ui/src/pages/ActionTypesPage.tsx
+++ b/ui/src/pages/ActionTypesPage.tsx
@@ -31,6 +31,7 @@ import {
     createActionType,
     deleteActionType,
 } from "../config/api";
+import { ConfirmDeleteModal } from "../components/ConfirmDeleteModal";
 
 export function ActionTypesPage() {
     const navigate = useNavigate();
@@ -150,20 +151,10 @@ export function ActionTypesPage() {
                 )}
             </div>
 
-            <Modal isOpen={deleteTarget !== null} onClose={() => setDeleteTarget(null)} variant="small">
-                <ModalHeader title="Delete Action Type" />
-                <ModalBody>
-                    Delete this action type?
-                </ModalBody>
-                <ModalFooter>
-                    <Button variant="danger" onClick={confirmDelete}>
-                        Delete
-                    </Button>
-                    <Button variant="link" onClick={() => setDeleteTarget(null)}>
-                        Cancel
-                    </Button>
-                </ModalFooter>
-            </Modal>
+            <ConfirmDeleteModal isOpen={deleteTarget !== null} title="Delete Action Type"
+                onConfirm={confirmDelete} onCancel={() => setDeleteTarget(null)}>
+                Delete this action type?
+            </ConfirmDeleteModal>
 
             {/* Simple create modal — just name and mode, then navigate to detail page */}
             <Modal isOpen={isCreateOpen} onClose={() => setIsCreateOpen(false)} variant="small">

--- a/ui/src/pages/ActorsPage.tsx
+++ b/ui/src/pages/ActorsPage.tsx
@@ -30,6 +30,7 @@ import {
     updateActor,
     deleteActor,
 } from "../config/api";
+import { ConfirmDeleteModal } from "../components/ConfirmDeleteModal";
 
 export function ActorsPage() {
     const navigate = useNavigate();
@@ -109,20 +110,10 @@ export function ActorsPage() {
                 )}
             </div>
 
-            <Modal isOpen={deleteTarget !== null} onClose={() => setDeleteTarget(null)} variant="small">
-                <ModalHeader title="Delete Actor" />
-                <ModalBody>
-                    Delete this actor?
-                </ModalBody>
-                <ModalFooter>
-                    <Button variant="danger" onClick={confirmDelete}>
-                        Delete
-                    </Button>
-                    <Button variant="link" onClick={() => setDeleteTarget(null)}>
-                        Cancel
-                    </Button>
-                </ModalFooter>
-            </Modal>
+            <ConfirmDeleteModal isOpen={deleteTarget !== null} title="Delete Actor"
+                onConfirm={confirmDelete} onCancel={() => setDeleteTarget(null)}>
+                Delete this actor?
+            </ConfirmDeleteModal>
 
             <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} variant="medium">
                 <ModalHeader title={editing ? "Edit Actor" : "Create Actor"} />

--- a/ui/src/pages/EventSourcesPage.tsx
+++ b/ui/src/pages/EventSourcesPage.tsx
@@ -36,6 +36,7 @@ import {
     updateEventSource,
     deleteEventSource,
 } from "../config/api";
+import { ConfirmDeleteModal } from "../components/ConfirmDeleteModal";
 
 export function EventSourcesPage() {
     const navigate = useNavigate();
@@ -219,20 +220,10 @@ export function EventSourcesPage() {
                 )}
             </div>
 
-            <Modal isOpen={deleteTarget !== null} onClose={() => setDeleteTarget(null)} variant="small">
-                <ModalHeader title="Delete Event Source" />
-                <ModalBody>
-                    Delete this event source?
-                </ModalBody>
-                <ModalFooter>
-                    <Button variant="danger" onClick={confirmDelete}>
-                        Delete
-                    </Button>
-                    <Button variant="link" onClick={() => setDeleteTarget(null)}>
-                        Cancel
-                    </Button>
-                </ModalFooter>
-            </Modal>
+            <ConfirmDeleteModal isOpen={deleteTarget !== null} title="Delete Event Source"
+                onConfirm={confirmDelete} onCancel={() => setDeleteTarget(null)}>
+                Delete this event source?
+            </ConfirmDeleteModal>
 
             <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} variant="medium">
                 <ModalHeader title={editing ? "Edit Event Source" : "Add Event Source"} />

--- a/ui/src/pages/McpServersPage.tsx
+++ b/ui/src/pages/McpServersPage.tsx
@@ -26,6 +26,7 @@ import {
     createMcpServer,
     deleteMcpServer,
 } from "../config/api";
+import { ConfirmDeleteModal } from "../components/ConfirmDeleteModal";
 
 export function McpServersPage() {
     const navigate = useNavigate();
@@ -120,20 +121,10 @@ export function McpServersPage() {
                 )}
             </div>
 
-            <Modal isOpen={deleteTarget !== null} onClose={() => setDeleteTarget(null)} variant="small">
-                <ModalHeader title="Delete MCP Server" />
-                <ModalBody>
-                    Delete this MCP server?
-                </ModalBody>
-                <ModalFooter>
-                    <Button variant="danger" onClick={confirmDelete}>
-                        Delete
-                    </Button>
-                    <Button variant="link" onClick={() => setDeleteTarget(null)}>
-                        Cancel
-                    </Button>
-                </ModalFooter>
-            </Modal>
+            <ConfirmDeleteModal isOpen={deleteTarget !== null} title="Delete MCP Server"
+                onConfirm={confirmDelete} onCancel={() => setDeleteTarget(null)}>
+                Delete this MCP server?
+            </ConfirmDeleteModal>
 
             <Modal isOpen={isCreateOpen} onClose={() => setIsCreateOpen(false)} variant="medium">
                 <ModalHeader title="Add MCP Server" />

--- a/ui/src/pages/ProjectDetailPage.tsx
+++ b/ui/src/pages/ProjectDetailPage.tsx
@@ -67,6 +67,7 @@ import {
 import { EditLabelsModal } from "../components/EditLabelsModal";
 import { LabelDisplay } from "../components/LabelDisplay";
 import { ExecutionLogModal } from "../components/ExecutionLogModal";
+import { ConfirmDeleteModal } from "../components/ConfirmDeleteModal";
 
 const STATUS_COLORS: Record<string, "blue" | "green" | "orange" | "grey" | "red"> = {
     Created: "blue",
@@ -402,21 +403,16 @@ export function ProjectDetailPage() {
                 </ModalFooter>
             </Modal>
 
-            <Modal isOpen={isDeleteOpen} onClose={() => setIsDeleteOpen(false)} variant="small">
-                <ModalHeader title="Delete Project" />
-                <ModalBody>
-                    Delete this project and all its data? This will remove all tasks,
-                    activity, thread entries, and workspace files. This cannot be undone.
-                </ModalBody>
-                <ModalFooter>
-                    <Button variant="danger" onClick={() => {
-                        deleteProject(id)
-                            .then(() => navigate("/projects"))
-                            .catch(console.error);
-                    }}>Delete</Button>
-                    <Button variant="link" onClick={() => setIsDeleteOpen(false)}>Cancel</Button>
-                </ModalFooter>
-            </Modal>
+            <ConfirmDeleteModal isOpen={isDeleteOpen} title="Delete Project"
+                onConfirm={() => {
+                    deleteProject(id)
+                        .then(() => navigate("/projects"))
+                        .catch(console.error);
+                }}
+                onCancel={() => setIsDeleteOpen(false)}>
+                Delete this project and all its data? This will remove all tasks,
+                activity, thread entries, and workspace files. This cannot be undone.
+            </ConfirmDeleteModal>
 
             <EditLabelsModal
                 isOpen={isLabelsOpen}

--- a/ui/src/pages/ProjectsPage.tsx
+++ b/ui/src/pages/ProjectsPage.tsx
@@ -30,6 +30,7 @@ import EyeIcon from "@patternfly/react-icons/dist/esm/icons/eye-icon";
 import EyeSlashIcon from "@patternfly/react-icons/dist/esm/icons/eye-slash-icon";
 import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
 import { ColoredLabel } from "../components/ColoredLabel";
+import { ConfirmDeleteModal } from "../components/ConfirmDeleteModal";
 import CodeBranchIcon from "@patternfly/react-icons/dist/esm/icons/code-branch-icon";
 import BugIcon from "@patternfly/react-icons/dist/esm/icons/bug-icon";
 import GithubIcon from "@patternfly/react-icons/dist/esm/icons/github-icon";
@@ -441,17 +442,11 @@ export function ProjectsPage() {
                 </ModalFooter>
             </Modal>
 
-            <Modal isOpen={deleteTarget !== null} onClose={() => setDeleteTarget(null)} variant="small">
-                <ModalHeader title="Delete Project" />
-                <ModalBody>
-                    Delete this project and all its data? This will remove all tasks,
-                    activity, thread entries, and workspace files. This cannot be undone.
-                </ModalBody>
-                <ModalFooter>
-                    <Button variant="danger" onClick={confirmDelete}>Delete</Button>
-                    <Button variant="link" onClick={() => setDeleteTarget(null)}>Cancel</Button>
-                </ModalFooter>
-            </Modal>
+            <ConfirmDeleteModal isOpen={deleteTarget !== null} title="Delete Project"
+                onConfirm={confirmDelete} onCancel={() => setDeleteTarget(null)}>
+                Delete this project and all its data? This will remove all tasks,
+                activity, thread entries, and workspace files. This cannot be undone.
+            </ConfirmDeleteModal>
         </PageSection>
     );
 }

--- a/ui/src/pages/ReportDefinitionDetailPage.tsx
+++ b/ui/src/pages/ReportDefinitionDetailPage.tsx
@@ -12,10 +12,6 @@ import {
     FormGroup,
     FormSelect,
     FormSelectOption,
-    Modal,
-    ModalBody,
-    ModalFooter,
-    ModalHeader,
     PageSection,
     Switch,
     Tab,
@@ -28,15 +24,16 @@ import {
 } from "@patternfly/react-core";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import { registerPlaceholderCompletions, REPORT_PLACEHOLDERS } from "../components/PlaceholderCompletionProvider";
-import { AddToolInput } from "../components/AddToolInput";
+import { EnvironmentTab } from "../components/EnvironmentTab";
+import { ToolListEditor } from "../components/ToolListEditor";
 import { LabelInput } from "../components/LabelInput";
 import { ReportAiModal } from "../components/ReportAiModal";
+import { ValidationProblemsPanel } from "../components/ValidationProblemsPanel";
+import { ConfirmDeleteModal } from "../components/ConfirmDeleteModal";
 import SaveIcon from "@patternfly/react-icons/dist/esm/icons/save-icon";
 import MagicIcon from "@patternfly/react-icons/dist/esm/icons/magic-icon";
 import PlayIcon from "@patternfly/react-icons/dist/esm/icons/play-icon";
 import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
-import TimesIcon from "@patternfly/react-icons/dist/esm/icons/times-icon";
-import PlusCircleIcon from "@patternfly/react-icons/dist/esm/icons/plus-circle-icon";
 import {
     type ReportDefinition,
     type NewReportDefinition,
@@ -263,9 +260,21 @@ export function ReportDefinitionDetailPage() {
                 <Tab eventKey={1} title={<TabTitleText>Allowed Tools ({tools.length})</TabTitleText>}>
                     <TabContent id="tools-tab" eventKey={1} activeKey={activeTab}
                         style={{ marginTop: "24px" }}>
-                        <AllowedToolsTab
-                            tools={tools} addTool={addTool} removeTool={removeTool}
-                            replaceTool={replaceTools}
+                        <ToolListEditor
+                            tools={tools}
+                            onAdd={addTool}
+                            onRemove={removeTool}
+                            onReplace={replaceTools}
+                            helpText={<>
+                                Define which tools the AI agent is allowed to use when generating this
+                                report. Use patterns like <code>Bash(gh issue *)</code> for specific
+                                shell commands and <code>mcp__axiom-tools__*</code> for MCP tools.
+                                Reference a toolset using <code>@ToolsetName</code> (e.g.{" "}
+                                <code>@Report Tools</code>) to include all tools from that collection.
+                            </>}
+                            emptyContent={
+                                <Alert variant="info" title="No tools configured. A default set of read-only tools will be used." ouiaId="InfoAlert" />
+                            }
                         />
                     </TabContent>
                 </Tab>
@@ -304,52 +313,17 @@ export function ReportDefinitionDetailPage() {
                         </TabTitleText>
                     }>
                         <TabContent id="problems-tab" eventKey={4} activeKey={activeTab} style={{ marginTop: "24px" }}>
-                            <div style={{ maxWidth: "700px" }}>
-                                {validationMessages.map((msg, i) => (
-                                    <div key={i} style={{
-                                        display: "flex",
-                                        alignItems: "flex-start",
-                                        gap: 8,
-                                        padding: "10px 12px",
-                                        marginBottom: 4,
-                                        borderRadius: 4,
-                                        backgroundColor: msg.severity === "error"
-                                            ? "#fef3f2" : "#fdf7e7",
-                                        border: `1px solid ${msg.severity === "error"
-                                            ? "#c9190b" : "#f0ab00"}`,
-                                    }}>
-                                        {msg.severity === "error"
-                                            ? <ExclamationCircleIcon style={{ color: "#c9190b", marginTop: 2 }} />
-                                            : <ExclamationTriangleIcon style={{ color: "#f0ab00", marginTop: 2 }} />
-                                        }
-                                        <div>
-                                            <div style={{ fontSize: "13px" }}>{msg.message}</div>
-                                            <div style={{ fontSize: "12px", color: "#6a6e73", marginTop: 2 }}>
-                                                Field: <code>{msg.field}</code>
-                                            </div>
-                                        </div>
-                                    </div>
-                                ))}
-                            </div>
+                            <ValidationProblemsPanel messages={validationMessages} />
                         </TabContent>
                     </Tab>
                 )}
             </Tabs>
 
-            <Modal isOpen={isDeleteOpen}
-                onClose={() => setIsDeleteOpen(false)}
-                variant="small"
-                aria-label="Confirm delete report definition">
-                <ModalHeader title="Delete Report Definition" />
-                <ModalBody>
-                    Are you sure you want to delete this report definition and all its
-                    generated reports? This action cannot be undone.
-                </ModalBody>
-                <ModalFooter>
-                    <Button variant="danger" onClick={handleDelete}>Delete</Button>
-                    <Button variant="link" onClick={() => setIsDeleteOpen(false)}>Cancel</Button>
-                </ModalFooter>
-            </Modal>
+            <ConfirmDeleteModal isOpen={isDeleteOpen} title="Delete Report Definition"
+                onConfirm={handleDelete} onCancel={() => setIsDeleteOpen(false)}>
+                Are you sure you want to delete this report definition and all its
+                generated reports? This action cannot be undone.
+            </ConfirmDeleteModal>
         </PageSection>
     );
 }
@@ -473,166 +447,5 @@ function PromptTemplateTab({ value, onChange }: {
     );
 }
 
-function AllowedToolsTab({ tools, addTool, removeTool, replaceTool }: {
-    tools: string[];
-    addTool: (tool: string) => void;
-    removeTool: (tool: string) => void;
-    replaceTool: (tools: string[]) => void;
-}) {
-    return (
-        <div style={{ maxWidth: "700px" }}>
-            <p style={{ color: "#6a6e73", marginBottom: "16px" }}>
-                Define which tools the AI agent is allowed to use when generating this
-                report. Use patterns like <code>Bash(gh issue *)</code> for specific
-                shell commands and <code>mcp__axiom-tools__*</code> for MCP tools.
-                Reference a toolset using <code>@ToolsetName</code> (e.g.{" "}
-                <code>@Report Tools</code>) to include all tools from that collection.
-            </p>
 
-            <div style={{ marginBottom: "16px" }}>
-                <AddToolInput onAdd={addTool} onReplace={replaceTool} existingTools={tools} />
-            </div>
-
-            {tools.length === 0 ? (
-                <Alert variant="info" title="No tools configured. A default set of read-only tools will be used." ouiaId="InfoAlert" />
-            ) : (
-                <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
-                    {tools.map((tool) => (
-                        <Flex key={tool} alignItems={{ default: "alignItemsCenter" }}
-                            style={{
-                                padding: "8px 12px",
-                                backgroundColor: tool.startsWith("@")
-                                    ? "var(--pf-t--global--background--color--primary--default)"
-                                    : "var(--pf-t--global--background--color--secondary--default)",
-                                borderRadius: "4px",
-                                border: tool.startsWith("@")
-                                    ? "1px solid var(--pf-t--global--border--color--default)"
-                                    : "none",
-                            }}>
-                            <FlexItem grow={{ default: "grow" }}>
-                                <code style={{
-                                    fontSize: "13px",
-                                    color: tool.startsWith("@")
-                                        ? "var(--pf-t--global--color--brand--default)"
-                                        : "inherit",
-                                }}>{tool}</code>
-                            </FlexItem>
-                            <FlexItem>
-                                <Button variant="plain" size="sm" onClick={() => removeTool(tool)}
-                                    aria-label={`Remove ${tool}`}>
-                                    <TimesIcon />
-                                </Button>
-                            </FlexItem>
-                        </Flex>
-                    ))}
-                </div>
-            )}
-        </div>
-    );
-}
-
-function EnvironmentTab({ envVars, onChange }: {
-    envVars: Record<string, string>;
-    onChange: (updated: Record<string, string>) => void;
-}) {
-    const [newName, setNewName] = useState("");
-    const [newValue, setNewValue] = useState("");
-
-    const entries = Object.entries(envVars);
-
-    const handleAdd = () => {
-        const trimmed = newName.trim();
-        if (!trimmed || trimmed in envVars) return;
-        onChange({ ...envVars, [trimmed]: newValue });
-        setNewName("");
-        setNewValue("");
-    };
-
-    const handleRemove = (key: string) => {
-        const updated = { ...envVars };
-        delete updated[key];
-        onChange(updated);
-    };
-
-    const handleValueChange = (key: string, value: string) => {
-        onChange({ ...envVars, [key]: value });
-    };
-
-    return (
-        <div style={{ maxWidth: "700px" }}>
-            <p style={{ color: "#6a6e73", marginBottom: "16px" }}>
-                Custom environment variables injected into the subprocess. When configured,
-                these replace the default all-secrets injection. Reference an encrypted secret
-                using <code>{"${secret:SECRET_NAME}"}</code> syntax.
-            </p>
-
-            <Flex alignItems={{ default: "alignItemsFlexEnd" }}
-                style={{ marginBottom: "16px", gap: "8px" }}>
-                <FlexItem style={{ flex: 1 }}>
-                    <FormGroup label="Name" fieldId="env-new-name">
-                        <TextInput id="env-new-name" value={newName}
-                            onChange={(_e, v) => setNewName(v)}
-                            placeholder="e.g. GH_TOKEN"
-                            onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); handleAdd(); } }}
-                        />
-                    </FormGroup>
-                </FlexItem>
-                <FlexItem style={{ flex: 2 }}>
-                    <FormGroup label="Value" fieldId="env-new-value">
-                        <TextInput id="env-new-value" value={newValue}
-                            onChange={(_e, v) => setNewValue(v)}
-                            placeholder="e.g. ${secret:GH_TOKEN}"
-                            onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); handleAdd(); } }}
-                        />
-                    </FormGroup>
-                </FlexItem>
-                <FlexItem>
-                    <Button variant="secondary" icon={<PlusCircleIcon />}
-                        onClick={handleAdd}
-                        isDisabled={!newName.trim() || newName.trim() in envVars}
-                        style={{ marginBottom: "1px" }}>
-                        Add
-                    </Button>
-                </FlexItem>
-            </Flex>
-
-            {entries.length === 0 ? (
-                <EmptyState>
-                    <EmptyStateBody>
-                        No custom environment configured. All secrets will be injected automatically.
-                    </EmptyStateBody>
-                </EmptyState>
-            ) : (
-                <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
-                    {entries.map(([key, value]) => (
-                        <Flex key={key} alignItems={{ default: "alignItemsCenter" }}
-                            style={{
-                                padding: "8px 12px",
-                                backgroundColor: "var(--pf-t--global--background--color--secondary--default)",
-                                borderRadius: "4px",
-                            }}>
-                            <FlexItem style={{ minWidth: "160px" }}>
-                                <code style={{ fontSize: "13px", fontWeight: 600 }}>{key}</code>
-                            </FlexItem>
-                            <FlexItem grow={{ default: "grow" }}>
-                                <TextInput value={value}
-                                    onChange={(_e, v) => handleValueChange(key, v)}
-                                    aria-label={`Value for ${key}`}
-                                    style={{ fontSize: "13px" }}
-                                />
-                            </FlexItem>
-                            <FlexItem>
-                                <Button variant="plain" size="sm"
-                                    onClick={() => handleRemove(key)}
-                                    aria-label={`Remove ${key}`}>
-                                    <TimesIcon />
-                                </Button>
-                            </FlexItem>
-                        </Flex>
-                    ))}
-                </div>
-            )}
-        </div>
-    );
-}
 

--- a/ui/src/pages/ReportDefinitionsPage.tsx
+++ b/ui/src/pages/ReportDefinitionsPage.tsx
@@ -28,6 +28,7 @@ import {
     createReportDefinition,
     deleteReportDefinition,
 } from "../config/api";
+import { ConfirmDeleteModal } from "../components/ConfirmDeleteModal";
 
 export function ReportDefinitionsPage() {
     const navigate = useNavigate();
@@ -146,20 +147,10 @@ export function ReportDefinitionsPage() {
                 )}
             </div>
 
-            <Modal isOpen={deleteTarget !== null} onClose={() => setDeleteTarget(null)} variant="small">
-                <ModalHeader title="Delete Report Definition" />
-                <ModalBody>
-                    Delete this report definition and all its generated reports?
-                </ModalBody>
-                <ModalFooter>
-                    <Button variant="danger" onClick={confirmDelete}>
-                        Delete
-                    </Button>
-                    <Button variant="link" onClick={() => setDeleteTarget(null)}>
-                        Cancel
-                    </Button>
-                </ModalFooter>
-            </Modal>
+            <ConfirmDeleteModal isOpen={deleteTarget !== null} title="Delete Report Definition"
+                onConfirm={confirmDelete} onCancel={() => setDeleteTarget(null)}>
+                Delete this report definition and all its generated reports?
+            </ConfirmDeleteModal>
 
             <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} variant="medium">
                 <ModalHeader title="Create Report Definition" />

--- a/ui/src/pages/ReportDetailPage.tsx
+++ b/ui/src/pages/ReportDetailPage.tsx
@@ -15,10 +15,6 @@ import {
     Flex,
     FlexItem,
     Label,
-    Modal,
-    ModalBody,
-    ModalFooter,
-    ModalHeader,
     PageSection, Spinner,
     Title,
 } from "@patternfly/react-core";
@@ -36,6 +32,7 @@ import { RenderedReport } from "../components/RenderedReport";
 import { ExecutionLogModal } from "../components/ExecutionLogModal";
 import { LabelDisplay } from "../components/LabelDisplay";
 import { EditLabelsModal } from "../components/EditLabelsModal";
+import { ConfirmDeleteModal } from "../components/ConfirmDeleteModal";
 import {If} from "@apitomy/common-ui-components";
 
 export function ReportDetailPage() {
@@ -231,19 +228,10 @@ export function ReportDetailPage() {
                 onClose={() => setIsLabelsOpen(false)}
             />
 
-            <Modal isOpen={isDeleteOpen}
-                onClose={() => setIsDeleteOpen(false)}
-                variant="small"
-                aria-label="Confirm delete report">
-                <ModalHeader title="Delete Report" />
-                <ModalBody>
-                    Are you sure you want to delete this report? This action cannot be undone.
-                </ModalBody>
-                <ModalFooter>
-                    <Button variant="danger" onClick={handleDelete}>Delete</Button>
-                    <Button variant="link" onClick={() => setIsDeleteOpen(false)}>Cancel</Button>
-                </ModalFooter>
-            </Modal>
+            <ConfirmDeleteModal isOpen={isDeleteOpen} title="Delete Report"
+                onConfirm={handleDelete} onCancel={() => setIsDeleteOpen(false)}>
+                Are you sure you want to delete this report? This action cannot be undone.
+            </ConfirmDeleteModal>
         </PageSection>
     );
 }

--- a/ui/src/pages/ReportsPage.tsx
+++ b/ui/src/pages/ReportsPage.tsx
@@ -7,10 +7,6 @@ import {
     EmptyStateFooter,
     EmptyStateActions,
     Label,
-    Modal,
-    ModalBody,
-    ModalFooter,
-    ModalHeader,
     PageSection,
     Pagination,
     Title,
@@ -29,6 +25,7 @@ import {
     FilterChips,
 } from "@apitomy/common-ui-components";
 import { type Report, fetchReports, deleteReport } from "../config/api";
+import { ConfirmDeleteModal } from "../components/ConfirmDeleteModal";
 
 const STATUS_COLORS: Record<string, "blue" | "green" | "grey" | "red"> = {
     Pending: "blue",
@@ -264,16 +261,10 @@ export function ReportsPage() {
                 )}
             </div>
 
-            <Modal isOpen={deleteTarget !== null} onClose={() => setDeleteTarget(null)} variant="small">
-                <ModalHeader title="Delete Report" />
-                <ModalBody>
-                    Are you sure you want to delete this report? This action cannot be undone.
-                </ModalBody>
-                <ModalFooter>
-                    <Button variant="danger" onClick={confirmDelete}>Delete</Button>
-                    <Button variant="link" onClick={() => setDeleteTarget(null)}>Cancel</Button>
-                </ModalFooter>
-            </Modal>
+            <ConfirmDeleteModal isOpen={deleteTarget !== null} title="Delete Report"
+                onConfirm={confirmDelete} onCancel={() => setDeleteTarget(null)}>
+                Are you sure you want to delete this report? This action cannot be undone.
+            </ConfirmDeleteModal>
         </PageSection>
     );
 }

--- a/ui/src/pages/SecretsPage.tsx
+++ b/ui/src/pages/SecretsPage.tsx
@@ -28,6 +28,7 @@ import {
     updateSecret,
     deleteSecret,
 } from "../config/api";
+import { ConfirmDeleteModal } from "../components/ConfirmDeleteModal";
 
 export function SecretsPage() {
     const [secrets, setSecrets] = useState<Secret[]>([]);
@@ -144,20 +145,10 @@ export function SecretsPage() {
                 )}
             </div>
 
-            <Modal isOpen={deleteTarget !== null} onClose={() => setDeleteTarget(null)} variant="small">
-                <ModalHeader title="Delete Secret" />
-                <ModalBody>
-                    Delete this secret? This cannot be undone.
-                </ModalBody>
-                <ModalFooter>
-                    <Button variant="danger" onClick={confirmDelete}>
-                        Delete
-                    </Button>
-                    <Button variant="link" onClick={() => setDeleteTarget(null)}>
-                        Cancel
-                    </Button>
-                </ModalFooter>
-            </Modal>
+            <ConfirmDeleteModal isOpen={deleteTarget !== null} title="Delete Secret"
+                onConfirm={confirmDelete} onCancel={() => setDeleteTarget(null)}>
+                Delete this secret? This cannot be undone.
+            </ConfirmDeleteModal>
 
             <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} variant="medium">
                 <ModalHeader title={editing ? "Update Secret" : "Add Secret"} />

--- a/ui/src/pages/TasksPage.tsx
+++ b/ui/src/pages/TasksPage.tsx
@@ -5,10 +5,6 @@ import {
     EmptyState,
     EmptyStateBody,
     Label,
-    Modal,
-    ModalBody,
-    ModalFooter,
-    ModalHeader,
     PageSection,
     Pagination,
     Title,
@@ -27,6 +23,7 @@ import {
 } from "@apitomy/common-ui-components";
 import { type Task, fetchAllTasks, cancelTask } from "../config/api";
 import { ExecutionLogModal } from "../components/ExecutionLogModal";
+import { ConfirmDeleteModal } from "../components/ConfirmDeleteModal";
 
 const STATUS_COLORS: Record<string, "blue" | "green" | "orange" | "grey" | "red"> = {
     Pending: "blue",
@@ -266,20 +263,11 @@ export function TasksPage() {
                 onClose={() => setIsLogModalOpen(false)}
             />
 
-            <Modal isOpen={cancelTarget !== null} onClose={() => setCancelTarget(null)} variant="small">
-                <ModalHeader title="Cancel Task" />
-                <ModalBody>
-                    {cancelTarget && `Cancel task #${cancelTarget.id} (${cancelTarget.actionType})?`}
-                </ModalBody>
-                <ModalFooter>
-                    <Button variant="danger" onClick={confirmCancel}>
-                        Cancel Task
-                    </Button>
-                    <Button variant="link" onClick={() => setCancelTarget(null)}>
-                        Cancel
-                    </Button>
-                </ModalFooter>
-            </Modal>
+            <ConfirmDeleteModal isOpen={cancelTarget !== null} title="Cancel Task"
+                onConfirm={confirmCancel} onCancel={() => setCancelTarget(null)}
+                confirmLabel="Cancel Task">
+                {cancelTarget && `Cancel task #${cancelTarget.id} (${cancelTarget.actionType})?`}
+            </ConfirmDeleteModal>
         </PageSection>
     );
 }

--- a/ui/src/pages/ToolDetailPage.tsx
+++ b/ui/src/pages/ToolDetailPage.tsx
@@ -51,6 +51,7 @@ import ExclamationCircleIcon from "@patternfly/react-icons/dist/esm/icons/exclam
 import { EditLabelsModal } from "../components/EditLabelsModal";
 import { LabelDisplay } from "../components/LabelDisplay";
 import { ToolAiModal } from "../components/ToolAiModal";
+import { ValidationProblemsPanel } from "../components/ValidationProblemsPanel";
 
 export function ToolDetailPage() {
     const { toolId } = useParams<{ toolId: string }>();
@@ -241,33 +242,7 @@ export function ToolDetailPage() {
                         </TabTitleText>
                     }>
                         <TabContent id="problems-tab" eventKey={4} activeKey={activeTab} style={{ marginTop: "24px" }}>
-                            <div style={{ maxWidth: "700px" }}>
-                                {validationMessages.map((msg, i) => (
-                                    <div key={i} style={{
-                                        display: "flex",
-                                        alignItems: "flex-start",
-                                        gap: 8,
-                                        padding: "10px 12px",
-                                        marginBottom: 4,
-                                        borderRadius: 4,
-                                        backgroundColor: msg.severity === "error"
-                                            ? "#fef3f2" : "#fdf7e7",
-                                        border: `1px solid ${msg.severity === "error"
-                                            ? "#c9190b" : "#f0ab00"}`,
-                                    }}>
-                                        {msg.severity === "error"
-                                            ? <ExclamationCircleIcon style={{ color: "#c9190b", marginTop: 2 }} />
-                                            : <ExclamationTriangleIcon style={{ color: "#f0ab00", marginTop: 2 }} />
-                                        }
-                                        <div>
-                                            <div style={{ fontSize: "13px" }}>{msg.message}</div>
-                                            <div style={{ fontSize: "12px", color: "#6a6e73", marginTop: 2 }}>
-                                                Field: <code>{msg.field}</code>
-                                            </div>
-                                        </div>
-                                    </div>
-                                ))}
-                            </div>
+                            <ValidationProblemsPanel messages={validationMessages} />
                         </TabContent>
                     </Tab>
                 )}

--- a/ui/src/pages/ToolsPage.tsx
+++ b/ui/src/pages/ToolsPage.tsx
@@ -38,6 +38,7 @@ import {
     createTool,
     deleteTool,
 } from "../config/api";
+import { ConfirmDeleteModal } from "../components/ConfirmDeleteModal";
 
 const FILTER_TYPES: ChipFilterType[] = [
     { value: "name", label: "Name", testId: "tool-filter-name" },
@@ -244,20 +245,10 @@ export function ToolsPage() {
                 )}
             </div>
 
-            <Modal isOpen={deleteTarget !== null} onClose={() => setDeleteTarget(null)} variant="small">
-                <ModalHeader title="Delete Tool" />
-                <ModalBody>
-                    Delete this tool?
-                </ModalBody>
-                <ModalFooter>
-                    <Button variant="danger" onClick={confirmDelete}>
-                        Delete
-                    </Button>
-                    <Button variant="link" onClick={() => setDeleteTarget(null)}>
-                        Cancel
-                    </Button>
-                </ModalFooter>
-            </Modal>
+            <ConfirmDeleteModal isOpen={deleteTarget !== null} title="Delete Tool"
+                onConfirm={confirmDelete} onCancel={() => setDeleteTarget(null)}>
+                Delete this tool?
+            </ConfirmDeleteModal>
 
             <Modal isOpen={isCreateOpen} onClose={() => setIsCreateOpen(false)} variant="small">
                 <ModalHeader title="Create Tool" />

--- a/ui/src/pages/ToolsetDetailPage.tsx
+++ b/ui/src/pages/ToolsetDetailPage.tsx
@@ -15,9 +15,8 @@ import {
     TextInput,
     Title,
 } from "@patternfly/react-core";
-import { AddToolInput } from "../components/AddToolInput";
+import { ToolListEditor } from "../components/ToolListEditor";
 import SaveIcon from "@patternfly/react-icons/dist/esm/icons/save-icon";
-import TimesIcon from "@patternfly/react-icons/dist/esm/icons/times-icon";
 import {
     type Toolset,
     type NewToolset,
@@ -135,63 +134,27 @@ export function ToolsetDetailPage() {
                 </FormGroup>
             </Form>
 
-            <div style={{ maxWidth: "700px" }}>
-                <Title headingLevel="h2" size="md" style={{ marginBottom: "8px" }}>
-                    Tools ({tools.length})
-                </Title>
-                <p style={{ color: "#6a6e73", marginBottom: "16px" }}>
+            <Title headingLevel="h2" size="md" style={{ marginBottom: "8px" }}>
+                Tools ({tools.length})
+            </Title>
+            <ToolListEditor
+                tools={tools}
+                onAdd={addTool}
+                onRemove={removeTool}
+                onReplace={replaceTools}
+                helpText={<>
                     Define the tools in this toolset. You can add individual tool
                     patterns like <code>Bash(git log *)</code> or reference other
                     toolsets using the <code>@ToolsetName</code> syntax.
-                </p>
-
-                <div style={{ marginBottom: "16px" }}>
-                    <AddToolInput onAdd={addTool} onReplace={replaceTools} existingTools={tools} />
-                </div>
-
-                {tools.length === 0 ? (
+                </>}
+                emptyContent={
                     <EmptyState variant="xs">
                         <EmptyStateBody>
                             No tools in this toolset yet.
                         </EmptyStateBody>
                     </EmptyState>
-                ) : (
-                    <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
-                        {tools.map((tool) => (
-                            <Flex key={tool}
-                                alignItems={{ default: "alignItemsCenter" }}
-                                style={{
-                                    padding: "8px 12px",
-                                    backgroundColor: tool.startsWith("@")
-                                        ? "var(--pf-t--global--background--color--primary--default)"
-                                        : "var(--pf-t--global--background--color--secondary--default)",
-                                    borderRadius: "4px",
-                                    border: tool.startsWith("@")
-                                        ? "1px solid var(--pf-t--global--border--color--default)"
-                                        : "none",
-                                }}>
-                                <FlexItem grow={{ default: "grow" }}>
-                                    <code style={{
-                                        fontSize: "13px",
-                                        color: tool.startsWith("@")
-                                            ? "var(--pf-t--global--color--brand--default)"
-                                            : "inherit",
-                                    }}>
-                                        {tool}
-                                    </code>
-                                </FlexItem>
-                                <FlexItem>
-                                    <Button variant="plain" size="sm"
-                                        onClick={() => removeTool(tool)}
-                                        aria-label={`Remove ${tool}`}>
-                                        <TimesIcon />
-                                    </Button>
-                                </FlexItem>
-                            </Flex>
-                        ))}
-                    </div>
-                )}
-            </div>
+                }
+            />
         </PageSection>
     );
 }

--- a/ui/src/pages/ToolsetsPage.tsx
+++ b/ui/src/pages/ToolsetsPage.tsx
@@ -25,6 +25,7 @@ import {
     createToolset,
     deleteToolset,
 } from "../config/api";
+import { ConfirmDeleteModal } from "../components/ConfirmDeleteModal";
 
 export function ToolsetsPage() {
     const navigate = useNavigate();
@@ -115,20 +116,10 @@ export function ToolsetsPage() {
                 )}
             </div>
 
-            <Modal isOpen={deleteTarget !== null} onClose={() => setDeleteTarget(null)} variant="small">
-                <ModalHeader title="Delete Toolset" />
-                <ModalBody>
-                    Delete this toolset?
-                </ModalBody>
-                <ModalFooter>
-                    <Button variant="danger" onClick={confirmDelete}>
-                        Delete
-                    </Button>
-                    <Button variant="link" onClick={() => setDeleteTarget(null)}>
-                        Cancel
-                    </Button>
-                </ModalFooter>
-            </Modal>
+            <ConfirmDeleteModal isOpen={deleteTarget !== null} title="Delete Toolset"
+                onConfirm={confirmDelete} onCancel={() => setDeleteTarget(null)}>
+                Delete this toolset?
+            </ConfirmDeleteModal>
 
             <Modal isOpen={isCreateOpen} onClose={() => setIsCreateOpen(false)} variant="medium">
                 <ModalHeader title="Add Toolset" />


### PR DESCRIPTION
## Summary

- Extracted four shared React components from duplicated code across 17 page files
- **EnvironmentTab**: key-value editor for environment variables (was copy-pasted between ActionTypeDetailPage and ReportDefinitionDetailPage)
- **ToolListEditor**: tool pattern list with add/remove and @-prefix toolset styling (was duplicated across ActionTypeDetailPage, ReportDefinitionDetailPage, and ToolsetDetailPage)
- **ValidationProblemsPanel**: severity-based validation message display (was triplicated across ActionTypeDetailPage, ToolDetailPage, and ReportDefinitionDetailPage)
- **ConfirmDeleteModal**: standardized destructive action confirmation dialog (was inlined across 14 pages)
- Net reduction of ~275 lines (409 added, 684 removed) with zero behavioral changes

## Test plan

- [ ] Verify TypeScript compiles cleanly (`npx tsc --noEmit` passes)
- [ ] Verify delete confirmation modals still work on list pages (ActionTypes, Tools, MCP Servers, Toolsets, Actors, EventSources, ReportDefinitions, Reports, Secrets, Projects)
- [ ] Verify cancel confirmation modal still works on TasksPage
- [ ] Verify delete confirmation modals still work on detail pages (ReportDefinitionDetail, ReportDetail, ProjectDetail)
- [ ] Verify environment variable editing works on ActionTypeDetailPage and ReportDefinitionDetailPage
- [ ] Verify allowed tools editing works on ActionTypeDetailPage, ReportDefinitionDetailPage, and ToolsetDetailPage
- [ ] Verify validation problems tab renders correctly on ActionTypeDetailPage, ToolDetailPage, and ReportDefinitionDetailPage