### PR TITLE
Extract AiEditModal and BooleanStatusIcon reusable components

### DIFF
--- a/ui/src/components/ActionTypeAiModal.tsx
+++ b/ui/src/components/ActionTypeAiModal.tsx
@@ -1,31 +1,13 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import {
-    Button,
-    Content,
     Flex,
     FlexItem,
-    Grid,
-    GridItem,
-    Modal,
-    ModalBody,
-    ModalFooter,
-    ModalHeader,
-    Spinner,
-    Stack,
     StackItem,
-    TextArea,
     Title,
 } from "@patternfly/react-core";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
-import Markdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import PaperPlaneIcon from "@patternfly/react-icons/dist/esm/icons/paper-plane-icon";
 import { aiEditActionPrompt } from "../config/api";
-
-interface ChatMessage {
-    role: "user" | "assistant";
-    content: string;
-}
+import { AiEditModal } from "./AiEditModal";
 
 interface ActionTypeAiModalProps {
     isOpen: boolean;
@@ -46,12 +28,8 @@ export function ActionTypeAiModal({
     isOpen, promptTemplate, allowedTools, actionTypeName, actionTypeDescription,
     onApply, onClose,
 }: ActionTypeAiModalProps) {
-    const [messages, setMessages] = useState<ChatMessage[]>([]);
-    const [input, setInput] = useState("");
-    const [loading, setLoading] = useState(false);
     const [localPrompt, setLocalPrompt] = useState(promptTemplate);
     const [localTools, setLocalTools] = useState(allowedTools);
-    const messagesEndRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
         if (isOpen) {
@@ -60,199 +38,91 @@ export function ActionTypeAiModal({
         }
     }, [isOpen, promptTemplate, allowedTools]);
 
-    useEffect(() => {
-        messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-    }, [messages]);
-
-    const handleSend = () => {
-        const text = input.trim();
-        if (!text || loading) return;
-
-        setMessages((prev) => [...prev, { role: "user", content: text }]);
-        setInput("");
-        setLoading(true);
-
+    const handleSend = (message: string) =>
         aiEditActionPrompt({
-            message: text,
+            message,
             currentPromptTemplate: localPrompt || undefined,
             currentAllowedTools: localTools.length > 0 ? localTools : undefined,
             reportName: actionTypeName,
             reportDescription: actionTypeDescription,
-        })
-            .then((response) => {
-                setMessages((prev) => [
-                    ...prev,
-                    { role: "assistant", content: response.explanation || "Done." },
-                ]);
-                if (response.promptTemplate) {
-                    setLocalPrompt(response.promptTemplate);
-                }
-                if (Array.isArray(response.allowedTools)) {
-                    setLocalTools(response.allowedTools);
-                }
-            })
-            .catch((err) => {
-                setMessages((prev) => [
-                    ...prev,
-                    { role: "assistant", content: "Error: " + err.message },
-                ]);
-            })
-            .finally(() => setLoading(false));
-    };
-
-    const handleApply = () => {
-        onApply(localPrompt, localTools);
-        onClose();
-    };
+        }).then((response) => {
+            if (response.promptTemplate) {
+                setLocalPrompt(response.promptTemplate);
+            }
+            if (Array.isArray(response.allowedTools)) {
+                setLocalTools(response.allowedTools);
+            }
+            return { explanation: response.explanation || "Done." };
+        });
 
     return (
-        <Modal isOpen={isOpen} onClose={onClose} variant="large"
-            style={{ maxWidth: "95vw", width: "95vw" }}>
-            <ModalHeader title="AI-Assisted Action Type Editor" />
-            <ModalBody style={{ padding: 0, height: "100vh", display: "flex" }}>
-                <Grid style={{ width: "100%" }}>
-                    <GridItem className="content" span={9}>
-                        <Stack>
-                            <StackItem style={{ padding: "16px", paddingBottom: "8px" }}>
-                                <Title headingLevel="h4" size="md" style={{ marginBottom: "8px" }}>
-                                    Allowed Tools ({localTools.length})
-                                </Title>
-                                {localTools.length > 0 ? (
-                                    <div style={{ display: "flex", flexWrap: "wrap", gap: "4px",
-                                        maxHeight: "80px", overflowY: "auto" }}>
-                                        {localTools.map((tool) => (
-                                            <Flex key={tool}
-                                                alignItems={{ default: "alignItemsCenter" }}
-                                                style={{
-                                                    padding: "4px 8px",
-                                                    backgroundColor: tool.startsWith("@")
-                                                        ? "var(--pf-t--global--background--color--primary--default)"
-                                                        : "var(--pf-t--global--background--color--secondary--default)",
-                                                    borderRadius: "4px",
-                                                    border: tool.startsWith("@")
-                                                        ? "1px solid var(--pf-t--global--border--color--default)"
-                                                        : "none",
-                                                }}>
-                                                <FlexItem>
-                                                    <code style={{
-                                                        fontSize: "12px",
-                                                        color: tool.startsWith("@")
-                                                            ? "var(--pf-t--global--color--brand--default)"
-                                                            : "inherit",
-                                                    }}>{tool}</code>
-                                                </FlexItem>
-                                            </Flex>
-                                        ))}
-                                    </div>
-                                ) : (
-                                    <div style={{ color: "#6a6e73", fontSize: "13px" }}>
-                                        No tools configured. Ask the AI to recommend tools.
-                                    </div>
-                                )}
-                            </StackItem>
-                            <StackItem style={{ paddingLeft: "16px", paddingBottom: "4px" }}>
-                                <Title headingLevel="h4" size="md">
-                                    Prompt Template
-                                </Title>
-                                <div style={{ color: "#6a6e73", fontSize: "13px", marginTop: "2px" }}>
-                                    Placeholders:{" "}
-                                    <code>{"{{managerInput}}"}</code>,{" "}
-                                    <code>{"{{issueRef}}"}</code>,{" "}
-                                    <code>{"{{repository}}"}</code>,{" "}
-                                    <code>{"{{projectName}}"}</code>
-                                </div>
-                            </StackItem>
-                            <StackItem isFilled style={{ paddingLeft: "16px", paddingRight: "16px" }}>
-                                <CodeEditor
-                                    code={localPrompt || ""}
-                                    language={Language.markdown}
-                                    isFullHeight
-                                    isReadOnly={false}
-                                    isLineNumbersVisible
-                                />
-                            </StackItem>
-                        </Stack>
-                    </GridItem>
-                    <GridItem className="chat" span={3} style={{
-                        borderLeft: "1px solid var(--pf-t--global--border--color--default)",
-                    }}>
-                        <Stack>
-                            <StackItem isFilled style={{
-                                overflowY: "auto", padding: "16px",
-                                display: "flex", flexDirection: "column", gap: "12px",
-                            }}>
-                                {messages.length === 0 && (
-                                    <div style={{
-                                        color: "#6a6e73", fontSize: "13px", textAlign: "center",
-                                        marginTop: "32px",
-                                    }}>
-                                        Describe what this action type should do. The AI will
-                                        generate a prompt template and recommend the appropriate
-                                        tools.
-                                    </div>
-                                )}
-                                {messages.map((msg, i) => (
-                                    <div key={i} style={{
-                                        alignSelf: msg.role === "user" ? "flex-end" : "flex-start",
-                                        maxWidth: "90%", padding: "8px 12px", borderRadius: "8px",
-                                        backgroundColor: msg.role === "user"
+        <AiEditModal
+            isOpen={isOpen}
+            onClose={onClose}
+            onApply={() => onApply(localPrompt, localTools)}
+            title="AI-Assisted Action Type Editor"
+            placeholder="Describe what this action type should do..."
+            emptyHint="Describe what this action type should do. The AI will generate a prompt template and recommend the appropriate tools."
+            onSendMessage={handleSend}
+        >
+            <StackItem style={{ padding: "16px", paddingBottom: "8px" }}>
+                <Title headingLevel="h4" size="md" style={{ marginBottom: "8px" }}>
+                    Allowed Tools ({localTools.length})
+                </Title>
+                {localTools.length > 0 ? (
+                    <div style={{ display: "flex", flexWrap: "wrap", gap: "4px",
+                        maxHeight: "80px", overflowY: "auto" }}>
+                        {localTools.map((tool) => (
+                            <Flex key={tool}
+                                alignItems={{ default: "alignItemsCenter" }}
+                                style={{
+                                    padding: "4px 8px",
+                                    backgroundColor: tool.startsWith("@")
+                                        ? "var(--pf-t--global--background--color--primary--default)"
+                                        : "var(--pf-t--global--background--color--secondary--default)",
+                                    borderRadius: "4px",
+                                    border: tool.startsWith("@")
+                                        ? "1px solid var(--pf-t--global--border--color--default)"
+                                        : "none",
+                                }}>
+                                <FlexItem>
+                                    <code style={{
+                                        fontSize: "12px",
+                                        color: tool.startsWith("@")
                                             ? "var(--pf-t--global--color--brand--default)"
-                                            : "var(--pf-t--global--background--color--secondary--default)",
-                                        color: msg.role === "user" ? "white" : "inherit",
-                                        fontSize: "13px",
-                                    }}>
-                                        {msg.role === "assistant" ? (
-                                            <Content>
-                                                <Markdown remarkPlugins={[remarkGfm]}>{msg.content}</Markdown>
-                                            </Content>
-                                        ) : msg.content}
-                                    </div>
-                                ))}
-                                {loading && (
-                                    <div style={{
-                                        alignSelf: "flex-start", padding: "8px 12px", borderRadius: "8px",
-                                        backgroundColor: "var(--pf-t--global--background--color--secondary--default)",
-                                        fontSize: "13px", color: "#6a6e73",
-                                    }}>
-                                        <Spinner size="sm" style={{ marginRight: "5px" }} />
-                                        Thinking...
-                                    </div>
-                                )}
-                                <div ref={messagesEndRef} />
-                            </StackItem>
-                            <StackItem style={{
-                                padding: "6px 8px",
-                                borderTop: "1px solid var(--pf-t--global--border--color--default)",
-                                display: "flex", gap: "8px",
-                            }}>
-                                <TextArea
-                                    value={input}
-                                    onChange={(_e, v) => setInput(v)}
-                                    onKeyDown={(e) => {
-                                        if (e.key === "Enter" && !e.shiftKey) {
-                                            e.preventDefault();
-                                            handleSend();
-                                        }
-                                    }}
-                                    placeholder="Describe what this action type should do..."
-                                    rows={2}
-                                    isDisabled={loading}
-                                    style={{ flex: 1, resize: "none" }}
-                                />
-                                <Button variant="primary" onClick={handleSend}
-                                    isDisabled={!input.trim() || loading}
-                                    style={{ alignSelf: "flex-end" }}>
-                                    <PaperPlaneIcon />
-                                </Button>
-                            </StackItem>
-                        </Stack>
-                    </GridItem>
-                </Grid>
-            </ModalBody>
-            <ModalFooter>
-                <Button variant="primary" onClick={handleApply}>Apply Changes</Button>
-                <Button variant="link" onClick={onClose}>Cancel</Button>
-            </ModalFooter>
-        </Modal>
+                                            : "inherit",
+                                    }}>{tool}</code>
+                                </FlexItem>
+                            </Flex>
+                        ))}
+                    </div>
+                ) : (
+                    <div style={{ color: "#6a6e73", fontSize: "13px" }}>
+                        No tools configured. Ask the AI to recommend tools.
+                    </div>
+                )}
+            </StackItem>
+            <StackItem style={{ paddingLeft: "16px", paddingBottom: "4px" }}>
+                <Title headingLevel="h4" size="md">
+                    Prompt Template
+                </Title>
+                <div style={{ color: "#6a6e73", fontSize: "13px", marginTop: "2px" }}>
+                    Placeholders:{" "}
+                    <code>{"{{managerInput}}"}</code>,{" "}
+                    <code>{"{{issueRef}}"}</code>,{" "}
+                    <code>{"{{repository}}"}</code>,{" "}
+                    <code>{"{{projectName}}"}</code>
+                </div>
+            </StackItem>
+            <StackItem isFilled style={{ paddingLeft: "16px", paddingRight: "16px" }}>
+                <CodeEditor
+                    code={localPrompt || ""}
+                    language={Language.markdown}
+                    isFullHeight
+                    isReadOnly={false}
+                    isLineNumbersVisible
+                />
+            </StackItem>
+        </AiEditModal>
     );
 }

--- a/ui/src/components/AiEditModal.tsx
+++ b/ui/src/components/AiEditModal.tsx
@@ -1,0 +1,186 @@
+import { type ReactNode, useEffect, useRef, useState } from "react";
+import {
+    Button,
+    Content,
+    Grid,
+    GridItem,
+    Modal,
+    ModalBody,
+    ModalFooter,
+    ModalHeader,
+    Spinner,
+    Stack,
+    StackItem,
+    TextArea,
+} from "@patternfly/react-core";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import PaperPlaneIcon from "@patternfly/react-icons/dist/esm/icons/paper-plane-icon";
+
+interface ChatMessage {
+    role: "user" | "assistant";
+    content: string;
+}
+
+interface AiEditModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onApply: () => void;
+    title: string;
+    placeholder: string;
+    emptyHint: string;
+    onSendMessage: (message: string) => Promise<{ explanation: string }>;
+    children: ReactNode;
+}
+
+/**
+ * Shared modal for AI-assisted editing. Renders a 9:3 grid with the
+ * caller-provided content panel on the left and a chat interface on
+ * the right. The modal manages all chat state internally.
+ */
+export function AiEditModal({
+    isOpen, onClose, onApply, title, placeholder, emptyHint,
+    onSendMessage, children,
+}: AiEditModalProps) {
+    const [messages, setMessages] = useState<ChatMessage[]>([]);
+    const [input, setInput] = useState("");
+    const [loading, setLoading] = useState(false);
+    const messagesEndRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    }, [messages]);
+
+    const handleSend = () => {
+        const text = input.trim();
+        if (!text || loading) return;
+
+        setMessages((prev) => [...prev, { role: "user", content: text }]);
+        setInput("");
+        setLoading(true);
+
+        onSendMessage(text)
+            .then((response) => {
+                setMessages((prev) => [
+                    ...prev,
+                    { role: "assistant", content: response.explanation || "Done." },
+                ]);
+            })
+            .catch((err) => {
+                setMessages((prev) => [
+                    ...prev,
+                    { role: "assistant", content: "Error: " + err.message },
+                ]);
+            })
+            .finally(() => setLoading(false));
+    };
+
+    const handleApply = () => {
+        onApply();
+        onClose();
+    };
+
+    return (
+        <Modal isOpen={isOpen} onClose={onClose} variant="large"
+            style={{ maxWidth: "95vw", width: "95vw" }}>
+            <ModalHeader title={title} />
+            <ModalBody style={{ padding: 0, height: "100vh", display: "flex" }}>
+                <Grid style={{ width: "100%" }}>
+                    <GridItem className="content" span={9}>
+                        <Stack>
+                            {children}
+                        </Stack>
+                    </GridItem>
+                    <GridItem className="chat" span={3} style={{
+                        borderLeft: "1px solid var(--pf-t--global--border--color--default)",
+                    }}>
+                        <Stack>
+                            <StackItem isFilled style={{
+                                overflowY: "auto",
+                                padding: "16px",
+                                display: "flex",
+                                flexDirection: "column",
+                                gap: "12px",
+                            }}>
+                                {messages.length === 0 && (
+                                    <div style={{
+                                        color: "#6a6e73", fontSize: "13px", textAlign: "center",
+                                        marginTop: "32px",
+                                    }}>
+                                        {emptyHint}
+                                    </div>
+                                )}
+                                {messages.map((msg, i) => (
+                                    <div key={i} style={{
+                                        alignSelf: msg.role === "user" ? "flex-end" : "flex-start",
+                                        maxWidth: "90%",
+                                        padding: "8px 12px",
+                                        borderRadius: "8px",
+                                        backgroundColor: msg.role === "user"
+                                            ? "var(--pf-t--global--color--brand--default)"
+                                            : "var(--pf-t--global--background--color--secondary--default)",
+                                        color: msg.role === "user" ? "white" : "inherit",
+                                        fontSize: "13px",
+                                    }}>
+                                        {msg.role === "assistant" ? (
+                                            <Content>
+                                                <Markdown remarkPlugins={[remarkGfm]}>{msg.content}</Markdown>
+                                            </Content>
+                                        ) : msg.content}
+                                    </div>
+                                ))}
+                                {loading && (
+                                    <div style={{
+                                        alignSelf: "flex-start",
+                                        padding: "8px 12px",
+                                        borderRadius: "8px",
+                                        backgroundColor: "var(--pf-t--global--background--color--secondary--default)",
+                                        fontSize: "13px",
+                                        color: "#6a6e73",
+                                    }}>
+                                        <Spinner size="sm" style={{ marginRight: "5px" }} />
+                                        Thinking...
+                                    </div>
+                                )}
+                                <div ref={messagesEndRef} />
+                            </StackItem>
+                            <StackItem style={{
+                                padding: "6px 8px",
+                                borderTop: "1px solid var(--pf-t--global--border--color--default)",
+                                display: "flex",
+                                gap: "8px",
+                            }}>
+                                <TextArea
+                                    value={input}
+                                    onChange={(_e, v) => setInput(v)}
+                                    onKeyDown={(e) => {
+                                        if (e.key === "Enter" && !e.shiftKey) {
+                                            e.preventDefault();
+                                            handleSend();
+                                        }
+                                    }}
+                                    placeholder={placeholder}
+                                    rows={2}
+                                    isDisabled={loading}
+                                    style={{ flex: 1, resize: "none" }}
+                                />
+                                <Button
+                                    variant="primary"
+                                    onClick={handleSend}
+                                    isDisabled={!input.trim() || loading}
+                                    style={{ alignSelf: "flex-end" }}
+                                >
+                                    <PaperPlaneIcon />
+                                </Button>
+                            </StackItem>
+                        </Stack>
+                    </GridItem>
+                </Grid>
+            </ModalBody>
+            <ModalFooter>
+                <Button variant="primary" onClick={handleApply}>Apply Changes</Button>
+                <Button variant="link" onClick={onClose}>Cancel</Button>
+            </ModalFooter>
+        </Modal>
+    );
+}

--- a/ui/src/components/BooleanStatusIcon.tsx
+++ b/ui/src/components/BooleanStatusIcon.tsx
@@ -1,0 +1,11 @@
+import CheckCircleIcon from "@patternfly/react-icons/dist/esm/icons/check-circle-icon";
+import MinusCircleIcon from "@patternfly/react-icons/dist/esm/icons/minus-circle-icon";
+
+/**
+ * Renders a green check or grey minus icon for boolean table cells.
+ */
+export function BooleanStatusIcon({ value }: { value: boolean }) {
+    return value
+        ? <CheckCircleIcon color="var(--pf-t--global--color--status--success--default)" />
+        : <MinusCircleIcon color="var(--pf-t--global--icon--color--disabled)" />;
+}

--- a/ui/src/components/ReportAiModal.tsx
+++ b/ui/src/components/ReportAiModal.tsx
@@ -1,31 +1,13 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import {
-    Button,
-    Content,
     Flex,
     FlexItem,
-    Grid,
-    GridItem,
-    Modal,
-    ModalBody,
-    ModalFooter,
-    ModalHeader,
-    Spinner,
-    Stack,
     StackItem,
-    TextArea,
     Title,
 } from "@patternfly/react-core";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
-import Markdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import PaperPlaneIcon from "@patternfly/react-icons/dist/esm/icons/paper-plane-icon";
 import { aiEditReportPrompt } from "../config/api";
-
-interface ChatMessage {
-    role: "user" | "assistant";
-    content: string;
-}
+import { AiEditModal } from "./AiEditModal";
 
 interface ReportAiModalProps {
     isOpen: boolean;
@@ -46,12 +28,8 @@ export function ReportAiModal({
     isOpen, promptTemplate, allowedTools, reportName, reportDescription,
     onApply, onClose,
 }: ReportAiModalProps) {
-    const [messages, setMessages] = useState<ChatMessage[]>([]);
-    const [input, setInput] = useState("");
-    const [loading, setLoading] = useState(false);
     const [localPrompt, setLocalPrompt] = useState(promptTemplate);
     const [localTools, setLocalTools] = useState(allowedTools);
-    const messagesEndRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
         if (isOpen) {
@@ -60,219 +38,93 @@ export function ReportAiModal({
         }
     }, [isOpen, promptTemplate, allowedTools]);
 
-    useEffect(() => {
-        messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-    }, [messages]);
-
-    const handleSend = () => {
-        const text = input.trim();
-        if (!text || loading) return;
-
-        setMessages((prev) => [...prev, { role: "user", content: text }]);
-        setInput("");
-        setLoading(true);
-
+    const handleSend = (message: string) =>
         aiEditReportPrompt({
-            message: text,
+            message,
             currentPromptTemplate: localPrompt || undefined,
             currentAllowedTools: localTools.length > 0 ? localTools : undefined,
             reportName,
             reportDescription,
-        })
-            .then((response) => {
-                setMessages((prev) => [
-                    ...prev,
-                    { role: "assistant", content: response.explanation || "Done." },
-                ]);
-                if (response.promptTemplate) {
-                    setLocalPrompt(response.promptTemplate);
-                }
-                if (Array.isArray(response.allowedTools)) {
-                    setLocalTools(response.allowedTools);
-                } else if (typeof response.allowedTools === "string") {
-                    setLocalTools((response.allowedTools as string).split(",").map((s: string) => s.trim()).filter(Boolean));
-                }
-            })
-            .catch((err) => {
-                setMessages((prev) => [
-                    ...prev,
-                    { role: "assistant", content: "Error: " + err.message },
-                ]);
-            })
-            .finally(() => setLoading(false));
-    };
-
-    const handleApply = () => {
-        onApply(localPrompt, localTools);
-        onClose();
-    };
+        }).then((response) => {
+            if (response.promptTemplate) {
+                setLocalPrompt(response.promptTemplate);
+            }
+            if (Array.isArray(response.allowedTools)) {
+                setLocalTools(response.allowedTools);
+            } else if (typeof response.allowedTools === "string") {
+                setLocalTools((response.allowedTools as string).split(",").map((s: string) => s.trim()).filter(Boolean));
+            }
+            return { explanation: response.explanation || "Done." };
+        });
 
     return (
-        <Modal isOpen={isOpen} onClose={onClose} variant="large"
-            style={{ maxWidth: "95vw", width: "95vw" }}>
-            <ModalHeader title="AI-Assisted Report Editor" />
-            <ModalBody style={{ padding: 0, height: "100vh", display: "flex" }}>
-                <Grid style={{ width: "100%" }}>
-                    <GridItem className="content" span={9}>
-                        <Stack>
-                            <StackItem style={{ padding: "16px", paddingBottom: "8px" }}>
-                                <Title headingLevel="h4" size="md" style={{ marginBottom: "8px" }}>
-                                    Allowed Tools ({localTools.length})
-                                </Title>
-                                {localTools.length > 0 ? (
-                                    <div style={{ display: "flex", flexWrap: "wrap", gap: "4px",
-                                        maxHeight: "80px", overflowY: "auto" }}>
-                                        {localTools.map((tool) => (
-                                            <Flex key={tool}
-                                                alignItems={{ default: "alignItemsCenter" }}
-                                                style={{
-                                                    padding: "4px 8px",
-                                                    backgroundColor: tool.startsWith("@")
-                                                        ? "var(--pf-t--global--background--color--primary--default)"
-                                                        : "var(--pf-t--global--background--color--secondary--default)",
-                                                    borderRadius: "4px",
-                                                    border: tool.startsWith("@")
-                                                        ? "1px solid var(--pf-t--global--border--color--default)"
-                                                        : "none",
-                                                }}>
-                                                <FlexItem>
-                                                    <code style={{
-                                                        fontSize: "12px",
-                                                        color: tool.startsWith("@")
-                                                            ? "var(--pf-t--global--color--brand--default)"
-                                                            : "inherit",
-                                                    }}>{tool}</code>
-                                                </FlexItem>
-                                            </Flex>
-                                        ))}
-                                    </div>
-                                ) : (
-                                    <div style={{ color: "#6a6e73", fontSize: "13px" }}>
-                                        No tools configured. Ask the AI to recommend tools.
-                                    </div>
-                                )}
-                            </StackItem>
-                            <StackItem style={{ paddingLeft: "16px", paddingBottom: "4px" }}>
-                                <Title headingLevel="h4" size="md">
-                                    Prompt Template
-                                </Title>
-                                <div style={{ color: "#6a6e73", fontSize: "13px", marginTop: "2px" }}>
-                                    Placeholders:{" "}
-                                    <code>{"{{repositories}}"}</code>,{" "}
-                                    <code>{"{{timeRangeStart}}"}</code>,{" "}
-                                    <code>{"{{timeRangeEnd}}"}</code>,{" "}
-                                    <code>{"{{timeWindow}}"}</code>
-                                </div>
-                            </StackItem>
-                            <StackItem isFilled style={{ paddingLeft: "16px", paddingRight: "16px" }}>
-                                <CodeEditor
-                                    code={localPrompt || ""}
-                                    language={Language.markdown}
-                                    isFullHeight
-                                    isReadOnly={false}
-                                    isLineNumbersVisible
-                                />
-                            </StackItem>
-                        </Stack>
-                    </GridItem>
-                    <GridItem className="chat" span={3} style={{
-                        borderLeft: "1px solid var(--pf-t--global--border--color--default)",
-                    }}>
-                        <Stack>
-                            <StackItem isFilled style={{
-                                overflowY: "auto",
-                                padding: "16px",
-                                display: "flex",
-                                flexDirection: "column",
-                                gap: "12px",
-                            }}>
-                                {messages.length === 0 && (
-                                    <div style={{
-                                        color: "#6a6e73", fontSize: "13px", textAlign: "center",
-                                        marginTop: "32px",
-                                    }}>
-                                        Describe what this report should cover. The AI will
-                                        generate a prompt template and recommend the appropriate
-                                        tools.
-                                    </div>
-                                )}
-                                {messages.map((msg, i) => (
-                                    <div key={i} style={{
-                                        alignSelf: msg.role === "user" ? "flex-end" : "flex-start",
-                                        maxWidth: "90%",
-                                        padding: "8px 12px",
-                                        borderRadius: "8px",
-                                        backgroundColor: msg.role === "user"
+        <AiEditModal
+            isOpen={isOpen}
+            onClose={onClose}
+            onApply={() => onApply(localPrompt, localTools)}
+            title="AI-Assisted Report Editor"
+            placeholder="Describe what this report should cover..."
+            emptyHint="Describe what this report should cover. The AI will generate a prompt template and recommend the appropriate tools."
+            onSendMessage={handleSend}
+        >
+            <StackItem style={{ padding: "16px", paddingBottom: "8px" }}>
+                <Title headingLevel="h4" size="md" style={{ marginBottom: "8px" }}>
+                    Allowed Tools ({localTools.length})
+                </Title>
+                {localTools.length > 0 ? (
+                    <div style={{ display: "flex", flexWrap: "wrap", gap: "4px",
+                        maxHeight: "80px", overflowY: "auto" }}>
+                        {localTools.map((tool) => (
+                            <Flex key={tool}
+                                alignItems={{ default: "alignItemsCenter" }}
+                                style={{
+                                    padding: "4px 8px",
+                                    backgroundColor: tool.startsWith("@")
+                                        ? "var(--pf-t--global--background--color--primary--default)"
+                                        : "var(--pf-t--global--background--color--secondary--default)",
+                                    borderRadius: "4px",
+                                    border: tool.startsWith("@")
+                                        ? "1px solid var(--pf-t--global--border--color--default)"
+                                        : "none",
+                                }}>
+                                <FlexItem>
+                                    <code style={{
+                                        fontSize: "12px",
+                                        color: tool.startsWith("@")
                                             ? "var(--pf-t--global--color--brand--default)"
-                                            : "var(--pf-t--global--background--color--secondary--default)",
-                                        color: msg.role === "user" ? "white" : "inherit",
-                                        fontSize: "13px",
-                                    }}>
-                                        {msg.role === "assistant" ? (
-                                            <Content>
-                                                <Markdown remarkPlugins={[remarkGfm]}>{msg.content}</Markdown>
-                                            </Content>
-                                        ) : (
-                                            msg.content
-                                        )}
-                                    </div>
-                                ))}
-                                {loading && (
-                                    <div style={{
-                                        alignSelf: "flex-start",
-                                        padding: "8px 12px",
-                                        borderRadius: "8px",
-                                        backgroundColor: "var(--pf-t--global--background--color--secondary--default)",
-                                        fontSize: "13px",
-                                        color: "#6a6e73",
-                                    }}>
-                                        <Spinner size="sm" style={{ marginRight: "5px" }} />
-                                        Thinking...
-                                    </div>
-                                )}
-                                <div ref={messagesEndRef} />
-                            </StackItem>
-                            <StackItem style={{
-                                padding: "6px 8px",
-                                borderTop: "1px solid var(--pf-t--global--border--color--default)",
-                                display: "flex",
-                                gap: "8px",
-                            }}>
-                                <TextArea
-                                    value={input}
-                                    onChange={(_e, v) => setInput(v)}
-                                    onKeyDown={(e) => {
-                                        if (e.key === "Enter" && !e.shiftKey) {
-                                            e.preventDefault();
-                                            handleSend();
-                                        }
-                                    }}
-                                    placeholder="Describe what this report should cover..."
-                                    rows={2}
-                                    isDisabled={loading}
-                                    style={{ flex: 1, resize: "none" }}
-                                />
-                                <Button
-                                    variant="primary"
-                                    onClick={handleSend}
-                                    isDisabled={!input.trim() || loading}
-                                    style={{ alignSelf: "flex-end" }}
-                                >
-                                    <PaperPlaneIcon />
-                                </Button>
-                            </StackItem>
-                        </Stack>
-                    </GridItem>
-                </Grid>
-            </ModalBody>
-            <ModalFooter>
-                <Button variant="primary" onClick={handleApply}>
-                    Apply Changes
-                </Button>
-                <Button variant="link" onClick={onClose}>
-                    Cancel
-                </Button>
-            </ModalFooter>
-        </Modal>
+                                            : "inherit",
+                                    }}>{tool}</code>
+                                </FlexItem>
+                            </Flex>
+                        ))}
+                    </div>
+                ) : (
+                    <div style={{ color: "#6a6e73", fontSize: "13px" }}>
+                        No tools configured. Ask the AI to recommend tools.
+                    </div>
+                )}
+            </StackItem>
+            <StackItem style={{ paddingLeft: "16px", paddingBottom: "4px" }}>
+                <Title headingLevel="h4" size="md">
+                    Prompt Template
+                </Title>
+                <div style={{ color: "#6a6e73", fontSize: "13px", marginTop: "2px" }}>
+                    Placeholders:{" "}
+                    <code>{"{{repositories}}"}</code>,{" "}
+                    <code>{"{{timeRangeStart}}"}</code>,{" "}
+                    <code>{"{{timeRangeEnd}}"}</code>,{" "}
+                    <code>{"{{timeWindow}}"}</code>
+                </div>
+            </StackItem>
+            <StackItem isFilled style={{ paddingLeft: "16px", paddingRight: "16px" }}>
+                <CodeEditor
+                    code={localPrompt || ""}
+                    language={Language.markdown}
+                    isFullHeight
+                    isReadOnly={false}
+                    isLineNumbersVisible
+                />
+            </StackItem>
+        </AiEditModal>
     );
 }

--- a/ui/src/components/ScriptAiModal.tsx
+++ b/ui/src/components/ScriptAiModal.tsx
@@ -1,29 +1,11 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import {
-    Button,
-    Content,
-    Grid,
-    GridItem,
-    Modal,
-    ModalBody,
-    ModalFooter,
-    ModalHeader,
-    Spinner,
-    Stack,
     StackItem,
-    TextArea,
     Title,
 } from "@patternfly/react-core";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
-import Markdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import PaperPlaneIcon from "@patternfly/react-icons/dist/esm/icons/paper-plane-icon";
 import { aiEditScript } from "../config/api";
-
-interface ChatMessage {
-    role: "user" | "assistant";
-    content: string;
-}
+import { AiEditModal } from "./AiEditModal";
 
 interface ScriptAiModalProps {
     isOpen: boolean;
@@ -42,11 +24,7 @@ interface ScriptAiModalProps {
 export function ScriptAiModal({
     isOpen, script, actionTypeName, actionTypeDescription, onApply, onClose,
 }: ScriptAiModalProps) {
-    const [messages, setMessages] = useState<ChatMessage[]>([]);
-    const [input, setInput] = useState("");
-    const [loading, setLoading] = useState(false);
     const [localScript, setLocalScript] = useState(script);
-    const messagesEndRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
         if (isOpen) {
@@ -54,181 +32,54 @@ export function ScriptAiModal({
         }
     }, [isOpen, script]);
 
-    useEffect(() => {
-        messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-    }, [messages]);
-
-    const handleSend = () => {
-        const text = input.trim();
-        if (!text || loading) return;
-
-        const userMessage: ChatMessage = { role: "user", content: text };
-        setMessages((prev) => [...prev, userMessage]);
-        setInput("");
-        setLoading(true);
-
+    const handleSend = (message: string) =>
         aiEditScript({
-            message: text,
+            message,
             currentScript: localScript || undefined,
             actionTypeName,
             actionTypeDescription,
-        })
-            .then((response) => {
-                setMessages((prev) => [
-                    ...prev,
-                    { role: "assistant", content: response.explanation || "Done." },
-                ]);
-                if (response.script) {
-                    setLocalScript(response.script);
-                }
-            })
-            .catch((err) => {
-                setMessages((prev) => [
-                    ...prev,
-                    { role: "assistant", content: "Error: " + err.message },
-                ]);
-            })
-            .finally(() => setLoading(false));
-    };
-
-    const handleApply = () => {
-        onApply(localScript);
-        onClose();
-    };
+        }).then((response) => {
+            if (response.script) {
+                setLocalScript(response.script);
+            }
+            return { explanation: response.explanation || "Done." };
+        });
 
     return (
-        <Modal isOpen={isOpen} onClose={onClose} variant="large"
-            style={{ maxWidth: "95vw", width: "95vw" }}>
-            <ModalHeader title="AI-Assisted Script Editor" />
-            <ModalBody style={{ padding: 0, height: "100vh", display: "flex" }}>
-                <Grid style={{ width: "100%" }}>
-                    <GridItem className="content" span={9}>
-                        <Stack>
-                            <StackItem style={{ padding: "16px", paddingBottom: "8px" }}>
-                                <Title headingLevel="h4" size="md">
-                                    Script Template
-                                </Title>
-                                <div style={{ color: "#6a6e73", fontSize: "13px", marginTop: "4px" }}>
-                                    Available placeholders:{" "}
-                                    <code>{"{{projectId}}"}</code>,{" "}
-                                    <code>{"{{eventId}}"}</code>,{" "}
-                                    <code>{"{{taskId}}"}</code>,{" "}
-                                    <code>{"{{issueRef}}"}</code>,{" "}
-                                    <code>{"{{repository}}"}</code>,{" "}
-                                    <code>{"{{projectName}}"}</code>,{" "}
-                                    <code>{"{{managerInput}}"}</code>,{" "}
-                                    <code>{"{{apiBaseUrl}}"}</code>
-                                </div>
-                            </StackItem>
-                            <StackItem isFilled style={{ paddingLeft: "16px", paddingRight: "16px" }}>
-                                <CodeEditor
-                                    code={localScript || ""}
-                                    language={Language.shell}
-                                    isFullHeight
-                                    isReadOnly={false}
-                                    isLineNumbersVisible
-                                />
-                            </StackItem>
-                        </Stack>
-                    </GridItem>
-                    <GridItem className="chat" span={3} style={{
-                        borderLeft: "1px solid var(--pf-t--global--border--color--default)",
-                    }}>
-                        <Stack>
-                            <StackItem isFilled style={{
-                                overflowY: "auto",
-                                padding: "16px",
-                                display: "flex",
-                                flexDirection: "column",
-                                gap: "12px",
-                            }}>
-                                {messages.length === 0 && (
-                                    <div style={{
-                                        color: "#6a6e73", fontSize: "13px", textAlign: "center",
-                                        marginTop: "32px",
-                                    }}>
-                                        Describe what this script should do. The AI will generate
-                                        a bash script with the appropriate Axiom API calls and
-                                        placeholders.
-                                    </div>
-                                )}
-                                {messages.map((msg, i) => (
-                                    <div key={i} style={{
-                                        alignSelf: msg.role === "user" ? "flex-end" : "flex-start",
-                                        maxWidth: "90%",
-                                        padding: "8px 12px",
-                                        borderRadius: "8px",
-                                        backgroundColor: msg.role === "user"
-                                            ? "var(--pf-t--global--color--brand--default)"
-                                            : "var(--pf-t--global--background--color--secondary--default)",
-                                        color: msg.role === "user" ? "white" : "inherit",
-                                        fontSize: "13px",
-                                    }}>
-                                        {msg.role === "assistant" ? (
-                                            <Content>
-                                                <Markdown remarkPlugins={[remarkGfm]}>{msg.content}</Markdown>
-                                            </Content>
-                                        ) : (
-                                            msg.content
-                                        )}
-                                    </div>
-                                ))}
-                                {loading && (
-                                    <div style={{
-                                        alignSelf: "flex-start",
-                                        padding: "8px 12px",
-                                        borderRadius: "8px",
-                                        backgroundColor: "var(--pf-t--global--background--color--secondary--default)",
-                                        fontSize: "13px",
-                                        color: "#6a6e73",
-                                    }}>
-                                        <Spinner size="sm" style={{ marginRight: "5px" }} />
-                                        Thinking...
-                                    </div>
-                                )}
-                                <div ref={messagesEndRef} />
-                            </StackItem>
-                            <StackItem style={{
-                                padding: "6px 8px",
-                                borderTop: "1px solid var(--pf-t--global--border--color--default)",
-                                display: "flex",
-                                gap: "8px",
-                            }}>
-                                <TextArea
-                                    value={input}
-                                    onChange={(_e, v) => setInput(v)}
-                                    onKeyDown={(e) => {
-                                        if (e.key === "Enter" && !e.shiftKey) {
-                                            e.preventDefault();
-                                            handleSend();
-                                        }
-                                    }}
-                                    placeholder="Describe what this script should do..."
-                                    rows={2}
-                                    isDisabled={loading}
-                                    style={{ flex: 1, resize: "none" }}
-                                />
-                                <Button
-                                    variant="primary"
-                                    onClick={handleSend}
-                                    isDisabled={!input.trim() || loading}
-                                    style={{ alignSelf: "flex-end" }}
-                                >
-                                    <PaperPlaneIcon />
-                                </Button>
-                            </StackItem>
-                        </Stack>
-                    </GridItem>
-                </Grid>
-            </ModalBody>
-            <ModalFooter>
-                <Button variant="primary" onClick={handleApply}>
-                    Apply Changes
-                </Button>
-                <Button variant="link" onClick={onClose}>
-                    Cancel
-                </Button>
-            </ModalFooter>
-        </Modal>
+        <AiEditModal
+            isOpen={isOpen}
+            onClose={onClose}
+            onApply={() => onApply(localScript)}
+            title="AI-Assisted Script Editor"
+            placeholder="Describe what this script should do..."
+            emptyHint="Describe what this script should do. The AI will generate a bash script with the appropriate Axiom API calls and placeholders."
+            onSendMessage={handleSend}
+        >
+            <StackItem style={{ padding: "16px", paddingBottom: "8px" }}>
+                <Title headingLevel="h4" size="md">
+                    Script Template
+                </Title>
+                <div style={{ color: "#6a6e73", fontSize: "13px", marginTop: "4px" }}>
+                    Available placeholders:{" "}
+                    <code>{"{{projectId}}"}</code>,{" "}
+                    <code>{"{{eventId}}"}</code>,{" "}
+                    <code>{"{{taskId}}"}</code>,{" "}
+                    <code>{"{{issueRef}}"}</code>,{" "}
+                    <code>{"{{repository}}"}</code>,{" "}
+                    <code>{"{{projectName}}"}</code>,{" "}
+                    <code>{"{{managerInput}}"}</code>,{" "}
+                    <code>{"{{apiBaseUrl}}"}</code>
+                </div>
+            </StackItem>
+            <StackItem isFilled style={{ paddingLeft: "16px", paddingRight: "16px" }}>
+                <CodeEditor
+                    code={localScript || ""}
+                    language={Language.shell}
+                    isFullHeight
+                    isReadOnly={false}
+                    isLineNumbersVisible
+                />
+            </StackItem>
+        </AiEditModal>
     );
 }

--- a/ui/src/components/ToolAiModal.tsx
+++ b/ui/src/components/ToolAiModal.tsx
@@ -1,29 +1,12 @@
-import {useEffect, useRef, useState} from "react";
+import { useEffect, useState } from "react";
 import {
-    Button,
-    Content,
-    Grid,
-    GridItem,
-    Modal,
-    ModalBody,
-    ModalFooter,
-    ModalHeader, Spinner,
-    Stack,
     StackItem,
-    TextArea,
     Title,
 } from "@patternfly/react-core";
-import {Table, Tbody, Td, Th, Thead, Tr} from "@patternfly/react-table";
-import {CodeEditor, Language} from "@patternfly/react-code-editor";
-import Markdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import PaperPlaneIcon from "@patternfly/react-icons/dist/esm/icons/paper-plane-icon";
-import {aiEditTool, type NewToolDefinition, type ToolParameter,} from "../config/api";
-
-interface ChatMessage {
-    role: "user" | "assistant";
-    content: string;
-}
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+import { CodeEditor, Language } from "@patternfly/react-code-editor";
+import { aiEditTool, type NewToolDefinition, type ToolParameter } from "../config/api";
+import { AiEditModal } from "./AiEditModal";
 
 interface ToolAiModalProps {
     isOpen: boolean;
@@ -39,14 +22,9 @@ interface ToolAiModalProps {
  * by AI). Right side is a chat interface for giving instructions.
  */
 export function ToolAiModal({ isOpen, form, params, onApply, onClose }: ToolAiModalProps) {
-    const [messages, setMessages] = useState<ChatMessage[]>([]);
-    const [input, setInput] = useState("");
-    const [loading, setLoading] = useState(false);
     const [localForm, setLocalForm] = useState(form);
     const [localParams, setLocalParams] = useState(params);
-    const messagesEndRef = useRef<HTMLDivElement>(null);
 
-    // Sync local state when modal opens
     useEffect(() => {
         if (isOpen) {
             setLocalForm(form);
@@ -54,219 +32,90 @@ export function ToolAiModal({ isOpen, form, params, onApply, onClose }: ToolAiMo
         }
     }, [isOpen, form, params]);
 
-    useEffect(() => {
-        messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-    }, [messages]);
-
-    const handleSend = () => {
-        const text = input.trim();
-        if (!text || loading) return;
-
-        const userMessage: ChatMessage = { role: "user", content: text };
-        setMessages((prev) => [...prev, userMessage]);
-        setInput("");
-        setLoading(true);
-
+    const handleSend = (message: string) => {
         const currentTool: NewToolDefinition = {
             ...localForm,
             parameters: localParams.length > 0 ? localParams : undefined,
         };
 
-        aiEditTool({ message: text, currentTool })
-            .then((response) => {
-                setMessages((prev) => [
+        return aiEditTool({ message, currentTool }).then((response) => {
+            if (response.tool) {
+                setLocalForm((prev) => ({
                     ...prev,
-                    { role: "assistant", content: response.explanation || "Done." },
-                ]);
-
-                if (response.tool) {
-                    setLocalForm((prev) => ({
-                        ...prev,
-                        name: response.tool!.name || prev.name,
-                        description: response.tool!.description || prev.description,
-                        scriptTemplate: response.tool!.scriptTemplate || prev.scriptTemplate,
-                    }));
-                    setLocalParams(response.tool!.parameters || []);
-                }
-            })
-            .catch((err) => {
-                setMessages((prev) => [
-                    ...prev,
-                    { role: "assistant", content: "Error: " + err.message },
-                ]);
-            })
-            .finally(() => setLoading(false));
-    };
-
-    const handleApply = () => {
-        onApply(
-            {
-                name: localForm.name,
-                description: localForm.description,
-                scriptTemplate: localForm.scriptTemplate,
-            },
-            localParams
-        );
-        onClose();
+                    name: response.tool!.name || prev.name,
+                    description: response.tool!.description || prev.description,
+                    scriptTemplate: response.tool!.scriptTemplate || prev.scriptTemplate,
+                }));
+                setLocalParams(response.tool!.parameters || []);
+            }
+            return { explanation: response.explanation || "Done." };
+        });
     };
 
     return (
-        <Modal isOpen={isOpen} onClose={onClose} variant="large"
-            style={{ maxWidth: "95vw", width: "95vw" }}>
-            <ModalHeader title="AI-Assisted Tool Editor" />
-            <ModalBody style={{ padding: 0, height: "100vh", display: "flex" }}>
-                <Grid style={{ width: "100%" }}>
-                    <GridItem className="content" span={9}>
-                        <Stack>
-                            {/* Parameters */}
-                            <StackItem style={{ padding: "16px" }}>
-                                <Title headingLevel="h4" size="md" style={{ marginBottom: "8px" }}>
-                                    Parameters ({localParams.length})
-                                </Title>
-                                {localParams.length > 0 ? (
-                                    <div style={{ maxHeight: "200px", overflowY: "auto" }}>
-                                        <Table aria-label="Parameters" variant="compact">
-                                            <Thead>
-                                                <Tr>
-                                                    <Th>Name</Th>
-                                                    <Th>Type</Th>
-                                                    <Th>Description</Th>
-                                                    <Th>Required</Th>
-                                                </Tr>
-                                            </Thead>
-                                            <Tbody>
-                                                {localParams.map((p, i) => (
-                                                    <Tr key={i}>
-                                                        <Td><code>{p.name}</code></Td>
-                                                        <Td>{p.type}</Td>
-                                                        <Td>{p.description || "—"}</Td>
-                                                        <Td>{p.required ? "Yes" : "No"}</Td>
-                                                    </Tr>
-                                                ))}
-                                            </Tbody>
-                                        </Table>
-                                    </div>
-                                ) : (
-                                    <div style={{ color: "#6a6e73", fontSize: "13px" }}>
-                                        No parameters defined yet. Ask the AI to create them.
-                                    </div>
-                                )}
-                            </StackItem>
-                            <StackItem>
-                                <Title headingLevel="h4" size="md" style={{ paddingLeft: "16px" }}>
-                                    Script Template
-                                </Title>
-                            </StackItem>
-                            {/* Tool Content */}
-                            <StackItem isFilled={true} style={{ paddingLeft: "16px", paddingRight: "16px" }}>
-                                <CodeEditor
-                                    code={localForm.scriptTemplate || ""}
-                                    language={Language.shell}
-                                    isFullHeight={true}
-                                    isReadOnly={false}
-                                    isLineNumbersVisible={true}
-                                />
-                            </StackItem>
-                        </Stack>
-                    </GridItem>
-                    <GridItem className="chat" span={3} style={{ borderLeft: "1px solid var(--pf-t--global--border--color--default)" }}>
-                        <Stack>
-                            {/* Messages */}
-                            <StackItem isFilled={true} style={{
-                                overflowY: "auto",
-                                padding: "16px",
-                                display: "flex",
-                                flexDirection: "column",
-                                gap: "12px",
-                            }}>
-                                {messages.length === 0 && (
-                                    <div style={{
-                                        color: "#6a6e73", fontSize: "13px", textAlign: "center",
-                                        marginTop: "32px",
-                                    }}>
-                                        Describe the tool you want to create or how you'd like
-                                        to modify it. The AI will generate the parameters and
-                                        script template.
-                                    </div>
-                                )}
-                                {messages.map((msg, i) => (
-                                    <div key={i} style={{
-                                        alignSelf: msg.role === "user" ? "flex-end" : "flex-start",
-                                        maxWidth: "90%",
-                                        padding: "8px 12px",
-                                        borderRadius: "8px",
-                                        backgroundColor: msg.role === "user"
-                                            ? "var(--pf-t--global--color--brand--default)"
-                                            : "var(--pf-t--global--background--color--secondary--default)",
-                                        color: msg.role === "user" ? "white" : "inherit",
-                                        fontSize: "13px",
-                                    }}>
-                                        {msg.role === "assistant" ? (
-                                            <Content>
-                                                <Markdown remarkPlugins={[remarkGfm]}>{msg.content}</Markdown>
-                                            </Content>
-                                        ) : (
-                                            msg.content
-                                        )}
-                                    </div>
+        <AiEditModal
+            isOpen={isOpen}
+            onClose={onClose}
+            onApply={() => onApply(
+                {
+                    name: localForm.name,
+                    description: localForm.description,
+                    scriptTemplate: localForm.scriptTemplate,
+                },
+                localParams,
+            )}
+            title="AI-Assisted Tool Editor"
+            placeholder="Describe what this tool should do..."
+            emptyHint="Describe the tool you want to create or how you'd like to modify it. The AI will generate the parameters and script template."
+            onSendMessage={handleSend}
+        >
+            <StackItem style={{ padding: "16px" }}>
+                <Title headingLevel="h4" size="md" style={{ marginBottom: "8px" }}>
+                    Parameters ({localParams.length})
+                </Title>
+                {localParams.length > 0 ? (
+                    <div style={{ maxHeight: "200px", overflowY: "auto" }}>
+                        <Table aria-label="Parameters" variant="compact">
+                            <Thead>
+                                <Tr>
+                                    <Th>Name</Th>
+                                    <Th>Type</Th>
+                                    <Th>Description</Th>
+                                    <Th>Required</Th>
+                                </Tr>
+                            </Thead>
+                            <Tbody>
+                                {localParams.map((p, i) => (
+                                    <Tr key={i}>
+                                        <Td><code>{p.name}</code></Td>
+                                        <Td>{p.type}</Td>
+                                        <Td>{p.description || "—"}</Td>
+                                        <Td>{p.required ? "Yes" : "No"}</Td>
+                                    </Tr>
                                 ))}
-                                {loading && (
-                                    <div style={{
-                                        alignSelf: "flex-start",
-                                        padding: "8px 12px",
-                                        borderRadius: "8px",
-                                        backgroundColor: "var(--pf-t--global--background--color--secondary--default)",
-                                        fontSize: "13px",
-                                        color: "#6a6e73",
-                                    }}>
-                                        <Spinner size="sm" style={{ marginRight: "5px" }} />
-                                        Thinking...
-                                    </div>
-                                )}
-                                <div ref={messagesEndRef} />
-                            </StackItem>
-                            {/* Input */}
-                            <StackItem style={{
-                                padding: "6px 8px",
-                                borderTop: "1px solid var(--pf-t--global--border--color--default)",
-                                display: "flex",
-                                gap: "8px"
-                            }}>
-                                <TextArea
-                                    value={input}
-                                    onChange={(_e, v) => setInput(v)}
-                                    onKeyDown={(e) => {
-                                        if (e.key === "Enter" && !e.shiftKey) {
-                                            e.preventDefault();
-                                            handleSend();
-                                        }
-                                    }}
-                                    placeholder="Describe what this tool should do..."
-                                    rows={2}
-                                    isDisabled={loading}
-                                    style={{ flex: 1, resize: "none" }}
-                                />
-                                <Button
-                                    variant="primary"
-                                    onClick={handleSend}
-                                    isDisabled={!input.trim() || loading}
-                                    style={{ alignSelf: "flex-end" }}
-                                >
-                                    <PaperPlaneIcon />
-                                </Button>
-                            </StackItem>
-                        </Stack>
-                    </GridItem>
-                </Grid>
-            </ModalBody>
-            <ModalFooter>
-                <Button variant="primary" onClick={handleApply}>
-                    Apply Changes
-                </Button>
-                <Button variant="link" onClick={onClose}>
-                    Cancel
-                </Button>
-            </ModalFooter>
-        </Modal>
+                            </Tbody>
+                        </Table>
+                    </div>
+                ) : (
+                    <div style={{ color: "#6a6e73", fontSize: "13px" }}>
+                        No parameters defined yet. Ask the AI to create them.
+                    </div>
+                )}
+            </StackItem>
+            <StackItem>
+                <Title headingLevel="h4" size="md" style={{ paddingLeft: "16px" }}>
+                    Script Template
+                </Title>
+            </StackItem>
+            <StackItem isFilled style={{ paddingLeft: "16px", paddingRight: "16px" }}>
+                <CodeEditor
+                    code={localForm.scriptTemplate || ""}
+                    language={Language.shell}
+                    isFullHeight
+                    isReadOnly={false}
+                    isLineNumbersVisible
+                />
+            </StackItem>
+        </AiEditModal>
     );
 }

--- a/ui/src/pages/ActionTypesPage.tsx
+++ b/ui/src/pages/ActionTypesPage.tsx
@@ -20,8 +20,6 @@ import {
     Title,
 } from "@patternfly/react-core";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
-import CheckCircleIcon from "@patternfly/react-icons/dist/esm/icons/check-circle-icon";
-import MinusCircleIcon from "@patternfly/react-icons/dist/esm/icons/minus-circle-icon";
 import PlusCircleIcon from "@patternfly/react-icons/dist/esm/icons/plus-circle-icon";
 import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
 import {
@@ -31,6 +29,7 @@ import {
     createActionType,
     deleteActionType,
 } from "../config/api";
+import { BooleanStatusIcon } from "../components/BooleanStatusIcon";
 import { ConfirmDeleteModal } from "../components/ConfirmDeleteModal";
 
 export function ActionTypesPage() {
@@ -125,15 +124,9 @@ export function ActionTypesPage() {
                                             {at.executionMode}
                                         </Label>
                                     </Td>
-                                    <Td>{at.userTriggerable
-                                        ? <CheckCircleIcon color="var(--pf-t--global--color--status--success--default)" />
-                                        : <MinusCircleIcon color="var(--pf-t--global--icon--color--disabled)" />}</Td>
-                                    <Td>{at.managerTriggerable
-                                        ? <CheckCircleIcon color="var(--pf-t--global--color--status--success--default)" />
-                                        : <MinusCircleIcon color="var(--pf-t--global--icon--color--disabled)" />}</Td>
-                                    <Td>{at.emitsEvent
-                                        ? <CheckCircleIcon color="var(--pf-t--global--color--status--success--default)" />
-                                        : <MinusCircleIcon color="var(--pf-t--global--icon--color--disabled)" />}</Td>
+                                    <Td><BooleanStatusIcon value={at.userTriggerable} /></Td>
+                                    <Td><BooleanStatusIcon value={at.managerTriggerable} /></Td>
+                                    <Td><BooleanStatusIcon value={at.emitsEvent} /></Td>
                                     <Td>{at.executionMode === "actor" ? `${at.allowedTools?.length || 0} tools` : "—"}</Td>
                                     <Td>{at.executionMode === "actor"
                                         ? (at.promptTemplate ? "Configured" : "—")

--- a/ui/src/pages/EventSourcesPage.tsx
+++ b/ui/src/pages/EventSourcesPage.tsx
@@ -24,8 +24,7 @@ import {
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import PlusCircleIcon from "@patternfly/react-icons/dist/esm/icons/plus-circle-icon";
 import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
-import CheckCircleIcon from "@patternfly/react-icons/dist/esm/icons/check-circle-icon";
-import MinusCircleIcon from "@patternfly/react-icons/dist/esm/icons/minus-circle-icon";
+import { BooleanStatusIcon } from "../components/BooleanStatusIcon";
 import {
     type EventSource,
     type NewEventSource,
@@ -201,11 +200,7 @@ export function EventSourcesPage() {
                                     <Td>{s.name}</Td>
                                     <Td>{s.sourceType}</Td>
                                     <Td><code>{describeSource(s)}</code></Td>
-                                    <Td>
-                                        {s.enabled
-                                            ? <CheckCircleIcon color="var(--pf-t--global--color--status--success--default)" />
-                                            : <MinusCircleIcon color="var(--pf-t--global--icon--color--disabled)" />}
-                                    </Td>
+                                    <Td><BooleanStatusIcon value={s.enabled} /></Td>
                                     <Td>{s.pollInterval != null ? `${s.pollInterval}s` : "—"}</Td>
                                     <Td>
                                         <Button variant="plain" size="sm" style={{ padding: 0 }}


### PR DESCRIPTION
## Summary
- Extract `AiEditModal` shared component that owns the modal shell (95vw, 9:3 grid layout), chat panel (messages, input, auto-scroll, markdown rendering, loading spinner), and Apply/Cancel footer — used by all four AI editor modals
- Extract `BooleanStatusIcon` component for the green-check / grey-minus boolean indicator pattern used in table columns
- Refactor `ActionTypeAiModal`, `ReportAiModal`, `ScriptAiModal`, and `ToolAiModal` to use `AiEditModal`, keeping only their unique content panels and API calls
- Update `ActionTypesPage` (3 uses) and `EventSourcesPage` (1 use) to use `BooleanStatusIcon`

Net effect: 293 lines added, 883 removed (590 lines eliminated, zero behavior change).

## Test plan
- [ ] Verify `tsc --noEmit` passes (confirmed)
- [ ] Verify full `build.sh` passes (confirmed)
- [ ] Open an AI-assisted editor modal for each entity type (action type, report, script, tool) and verify the chat interface works
- [ ] Verify the ActionTypes and Event Sources list pages render boolean columns correctly