### PR TITLE
Add Human Task Inbox for structured user interaction

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/PipelineOrchestrator.java
+++ b/app/src/main/java/io/apitomy/axiom/app/PipelineOrchestrator.java
@@ -283,6 +283,8 @@ public class PipelineOrchestrator {
         task.createdBy = "manager";
         task.status = "Pending";
         task.input = decision.inputContext();
+        task.humanContext = decision.humanContext();
+        task.outputSchema = decision.outputSchema();
         task.createdOn = Instant.now();
         if (traceCtx != null) {
             task.traceId = traceCtx.traceId();
@@ -366,6 +368,8 @@ public class PipelineOrchestrator {
         task.createdBy = "manager";
         task.status = "Pending";
         task.input = decision.inputContext();
+        task.humanContext = decision.humanContext();
+        task.outputSchema = decision.outputSchema();
         task.createdOn = Instant.now();
         if (traceCtx != null) {
             task.traceId = traceCtx.traceId();

--- a/app/src/main/java/io/apitomy/axiom/app/TaskExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/TaskExecutionService.java
@@ -389,6 +389,10 @@ public class TaskExecutionService {
             sseEvents.fire(SseEvent.taskUpdated(task.projectId, taskId, "AwaitingInput"));
             sseEvents.fire(SseEvent.projectUpdated(task.projectId));
             sseEvents.fire(SseEvent.threadEntry(task.projectId));
+
+            // Notify inbox subscribers
+            long inboxCount = TaskEntity.count("status", "AwaitingInput");
+            sseEvents.fire(SseEvent.inboxUpdated(taskId, "added", inboxCount));
         }
     }
 
@@ -399,6 +403,7 @@ public class TaskExecutionService {
             return;
         }
 
+        String previousStatus = task.status;
         task.status = result.isSuccess() ? "Completed" : "Failed";
         task.output = result.getOutput();
         task.completedOn = Instant.now();
@@ -439,6 +444,12 @@ public class TaskExecutionService {
         if (!result.isSuccess()) {
             sseEvents.fire(SseEvent.notification(
                     "Task failed: " + task.actionType, "error"));
+        }
+
+        // Notify inbox subscribers if this task was awaiting human input
+        if ("AwaitingInput".equals(previousStatus)) {
+            long inboxCount = TaskEntity.count("status", "AwaitingInput");
+            sseEvents.fire(SseEvent.inboxUpdated(taskId, "removed", inboxCount));
         }
 
         // Complete the trace (async traces are finalized here)

--- a/app/src/main/java/io/apitomy/axiom/app/TaskExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/TaskExecutionService.java
@@ -396,6 +396,39 @@ public class TaskExecutionService {
         }
     }
 
+    /**
+     * Registers a directly-created human task. Sets the task to AwaitingInput,
+     * registers it with the HumanActor, and wires the completion callback.
+     *
+     * @param taskId the persisted task ID
+     */
+    public void registerDirectHumanTask(Long taskId) {
+        TaskEntity task = TaskEntity.findById(taskId);
+        if (task == null) {
+            return;
+        }
+
+        // Find the human actor entity and implementation
+        ActorEntity actorEntity = ActorEntity.find("type", "human").firstResult();
+        Long actorEntityId = actorEntity != null ? actorEntity.id : null;
+        String actorName = actorEntity != null ? actorEntity.name : "Human";
+
+        // Mark the task as awaiting input (sets status, logs activity, fires SSE)
+        markTaskAwaitingInput(taskId, actorEntityId, actorName);
+
+        // Register with the HumanActor and wire completion
+        Actor humanActor = findActorByType("human", null);
+        if (humanActor != null) {
+            humanActor.execute(task, null)
+                    .thenAccept(result -> onTaskCompleted(taskId, result))
+                    .exceptionally(throwable -> {
+                        LOG.errorf(throwable, "Direct human task %d failed unexpectedly", taskId);
+                        failTask(taskId, "Unexpected error: " + throwable.getMessage());
+                        return null;
+                    });
+        }
+    }
+
     @Transactional
     void onTaskCompleted(Long taskId, TaskResult result) {
         TaskEntity task = TaskEntity.findById(taskId);

--- a/app/src/main/java/io/apitomy/axiom/app/rest/InboxResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/InboxResourceImpl.java
@@ -1,0 +1,246 @@
+package io.apitomy.axiom.app.rest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.apitomy.axiom.actors.human.HumanActor;
+import io.apitomy.axiom.api.InboxResource;
+import io.apitomy.axiom.api.beans.HumanContext;
+import io.apitomy.axiom.api.beans.HumanContextReference;
+import io.apitomy.axiom.api.beans.InboxCount;
+import io.apitomy.axiom.api.beans.InboxItem;
+import io.apitomy.axiom.api.beans.InboxResponse;
+import io.apitomy.axiom.api.beans.InboxSearchResults;
+import io.apitomy.axiom.api.beans.OutputSchema;
+import io.apitomy.axiom.api.beans.OutputSchemaField;
+import io.apitomy.axiom.api.beans.OutputSchemaFieldOption;
+import io.apitomy.axiom.core.entities.ProjectEntity;
+import io.apitomy.axiom.core.entities.TaskEntity;
+import io.quarkus.panache.common.Page;
+import io.quarkus.panache.common.Sort;
+import io.smallrye.common.annotation.RunOnVirtualThread;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.WebApplicationException;
+import org.jboss.logging.Logger;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Implementation of the Inbox REST API. Provides access to human tasks
+ * awaiting user input and allows completing them with structured responses.
+ */
+@ApplicationScoped
+@RunOnVirtualThread
+public class InboxResourceImpl implements InboxResource {
+
+    private static final Logger LOG = Logger.getLogger(InboxResourceImpl.class);
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Inject
+    HumanActor humanActor;
+
+    @Inject
+    InboxResponseValidator responseValidator;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public InboxSearchResults listInboxItems(BigInteger page, BigInteger limit) {
+        int pageNum = page != null ? page.intValue() : 1;
+        int pageSize = limit != null ? limit.intValue() : 20;
+
+        long totalCount = TaskEntity.count("status", "AwaitingInput");
+        List<TaskEntity> taskEntities = TaskEntity.<TaskEntity>find(
+                        "status = ?1", Sort.descending("createdOn"), "AwaitingInput")
+                .page(Page.of(pageNum - 1, pageSize))
+                .list();
+
+        // Batch-fetch project names to avoid N+1 queries
+        Map<Long, String> projectNames = new java.util.HashMap<>();
+        for (TaskEntity t : taskEntities) {
+            projectNames.putIfAbsent(t.projectId, null);
+        }
+        for (Long pid : projectNames.keySet()) {
+            ProjectEntity p = ProjectEntity.findById(pid);
+            if (p != null) {
+                projectNames.put(pid, p.name);
+            }
+        }
+
+        List<InboxItem> items = taskEntities.stream()
+                .map(entity -> toInboxItem(entity, projectNames.get(entity.projectId)))
+                .toList();
+
+        InboxSearchResults results = new InboxSearchResults();
+        results.setItems(items);
+        results.setTotalCount(totalCount);
+        results.setPage(pageNum);
+        results.setLimit(pageSize);
+        return results;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public InboxCount getInboxCount() {
+        long count = TaskEntity.count("status", "AwaitingInput");
+        InboxCount result = new InboxCount();
+        result.setCount(count);
+        return result;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public InboxItem getInboxItem(BigInteger taskId) {
+        long tid = taskId.longValue();
+        TaskEntity task = TaskEntity.findById(tid);
+
+        if (task == null || !"AwaitingInput".equals(task.status)) {
+            throw new WebApplicationException("Inbox item not found: " + tid, 404);
+        }
+
+        ProjectEntity project = ProjectEntity.findById(task.projectId);
+        String projectName = project != null ? project.name : null;
+        return toInboxItem(task, projectName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void completeInboxItem(BigInteger taskId, InboxResponse data) {
+        long tid = taskId.longValue();
+        TaskEntity task = TaskEntity.findById(tid);
+
+        if (task == null || !"AwaitingInput".equals(task.status)) {
+            throw new WebApplicationException("Inbox item not found or not awaiting input: " + tid, 404);
+        }
+
+        Map<String, Object> responseMap = data.getAdditionalProperties();
+
+        // Validate against output schema
+        List<String> validationErrors = responseValidator.validate(task.outputSchema, responseMap);
+        if (!validationErrors.isEmpty()) {
+            throw new WebApplicationException(
+                    "Validation failed: " + String.join("; ", validationErrors), 400);
+        }
+
+        // Serialize response to JSON and submit
+        try {
+            String responseJson = objectMapper.writeValueAsString(responseMap);
+            boolean accepted = humanActor.submitResponse(tid, responseJson);
+            if (!accepted) {
+                throw new WebApplicationException("Task is not pending a human response", 409);
+            }
+
+            LOG.infof("Inbox item %d completed with structured response", tid);
+        } catch (WebApplicationException e) {
+            throw e;
+        } catch (Exception e) {
+            LOG.errorf(e, "Failed to complete inbox item %d", tid);
+            throw new WebApplicationException("Failed to process response: " + e.getMessage(), 500);
+        }
+    }
+
+    private InboxItem toInboxItem(TaskEntity entity, String projectName) {
+        InboxItem item = new InboxItem();
+        item.setId(entity.id);
+        item.setProjectId(entity.projectId);
+        item.setActionType(entity.actionType);
+        item.setStatus(entity.status);
+        item.setInput(entity.input);
+        item.setCreatedOn(Date.from(entity.createdOn));
+        item.setEventId(entity.eventId);
+        if (entity.traceId != null) {
+            item.setTraceId(entity.traceId);
+        }
+
+        if (projectName != null) {
+            item.setProjectName(projectName);
+        }
+
+        // Parse humanContext JSON
+        if (entity.humanContext != null) {
+            try {
+                item.setHumanContext(parseHumanContext(entity.humanContext));
+            } catch (Exception e) {
+                LOG.warnf("Failed to parse humanContext for task %d: %s", entity.id, e.getMessage());
+            }
+        }
+
+        // Parse outputSchema JSON
+        if (entity.outputSchema != null) {
+            try {
+                item.setOutputSchema(parseOutputSchema(entity.outputSchema));
+            } catch (Exception e) {
+                LOG.warnf("Failed to parse outputSchema for task %d: %s", entity.id, e.getMessage());
+            }
+        }
+
+        return item;
+    }
+
+    private HumanContext parseHumanContext(String json) throws Exception {
+        JsonNode node = objectMapper.readTree(json);
+        HumanContext ctx = new HumanContext();
+        ctx.setTitle(node.path("title").asText(""));
+        if (node.has("description")) {
+            ctx.setDescription(node.get("description").asText());
+        }
+        if (node.has("references") && node.get("references").isArray()) {
+            List<HumanContextReference> refs = new ArrayList<>();
+            for (JsonNode refNode : node.get("references")) {
+                HumanContextReference ref = new HumanContextReference();
+                ref.setLabel(refNode.path("label").asText(""));
+                ref.setUrl(refNode.path("url").asText(""));
+                refs.add(ref);
+            }
+            ctx.setReferences(refs);
+        }
+        return ctx;
+    }
+
+    private OutputSchema parseOutputSchema(String json) throws Exception {
+        JsonNode node = objectMapper.readTree(json);
+        OutputSchema schema = new OutputSchema();
+        List<OutputSchemaField> fields = new ArrayList<>();
+
+        JsonNode fieldsNode = node.path("fields");
+        if (fieldsNode.isArray()) {
+            for (JsonNode fieldNode : fieldsNode) {
+                OutputSchemaField field = new OutputSchemaField();
+                field.setName(fieldNode.path("name").asText());
+                field.setType(OutputSchemaField.Type.fromValue(fieldNode.path("type").asText("text")));
+                field.setLabel(fieldNode.path("label").asText());
+                if (fieldNode.has("description")) {
+                    field.setDescription(fieldNode.get("description").asText());
+                }
+                field.setRequired(fieldNode.path("required").asBoolean(false));
+
+                if (fieldNode.has("options") && fieldNode.get("options").isArray()) {
+                    List<OutputSchemaFieldOption> options = new ArrayList<>();
+                    for (JsonNode optNode : fieldNode.get("options")) {
+                        OutputSchemaFieldOption opt = new OutputSchemaFieldOption();
+                        opt.setLabel(optNode.path("label").asText(""));
+                        opt.setValue(optNode.path("value").asText(""));
+                        options.add(opt);
+                    }
+                    field.setOptions(options);
+                }
+
+                fields.add(field);
+            }
+        }
+
+        schema.setFields(fields);
+        return schema;
+    }
+}

--- a/app/src/main/java/io/apitomy/axiom/app/rest/InboxResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/InboxResourceImpl.java
@@ -10,6 +10,8 @@ import io.apitomy.axiom.api.beans.InboxCount;
 import io.apitomy.axiom.api.beans.InboxItem;
 import io.apitomy.axiom.api.beans.InboxResponse;
 import io.apitomy.axiom.api.beans.InboxSearchResults;
+import io.apitomy.axiom.api.beans.NewInboxItem;
+import io.apitomy.axiom.app.TaskExecutionService;
 import io.apitomy.axiom.api.beans.OutputSchema;
 import io.apitomy.axiom.api.beans.OutputSchemaField;
 import io.apitomy.axiom.api.beans.OutputSchemaFieldOption;
@@ -23,7 +25,10 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.WebApplicationException;
 import org.jboss.logging.Logger;
 
+import jakarta.transaction.Transactional;
+
 import java.math.BigInteger;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -45,6 +50,9 @@ public class InboxResourceImpl implements InboxResource {
 
     @Inject
     InboxResponseValidator responseValidator;
+
+    @Inject
+    TaskExecutionService taskExecutionService;
 
     /**
      * {@inheritDoc}
@@ -93,6 +101,57 @@ public class InboxResourceImpl implements InboxResource {
         InboxCount result = new InboxCount();
         result.setCount(count);
         return result;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Transactional
+    public InboxItem createInboxItem(NewInboxItem data) {
+        long projectId = data.getProjectId();
+        ProjectEntity project = ProjectEntity.findById(projectId);
+        if (project == null) {
+            throw new WebApplicationException("Project not found: " + projectId, 404);
+        }
+
+        // Serialize humanContext and outputSchema beans to JSON for storage
+        String humanContextJson = null;
+        if (data.getHumanContext() != null) {
+            try {
+                humanContextJson = objectMapper.writeValueAsString(data.getHumanContext());
+            } catch (Exception e) {
+                throw new WebApplicationException("Invalid humanContext: " + e.getMessage(), 400);
+            }
+        }
+
+        String outputSchemaJson = null;
+        if (data.getOutputSchema() != null) {
+            try {
+                outputSchemaJson = objectMapper.writeValueAsString(data.getOutputSchema());
+            } catch (Exception e) {
+                throw new WebApplicationException("Invalid outputSchema: " + e.getMessage(), 400);
+            }
+        }
+
+        // Create and persist the task entity
+        TaskEntity task = new TaskEntity();
+        task.projectId = projectId;
+        task.actionType = data.getActionType();
+        task.createdBy = "user";
+        task.status = "Pending";
+        task.humanContext = humanContextJson;
+        task.outputSchema = outputSchemaJson;
+        task.createdOn = Instant.now();
+        task.persist();
+
+        LOG.infof("Created direct human task %d (%s) for project %d",
+                task.id, task.actionType, projectId);
+
+        // Register with HumanActor and wire completion callback
+        taskExecutionService.registerDirectHumanTask(task.id);
+
+        return toInboxItem(task, project.name);
     }
 
     /**

--- a/app/src/main/java/io/apitomy/axiom/app/rest/InboxResponseValidator.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/InboxResponseValidator.java
@@ -1,0 +1,103 @@
+package io.apitomy.axiom.app.rest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Validates a structured response against an output schema definition.
+ */
+@ApplicationScoped
+public class InboxResponseValidator {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * Validates a response map against the output schema JSON.
+     *
+     * @param outputSchemaJson the output schema definition (JSON string)
+     * @param response the user's response data
+     * @return list of validation error messages (empty if valid)
+     */
+    public List<String> validate(String outputSchemaJson, Map<String, Object> response) {
+        if (outputSchemaJson == null || outputSchemaJson.isBlank()) {
+            return List.of();
+        }
+
+        List<String> errors = new ArrayList<>();
+        try {
+            JsonNode schema = objectMapper.readTree(outputSchemaJson);
+            JsonNode fields = schema.path("fields");
+
+            if (!fields.isArray()) {
+                return List.of();
+            }
+
+            for (JsonNode field : fields) {
+                String name = field.path("name").asText();
+                boolean required = field.path("required").asBoolean(false);
+                String type = field.path("type").asText("text");
+
+                Object value = response.get(name);
+
+                if (required && isBlank(value)) {
+                    errors.add("Field '" + name + "' is required");
+                    continue;
+                }
+
+                if (value != null) {
+                    validateFieldType(name, type, value, field, errors);
+                }
+            }
+        } catch (Exception e) {
+            errors.add("Invalid output schema: " + e.getMessage());
+        }
+
+        return errors;
+    }
+
+    private void validateFieldType(String name, String type, Object value,
+                                   JsonNode field, List<String> errors) {
+        switch (type) {
+            case "boolean" -> {
+                if (!(value instanceof Boolean)) {
+                    errors.add("Field '" + name + "' must be a boolean");
+                }
+            }
+            case "number" -> {
+                if (!(value instanceof Number)) {
+                    errors.add("Field '" + name + "' must be a number");
+                }
+            }
+            case "select" -> {
+                JsonNode options = field.path("options");
+                if (options.isArray()) {
+                    List<String> allowedValues = new ArrayList<>();
+                    for (JsonNode opt : options) {
+                        allowedValues.add(opt.path("value").asText());
+                    }
+                    if (!allowedValues.contains(value.toString())) {
+                        errors.add("Field '" + name + "' must be one of: " + allowedValues);
+                    }
+                }
+            }
+            default -> {
+                // text and textarea accept any string value
+            }
+        }
+    }
+
+    private boolean isBlank(Object value) {
+        if (value == null) {
+            return true;
+        }
+        if (value instanceof String s) {
+            return s.isBlank();
+        }
+        return false;
+    }
+}

--- a/app/src/main/java/io/apitomy/axiom/app/rest/ProjectsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/ProjectsResourceImpl.java
@@ -525,6 +525,8 @@ public class ProjectsResourceImpl implements ProjectsResource {
         if (entity.traceId != null) {
             task.setTraceId(entity.traceId);
         }
+        task.setHumanContext(entity.humanContext);
+        task.setOutputSchema(entity.outputSchema);
         return task;
     }
 

--- a/app/src/main/java/io/apitomy/axiom/app/rest/TasksResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/TasksResourceImpl.java
@@ -86,6 +86,8 @@ public class TasksResourceImpl implements TasksResource {
         if (entity.traceId != null) {
             task.setTraceId(entity.traceId);
         }
+        task.setHumanContext(entity.humanContext);
+        task.setOutputSchema(entity.outputSchema);
         return task;
     }
 }

--- a/app/src/main/resources/db/migration/V23__add_human_task_fields.sql
+++ b/app/src/main/resources/db/migration/V23__add_human_task_fields.sql
@@ -1,0 +1,3 @@
+-- Add structured human task fields for the Inbox feature
+ALTER TABLE task ADD COLUMN IF NOT EXISTS human_context TEXT;
+ALTER TABLE task ADD COLUMN IF NOT EXISTS output_schema TEXT;

--- a/app/src/test/java/io/apitomy/axiom/app/PipelineOrchestratorTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/PipelineOrchestratorTest.java
@@ -77,7 +77,7 @@ class PipelineOrchestratorTest {
 
         ManagerDecision decision = new ManagerDecision(
                 "create_task", "analyze", null,
-                "Analyze this new issue", 0.9, "New issue needs analysis");
+                "Analyze this new issue", 0.9, "New issue needs analysis", null, null);
         when(managerService.evaluate(any(), any())).thenReturn(List.of(decision));
 
         orchestrator.processEvent(queueEntry);
@@ -117,7 +117,7 @@ class PipelineOrchestratorTest {
 
         ManagerDecision decision = new ManagerDecision(
                 "create_task", "answer-question", null,
-                "Answer the user's question", 0.85, "User asked a question");
+                "Answer the user's question", 0.85, "User asked a question", null, null);
         when(managerService.evaluate(any(), any())).thenReturn(List.of(decision));
 
         orchestrator.processEvent(queueEntry);
@@ -141,7 +141,7 @@ class PipelineOrchestratorTest {
 
         ManagerDecision decision = new ManagerDecision(
                 "create_task", "review", null,
-                "Review this PR", 0.9, "New PR needs review");
+                "Review this PR", 0.9, "New PR needs review", null, null);
         when(managerService.evaluate(any(), any())).thenReturn(List.of(decision));
 
         orchestrator.processEvent(queueEntry);
@@ -161,7 +161,7 @@ class PipelineOrchestratorTest {
 
         ManagerDecision decision = new ManagerDecision(
                 "create_task", "analyze", null,
-                "Analyze this", 0.9, "Needs analysis");
+                "Analyze this", 0.9, "Needs analysis", null, null);
         when(managerService.evaluate(any(), any())).thenReturn(List.of(decision));
 
         orchestrator.processEvent(queueEntry);
@@ -180,9 +180,9 @@ class PipelineOrchestratorTest {
 
         List<ManagerDecision> decisions = List.of(
                 new ManagerDecision("create_task", "auto-tag", null,
-                        "Tag this issue", 0.95, "New issue should be tagged"),
+                        "Tag this issue", 0.95, "New issue should be tagged", null, null),
                 new ManagerDecision("create_task", "analyze", null,
-                        "Analyze this issue", 0.88, "New issue needs analysis")
+                        "Analyze this issue", 0.88, "New issue needs analysis", null, null)
         );
         when(managerService.evaluate(any(), any())).thenReturn(decisions);
 
@@ -205,7 +205,7 @@ class PipelineOrchestratorTest {
                 "{\"action\":\"created\",\"comment\":{\"body\":\"bot message\"}}");
 
         ManagerDecision decision = new ManagerDecision(
-                "ignore", null, null, null, 0.98, "Bot comment, ignoring");
+                "ignore", null, null, null, 0.98, "Bot comment, ignoring", null, null);
         when(managerService.evaluate(any(), any())).thenReturn(List.of(decision));
 
         orchestrator.processEvent(queueEntry);
@@ -234,7 +234,7 @@ class PipelineOrchestratorTest {
                 "{\"action\":\"closed\"}");
 
         ManagerDecision decision = new ManagerDecision(
-                "script_action", "close-project", null, null, 0.9, "Issue closed");
+                "script_action", "close-project", null, null, 0.9, "Issue closed", null, null);
         when(managerService.evaluate(any(), any())).thenReturn(List.of(decision));
 
         orchestrator.processEvent(queueEntry);
@@ -257,7 +257,7 @@ class PipelineOrchestratorTest {
                 "{\"action\":\"reopened\"}");
 
         ManagerDecision decision = new ManagerDecision(
-                "script_action", "reopen-project", null, null, 0.85, "Issue reopened");
+                "script_action", "reopen-project", null, null, 0.85, "Issue reopened", null, null);
         when(managerService.evaluate(any(), any())).thenReturn(List.of(decision));
 
         orchestrator.processEvent(queueEntry);
@@ -276,7 +276,7 @@ class PipelineOrchestratorTest {
                 "{\"action\":\"edited\"}");
 
         ManagerDecision decision = new ManagerDecision(
-                "escalate", null, null, null, 0.4, "Not sure what to do");
+                "escalate", null, null, null, 0.4, "Not sure what to do", null, null);
         when(managerService.evaluate(any(), any())).thenReturn(List.of(decision));
 
         orchestrator.processEvent(queueEntry);
@@ -298,7 +298,7 @@ class PipelineOrchestratorTest {
         // Decision with confidence below threshold (0.7 default)
         ManagerDecision decision = new ManagerDecision(
                 "create_task", "implement", null,
-                "Implement something", 0.3, "Low confidence guess");
+                "Implement something", 0.3, "Low confidence guess", null, null);
         when(managerService.evaluate(any(), any())).thenReturn(List.of(decision));
         when(managerService.meetsConfidenceThreshold(any())).thenReturn(false);
 
@@ -350,7 +350,7 @@ class PipelineOrchestratorTest {
 
         ManagerDecision decision = new ManagerDecision(
                 "create_task", "analyze", null,
-                "Analyze this", 0.95, "Testing activity logging");
+                "Analyze this", 0.95, "Testing activity logging", null, null);
         when(managerService.evaluate(any(), any())).thenReturn(List.of(decision));
 
         orchestrator.processEvent(queueEntry);

--- a/app/src/test/java/io/apitomy/axiom/app/rest/InboxResponseValidatorTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/rest/InboxResponseValidatorTest.java
@@ -1,0 +1,270 @@
+package io.apitomy.axiom.app.rest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for InboxResponseValidator.
+ */
+class InboxResponseValidatorTest {
+
+    private InboxResponseValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new InboxResponseValidator();
+    }
+
+    @Test
+    void testNullSchemaSkipsValidation() {
+        List<String> errors = validator.validate(null, Map.of("anything", "goes"));
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    void testBlankSchemaSkipsValidation() {
+        List<String> errors = validator.validate("  ", Map.of("anything", "goes"));
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    void testEmptyFieldsArrayPassesValidation() {
+        String schema = """
+                { "fields": [] }
+                """;
+        List<String> errors = validator.validate(schema, Map.of());
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    void testRequiredFieldMissing() {
+        String schema = """
+                {
+                    "fields": [
+                        { "name": "approved", "type": "boolean", "label": "Approve?", "required": true }
+                    ]
+                }
+                """;
+        List<String> errors = validator.validate(schema, Map.of());
+
+        assertEquals(1, errors.size());
+        assertTrue(errors.getFirst().contains("approved"));
+        assertTrue(errors.getFirst().contains("required"));
+    }
+
+    @Test
+    void testRequiredFieldBlankString() {
+        String schema = """
+                {
+                    "fields": [
+                        { "name": "name", "type": "text", "label": "Name", "required": true }
+                    ]
+                }
+                """;
+        List<String> errors = validator.validate(schema, Map.of("name", "   "));
+
+        assertEquals(1, errors.size());
+        assertTrue(errors.getFirst().contains("name"));
+    }
+
+    @Test
+    void testRequiredFieldPresent() {
+        String schema = """
+                {
+                    "fields": [
+                        { "name": "approved", "type": "boolean", "label": "Approve?", "required": true }
+                    ]
+                }
+                """;
+        List<String> errors = validator.validate(schema, Map.of("approved", true));
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    void testOptionalFieldMissingIsAllowed() {
+        String schema = """
+                {
+                    "fields": [
+                        { "name": "notes", "type": "textarea", "label": "Notes", "required": false }
+                    ]
+                }
+                """;
+        List<String> errors = validator.validate(schema, Map.of());
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    void testBooleanTypeValidation() {
+        String schema = """
+                {
+                    "fields": [
+                        { "name": "flag", "type": "boolean", "label": "Flag", "required": false }
+                    ]
+                }
+                """;
+
+        List<String> errors = validator.validate(schema, Map.of("flag", "yes"));
+        assertEquals(1, errors.size());
+        assertTrue(errors.getFirst().contains("boolean"));
+
+        errors = validator.validate(schema, Map.of("flag", true));
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    void testNumberTypeValidation() {
+        String schema = """
+                {
+                    "fields": [
+                        { "name": "count", "type": "number", "label": "Count", "required": false }
+                    ]
+                }
+                """;
+
+        List<String> errors = validator.validate(schema, Map.of("count", "five"));
+        assertEquals(1, errors.size());
+        assertTrue(errors.getFirst().contains("number"));
+
+        errors = validator.validate(schema, Map.of("count", 42));
+        assertTrue(errors.isEmpty());
+
+        errors = validator.validate(schema, Map.of("count", 3.14));
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    void testSelectValidatesAgainstOptions() {
+        String schema = """
+                {
+                    "fields": [
+                        {
+                            "name": "env",
+                            "type": "select",
+                            "label": "Environment",
+                            "required": true,
+                            "options": [
+                                { "label": "Dev", "value": "dev" },
+                                { "label": "Staging", "value": "staging" },
+                                { "label": "Prod", "value": "prod" }
+                            ]
+                        }
+                    ]
+                }
+                """;
+
+        List<String> errors = validator.validate(schema, Map.of("env", "dev"));
+        assertTrue(errors.isEmpty());
+
+        errors = validator.validate(schema, Map.of("env", "prod"));
+        assertTrue(errors.isEmpty());
+
+        errors = validator.validate(schema, Map.of("env", "invalid-env"));
+        assertEquals(1, errors.size());
+        assertTrue(errors.getFirst().contains("must be one of"));
+    }
+
+    @Test
+    void testTextFieldAcceptsAnyString() {
+        String schema = """
+                {
+                    "fields": [
+                        { "name": "notes", "type": "text", "label": "Notes", "required": false }
+                    ]
+                }
+                """;
+        List<String> errors = validator.validate(schema, Map.of("notes", "anything at all"));
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    void testTextareaFieldAcceptsAnyString() {
+        String schema = """
+                {
+                    "fields": [
+                        { "name": "body", "type": "textarea", "label": "Body", "required": false }
+                    ]
+                }
+                """;
+        List<String> errors = validator.validate(schema, Map.of("body", "multi\nline\ntext"));
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    void testMultipleFieldsWithMixedErrors() {
+        String schema = """
+                {
+                    "fields": [
+                        { "name": "approved", "type": "boolean", "label": "Approve?", "required": true },
+                        { "name": "count", "type": "number", "label": "Count", "required": true },
+                        { "name": "notes", "type": "text", "label": "Notes", "required": false }
+                    ]
+                }
+                """;
+        List<String> errors = validator.validate(schema, Map.of("count", "not-a-number"));
+
+        assertEquals(2, errors.size());
+        assertTrue(errors.stream().anyMatch(e -> e.contains("approved") && e.contains("required")));
+        assertTrue(errors.stream().anyMatch(e -> e.contains("count") && e.contains("number")));
+    }
+
+    @Test
+    void testExtraFieldsInResponseAreIgnored() {
+        String schema = """
+                {
+                    "fields": [
+                        { "name": "approved", "type": "boolean", "label": "Approve?", "required": true }
+                    ]
+                }
+                """;
+        List<String> errors = validator.validate(schema,
+                Map.of("approved", true, "extraField", "ignored"));
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    void testInvalidSchemaJsonReturnsError() {
+        List<String> errors = validator.validate("not valid json", Map.of());
+        assertEquals(1, errors.size());
+        assertTrue(errors.getFirst().contains("Invalid output schema"));
+    }
+
+    @Test
+    void testMissingFieldsKeyInSchemaPassesValidation() {
+        String schema = """
+                { "something": "else" }
+                """;
+        List<String> errors = validator.validate(schema, Map.of());
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    void testRequiredBooleanFalseIsValid() {
+        String schema = """
+                {
+                    "fields": [
+                        { "name": "agreed", "type": "boolean", "label": "Agree?", "required": true }
+                    ]
+                }
+                """;
+        List<String> errors = validator.validate(schema, Map.of("agreed", false));
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    void testRequiredNumberZeroIsValid() {
+        String schema = """
+                {
+                    "fields": [
+                        { "name": "priority", "type": "number", "label": "Priority", "required": true }
+                    ]
+                }
+                """;
+        List<String> errors = validator.validate(schema, Map.of("priority", 0));
+        assertTrue(errors.isEmpty());
+    }
+}

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -3650,6 +3650,160 @@
           }
         }
       ]
+    },
+    "/inbox": {
+      "get": {
+        "tags": [
+          "Inbox"
+        ],
+        "summary": "List inbox items awaiting human input (paginated)",
+        "operationId": "listInboxItems",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of inbox items",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InboxSearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/inbox/count": {
+      "get": {
+        "tags": [
+          "Inbox"
+        ],
+        "summary": "Get the count of inbox items awaiting human input",
+        "operationId": "getInboxCount",
+        "responses": {
+          "200": {
+            "description": "Inbox item count",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InboxCount"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/inbox/{taskId}": {
+      "get": {
+        "tags": [
+          "Inbox"
+        ],
+        "summary": "Get a single inbox item with full detail",
+        "operationId": "getInboxItem",
+        "responses": {
+          "200": {
+            "description": "Inbox item detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InboxItem"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Inbox item not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "taskId",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/inbox/{taskId}/complete": {
+      "post": {
+        "tags": [
+          "Inbox"
+        ],
+        "summary": "Submit a structured response to complete an inbox item",
+        "operationId": "completeInboxItem",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InboxResponse"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Inbox item completed successfully"
+          },
+          "400": {
+            "description": "Validation error in response data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Inbox item not found or not awaiting input",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "taskId",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
     }
   },
   "components": {
@@ -3961,6 +4115,14 @@
           },
           "traceId": {
             "format": "uuid",
+            "type": "string"
+          },
+          "humanContext": {
+            "description": "Structured context for human tasks (JSON string)",
+            "type": "string"
+          },
+          "outputSchema": {
+            "description": "Schema defining form fields for human response (JSON string)",
             "type": "string"
           }
         }
@@ -5991,6 +6153,198 @@
             "type": "integer"
           }
         }
+      },
+      "HumanContextReference": {
+        "required": [
+          "label",
+          "url"
+        ],
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        }
+      },
+      "HumanContext": {
+        "required": [
+          "title"
+        ],
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "references": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HumanContextReference"
+            }
+          }
+        }
+      },
+      "OutputSchemaFieldOption": {
+        "required": [
+          "label",
+          "value"
+        ],
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      },
+      "OutputSchemaField": {
+        "required": [
+          "name",
+          "type",
+          "label",
+          "required"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "text",
+              "textarea",
+              "boolean",
+              "select",
+              "number"
+            ],
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "required": {
+            "type": "boolean"
+          },
+          "defaultValue": {},
+          "options": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OutputSchemaFieldOption"
+            }
+          }
+        }
+      },
+      "OutputSchema": {
+        "required": [
+          "fields"
+        ],
+        "type": "object",
+        "properties": {
+          "fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OutputSchemaField"
+            }
+          }
+        }
+      },
+      "InboxItem": {
+        "required": [
+          "id",
+          "projectId",
+          "actionType",
+          "status",
+          "createdOn"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "projectId": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "projectName": {
+            "type": "string"
+          },
+          "actionType": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "input": {
+            "type": "string"
+          },
+          "humanContext": {
+            "$ref": "#/components/schemas/HumanContext"
+          },
+          "outputSchema": {
+            "$ref": "#/components/schemas/OutputSchema"
+          },
+          "createdOn": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "eventId": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "traceId": {
+            "format": "uuid",
+            "type": "string"
+          }
+        }
+      },
+      "InboxSearchResults": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InboxItem"
+            }
+          },
+          "totalCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "page": {
+            "type": "integer"
+          },
+          "limit": {
+            "type": "integer"
+          }
+        }
+      },
+      "InboxCount": {
+        "required": [
+          "count"
+        ],
+        "type": "object",
+        "properties": {
+          "count": {
+            "format": "int64",
+            "type": "integer"
+          }
+        }
+      },
+      "InboxResponse": {
+        "description": "Structured response to an inbox item. Keys match the output schema field names.",
+        "type": "object",
+        "additionalProperties": true
       }
     },
     "responses": {
@@ -6110,6 +6464,10 @@
     {
       "name": "traces",
       "description": "Activity tracing and execution lineage"
+    },
+    {
+      "name": "Inbox",
+      "description": "Human task inbox operations"
     }
   ]
 }

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -3688,6 +3688,44 @@
             }
           }
         }
+      },
+      "post": {
+        "tags": [
+          "Inbox"
+        ],
+        "summary": "Create a new human task directly in the inbox",
+        "operationId": "createInboxItem",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewInboxItem"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Human task created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InboxItem"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Project not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/inbox/count": {
@@ -6345,6 +6383,31 @@
         "description": "Structured response to an inbox item. Keys match the output schema field names.",
         "type": "object",
         "additionalProperties": true
+      },
+      "NewInboxItem": {
+        "required": [
+          "projectId",
+          "actionType",
+          "humanContext"
+        ],
+        "type": "object",
+        "properties": {
+          "projectId": {
+            "format": "int64",
+            "description": "Project to associate the task with",
+            "type": "integer"
+          },
+          "actionType": {
+            "description": "The action type for this human task",
+            "type": "string"
+          },
+          "humanContext": {
+            "$ref": "#/components/schemas/HumanContext"
+          },
+          "outputSchema": {
+            "$ref": "#/components/schemas/OutputSchema"
+          }
+        }
       }
     },
     "responses": {

--- a/core/src/main/java/io/apitomy/axiom/core/entities/TaskEntity.java
+++ b/core/src/main/java/io/apitomy/axiom/core/entities/TaskEntity.java
@@ -52,6 +52,21 @@ public class TaskEntity extends PanacheEntity {
     @Column(name = "session_id")
     public String sessionId;
 
+
+    /**
+     * Structured context for human tasks: title, description, reference links.
+     * Stored as JSON. Null for non-human tasks.
+     */
+    @Column(name = "human_context", columnDefinition = "TEXT")
+    public String humanContext;
+
+    /**
+     * Schema defining the form fields the human must fill in.
+     * Stored as JSON. Null means a freeform text response is expected.
+     */
+    @Column(name = "output_schema", columnDefinition = "TEXT")
+    public String outputSchema;
+
     @Column(name = "execution_log", columnDefinition = "TEXT")
     public String executionLog;
 }

--- a/core/src/main/java/io/apitomy/axiom/core/events/SseEvent.java
+++ b/core/src/main/java/io/apitomy/axiom/core/events/SseEvent.java
@@ -106,6 +106,21 @@ public record SseEvent(
                 "{\"traceId\":\"" + traceId + "\"}");
     }
 
+    /**
+     * Creates an inbox-updated event when a task enters or leaves AwaitingInput.
+     *
+     * @param taskId the task that changed
+     * @param action "added" or "removed"
+     * @param count the current total inbox count
+     * @return a new SSE event
+     */
+    public static SseEvent inboxUpdated(Long taskId, String action, long count) {
+        return new SseEvent("inbox-updated",
+                "{\"taskId\":" + taskId
+                        + ",\"action\":\"" + action + "\""
+                        + ",\"count\":" + count + "}");
+    }
+
     private static String escapeJson(String s) {
         if (s == null) return "";
         return s.replace("\\", "\\\\")

--- a/manager/src/main/java/io/apitomy/axiom/manager/ManagerDecision.java
+++ b/manager/src/main/java/io/apitomy/axiom/manager/ManagerDecision.java
@@ -34,7 +34,19 @@ public record ManagerDecision(
         /**
          * The Manager's reasoning for this decision.
          */
-        String reasoning
+        String reasoning,
+
+        /**
+         * Structured context for human tasks: title, description, reference links.
+         * JSON string conforming to the HumanContext schema. Null for non-human tasks.
+         */
+        String humanContext,
+
+        /**
+         * Schema defining the form fields the human must fill in.
+         * JSON string conforming to the OutputSchema schema. Null means freeform text.
+         */
+        String outputSchema
 ) {
 
     /**

--- a/manager/src/main/java/io/apitomy/axiom/manager/ManagerPromptBuilder.java
+++ b/manager/src/main/java/io/apitomy/axiom/manager/ManagerPromptBuilder.java
@@ -151,13 +151,26 @@ public final class ManagerPromptBuilder {
      * Used with Claude Code's {@code --json-schema} flag.
      */
     public static String getResponseJsonSchema() {
-        return "{\"type\":\"object\",\"required\":[\"decisions\"],\"properties\":{\"decisions\":"
-                + "{\"type\":\"array\",\"items\":{\"type\":\"object\",\"required\":[\"decision\","
-                + "\"confidence\",\"reasoning\"],\"properties\":{\"decision\":{\"type\":\"string\","
-                + "\"enum\":[\"create_task\",\"ignore\",\"script_action\",\"escalate\"]},"
-                + "\"actionType\":{\"type\":\"string\"},\"actorHint\":{\"type\":\"string\"},"
-                + "\"inputContext\":{\"type\":\"string\"},\"confidence\":{\"type\":\"number\","
-                + "\"minimum\":0,\"maximum\":1},\"reasoning\":{\"type\":\"string\"}}}}}}";
+        return """
+                {"type":"object","required":["decisions"],"properties":{"decisions":\
+                {"type":"array","items":{"type":"object","required":["decision",\
+                "confidence","reasoning"],"properties":{"decision":{"type":"string",\
+                "enum":["create_task","ignore","script_action","escalate"]},\
+                "actionType":{"type":"string"},"actorHint":{"type":"string"},\
+                "inputContext":{"type":"string"},"confidence":{"type":"number",\
+                "minimum":0,"maximum":1},"reasoning":{"type":"string"},\
+                "humanContext":{"type":"object","properties":{"title":{"type":"string"},\
+                "description":{"type":"string"},"references":{"type":"array","items":\
+                {"type":"object","properties":{"label":{"type":"string"},"url":\
+                {"type":"string"}}}}}},\
+                "outputSchema":{"type":"object","properties":{"fields":{"type":"array",\
+                "items":{"type":"object","properties":{"name":{"type":"string"},\
+                "type":{"type":"string","enum":["text","textarea","boolean","select","number"]},\
+                "label":{"type":"string"},"description":{"type":"string"},\
+                "required":{"type":"boolean"},"options":{"type":"array","items":\
+                {"type":"object","properties":{"label":{"type":"string"},"value":\
+                {"type":"string"}}}}}}}}}\
+                }}}}}""";
     }
 
     /**
@@ -175,6 +188,25 @@ public final class ManagerPromptBuilder {
             - **inputContext**: Instructions or context for the actor performing the task
             - **confidence**: 0.0 to 1.0 indicating your confidence
             - **reasoning**: Brief explanation of why you made this decision
+
+            When creating a task for a human actor (actorHint is "human" or the action \
+            type is designated for humans), you should also provide:
+            - **humanContext**: An object with:
+              - **title**: A short, clear title of what you need from the human
+              - **description**: Detailed context about what is being asked and why
+              - **references**: (Optional) array of {label, url} links to relevant resources
+            - **outputSchema**: (Optional) an object with a "fields" array defining the \
+              form fields the human must fill in. Each field has:
+              - **name**: Field identifier (used as the response key)
+              - **type**: One of: text, textarea, boolean, select, number
+              - **label**: Human-readable label displayed in the form
+              - **description**: (Optional) help text for the field
+              - **required**: Whether the field must be filled in
+              - **options**: (For select type only) array of {label, value} choices
+
+            If no outputSchema is provided for a human task, the user will see a \
+            freeform text input. Use outputSchema for structured responses like \
+            approvals, selections, or multi-field forms.
 
             Guidelines:
             - You may return multiple decisions for a single event

--- a/manager/src/main/java/io/apitomy/axiom/manager/ManagerService.java
+++ b/manager/src/main/java/io/apitomy/axiom/manager/ManagerService.java
@@ -248,13 +248,19 @@ public class ManagerService {
 
             List<ManagerDecision> decisions = new ArrayList<>();
             for (JsonNode node : decisionsNode) {
+                String humanContext = node.has("humanContext")
+                        ? node.get("humanContext").toString() : null;
+                String outputSchema = node.has("outputSchema")
+                        ? node.get("outputSchema").toString() : null;
                 ManagerDecision decision = new ManagerDecision(
                         node.path("decision").asText("ignore"),
                         node.path("actionType").asText(null),
                         node.path("actorHint").asText(null),
                         node.path("inputContext").asText(null),
                         node.path("confidence").asDouble(0.5),
-                        node.path("reasoning").asText("")
+                        node.path("reasoning").asText(""),
+                        humanContext,
+                        outputSchema
                 );
                 decisions.add(decision);
             }

--- a/manager/src/test/java/io/apitomy/axiom/manager/ManagerDecisionParsingTest.java
+++ b/manager/src/test/java/io/apitomy/axiom/manager/ManagerDecisionParsingTest.java
@@ -212,4 +212,92 @@ class ManagerDecisionParsingTest {
         assertNull(d.actorHint());
         assertNull(d.inputContext());
     }
+
+    @Test
+    void testParseHumanContextAndOutputSchema() {
+        String json = """
+                {
+                    "decisions": [
+                        {
+                            "decision": "create_task",
+                            "actionType": "approve-deployment",
+                            "actorHint": "human",
+                            "inputContext": "PR #42 needs deployment approval",
+                            "confidence": 0.95,
+                            "reasoning": "Deployment requires human sign-off",
+                            "humanContext": {
+                                "title": "Approve deployment for auth-service",
+                                "description": "PR #42 changes the authentication flow.",
+                                "references": [
+                                    { "label": "PR #42", "url": "https://github.com/org/repo/pull/42" }
+                                ]
+                            },
+                            "outputSchema": {
+                                "fields": [
+                                    {
+                                        "name": "approved",
+                                        "type": "boolean",
+                                        "label": "Approve?",
+                                        "required": true
+                                    },
+                                    {
+                                        "name": "strategy",
+                                        "type": "select",
+                                        "label": "Strategy",
+                                        "required": true,
+                                        "options": [
+                                            { "label": "Blue-Green", "value": "blue-green" },
+                                            { "label": "Canary", "value": "canary" }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+                """;
+
+        List<ManagerDecision> decisions = service.parseDecisions(json);
+
+        assertEquals(1, decisions.size());
+        ManagerDecision d = decisions.getFirst();
+        assertTrue(d.isCreateTask());
+        assertEquals("human", d.actorHint());
+
+        // humanContext should be a JSON string
+        assertNotNull(d.humanContext());
+        assertTrue(d.humanContext().contains("Approve deployment for auth-service"));
+        assertTrue(d.humanContext().contains("PR #42"));
+
+        // outputSchema should be a JSON string
+        assertNotNull(d.outputSchema());
+        assertTrue(d.outputSchema().contains("approved"));
+        assertTrue(d.outputSchema().contains("boolean"));
+        assertTrue(d.outputSchema().contains("blue-green"));
+    }
+
+    @Test
+    void testParseHumanTaskWithoutOptionalFields() {
+        String json = """
+                {
+                    "decisions": [
+                        {
+                            "decision": "create_task",
+                            "actionType": "review",
+                            "actorHint": "human",
+                            "inputContext": "Review this PR",
+                            "confidence": 0.8,
+                            "reasoning": "Needs human review"
+                        }
+                    ]
+                }
+                """;
+
+        List<ManagerDecision> decisions = service.parseDecisions(json);
+
+        assertEquals(1, decisions.size());
+        ManagerDecision d = decisions.getFirst();
+        assertNull(d.humanContext());
+        assertNull(d.outputSchema());
+    }
 }

--- a/manager/src/test/java/io/apitomy/axiom/manager/ManagerDecisionTest.java
+++ b/manager/src/test/java/io/apitomy/axiom/manager/ManagerDecisionTest.java
@@ -13,7 +13,7 @@ class ManagerDecisionTest {
     void testCreateTaskDecision() {
         ManagerDecision decision = new ManagerDecision(
                 "create_task", "analyze", "claude-agent",
-                "Analyze this issue", 0.9, "New issue needs analysis");
+                "Analyze this issue", 0.9, "New issue needs analysis", null, null);
 
         assertTrue(decision.isCreateTask());
         assertFalse(decision.isIgnore());
@@ -27,7 +27,7 @@ class ManagerDecisionTest {
     @Test
     void testIgnoreDecision() {
         ManagerDecision decision = new ManagerDecision(
-                "ignore", null, null, null, 0.95, "Bot comment, ignoring");
+                "ignore", null, null, null, 0.95, "Bot comment, ignoring", null, null);
 
         assertFalse(decision.isCreateTask());
         assertTrue(decision.isIgnore());
@@ -37,7 +37,7 @@ class ManagerDecisionTest {
     @Test
     void testScriptActionDecision() {
         ManagerDecision decision = new ManagerDecision(
-                "script_action", "close-project", null, null, 0.85, "Issue closed");
+                "script_action", "close-project", null, null, 0.85, "Issue closed", null, null);
 
         assertTrue(decision.isScriptAction());
         assertEquals("close-project", decision.actionType());
@@ -46,7 +46,7 @@ class ManagerDecisionTest {
     @Test
     void testEscalateDecision() {
         ManagerDecision decision = new ManagerDecision(
-                "escalate", null, null, null, 0.3, "Uncertain what to do");
+                "escalate", null, null, null, 0.3, "Uncertain what to do", null, null);
 
         assertTrue(decision.isEscalate());
         assertEquals(0.3, decision.confidence());

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -38,6 +38,7 @@ import { AssistantPage } from "./pages/AssistantPage";
 import { AssistantSessionPage } from "./pages/AssistantSessionPage";
 import { TracesPage } from "./pages/TracesPage";
 import { TraceDetailPage } from "./pages/TraceDetailPage";
+import { InboxPage } from "./pages/InboxPage";
 import { type StartupCheck, fetchSystemHealth, fetchSystemConfig } from "./config/api";
 import { sseClient } from "./config/sse";
 
@@ -86,6 +87,7 @@ export function App() {
             ) : (
                 <Routes>
                     <Route path="/" element={<DashboardPage />} />
+                    <Route path="/inbox" element={<InboxPage />} />
                     <Route path="/projects" element={<ProjectsPage />} />
                     <Route path="/projects/:projectId" element={<ProjectDetailPage />} />
                     <Route path="/engine" element={<EngineSettingsPage />} />

--- a/ui/src/components/AppSidebar.tsx
+++ b/ui/src/components/AppSidebar.tsx
@@ -1,5 +1,7 @@
+import { useState, useEffect } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import {
+    Badge,
     Nav,
     NavExpandable,
     NavItem,
@@ -7,12 +9,28 @@ import {
     PageSidebar,
     PageSidebarBody,
 } from "@patternfly/react-core";
+import { fetchInboxCount } from "../config/api";
+import { sseClient, type AxiomSseEvent } from "../config/sse";
 
 const CONFIG_PATHS = ["/actors", "/manager", "/action-types", "/tools", "/toolsets", "/mcp-servers", "/secrets", "/event-sources", "/report-definitions", "/engine", "/configuration-packs"];
 
 export function AppSidebar() {
     const navigate = useNavigate();
     const location = useLocation();
+    const [inboxCount, setInboxCount] = useState(0);
+
+    useEffect(() => {
+        fetchInboxCount()
+            .then((result) => setInboxCount(result.count))
+            .catch(() => setInboxCount(0));
+
+        const unsubscribe = sseClient.subscribe((event: AxiomSseEvent) => {
+            if (event.type === "inbox-updated" && typeof event.data.count === "number") {
+                setInboxCount(event.data.count);
+            }
+        });
+        return unsubscribe;
+    }, []);
 
     const isConfigActive = CONFIG_PATHS.some(
         (p) => location.pathname === p || location.pathname.startsWith(p + "/")
@@ -25,6 +43,12 @@ export function AppSidebar() {
                     <NavList>
                         <NavItem isActive={location.pathname === "/"} onClick={() => navigate("/")}>
                             Dashboard
+                        </NavItem>
+                        <NavItem isActive={location.pathname.startsWith("/inbox")} onClick={() => navigate("/inbox")}>
+                            Inbox{" "}
+                            {inboxCount > 0 && (
+                                <Badge isRead={false}>{inboxCount}</Badge>
+                            )}
                         </NavItem>
                         <NavItem isActive={location.pathname.startsWith("/reports")} onClick={() => navigate("/reports")}>
                             Reports

--- a/ui/src/components/DynamicFormRenderer.tsx
+++ b/ui/src/components/DynamicFormRenderer.tsx
@@ -1,0 +1,172 @@
+import { useCallback } from "react";
+import {
+    Form,
+    FormGroup,
+    FormHelperText,
+    FormSelect,
+    FormSelectOption,
+    HelperText,
+    HelperTextItem,
+    Switch,
+    TextArea,
+    TextInput,
+} from "@patternfly/react-core";
+import type { OutputSchema, OutputSchemaField } from "../config/api";
+
+export interface DynamicFormRendererProps {
+    schema: OutputSchema | undefined;
+    values: Record<string, unknown>;
+    onChange: (values: Record<string, unknown>) => void;
+    errors?: Record<string, string>;
+}
+
+/**
+ * Renders PatternFly form fields dynamically from an OutputSchema.
+ * Falls back to a single TextArea when no schema is provided.
+ */
+export function DynamicFormRenderer({ schema, values, onChange, errors }: DynamicFormRendererProps) {
+    const updateField = useCallback((name: string, value: unknown) => {
+        onChange({ ...values, [name]: value });
+    }, [values, onChange]);
+
+    if (!schema || !schema.fields || schema.fields.length === 0) {
+        return (
+            <Form>
+                <FormGroup label="Response" isRequired fieldId="freeform-response">
+                    <TextArea
+                        id="freeform-response"
+                        value={(values["response"] as string) || ""}
+                        onChange={(_e, val) => updateField("response", val)}
+                        rows={6}
+                        resizeOrientation="vertical"
+                    />
+                </FormGroup>
+            </Form>
+        );
+    }
+
+    return (
+        <Form>
+            {schema.fields.map((field) => (
+                <DynamicField
+                    key={field.name}
+                    field={field}
+                    value={values[field.name]}
+                    onChange={(val) => updateField(field.name, val)}
+                    error={errors?.[field.name]}
+                />
+            ))}
+        </Form>
+    );
+}
+
+interface DynamicFieldProps {
+    field: OutputSchemaField;
+    value: unknown;
+    onChange: (value: unknown) => void;
+    error?: string;
+}
+
+function DynamicField({ field, value, onChange, error }: DynamicFieldProps) {
+    const fieldId = `field-${field.name}`;
+    const validated = error ? "error" as const : "default" as const;
+
+    return (
+        <FormGroup
+            label={field.label}
+            isRequired={field.required}
+            fieldId={fieldId}
+        >
+            {renderInput(field, fieldId, value, onChange, validated)}
+            {(field.description || error) && (
+                <FormHelperText>
+                    <HelperText>
+                        {error ? (
+                            <HelperTextItem variant="error">{error}</HelperTextItem>
+                        ) : (
+                            <HelperTextItem>{field.description}</HelperTextItem>
+                        )}
+                    </HelperText>
+                </FormHelperText>
+            )}
+        </FormGroup>
+    );
+}
+
+function renderInput(
+    field: OutputSchemaField,
+    fieldId: string,
+    value: unknown,
+    onChange: (value: unknown) => void,
+    validated: "error" | "default",
+) {
+    switch (field.type) {
+        case "text":
+            return (
+                <TextInput
+                    id={fieldId}
+                    type="text"
+                    value={(value as string) ?? (field.defaultValue as string) ?? ""}
+                    onChange={(_e, val) => onChange(val)}
+                    validated={validated}
+                />
+            );
+        case "textarea":
+            return (
+                <TextArea
+                    id={fieldId}
+                    value={(value as string) ?? (field.defaultValue as string) ?? ""}
+                    onChange={(_e, val) => onChange(val)}
+                    rows={4}
+                    resizeOrientation="vertical"
+                    validated={validated}
+                />
+            );
+        case "boolean":
+            return (
+                <Switch
+                    id={fieldId}
+                    isChecked={(value as boolean) ?? (field.defaultValue as boolean) ?? false}
+                    onChange={(_e, checked) => onChange(checked)}
+                    label="Yes"
+                />
+            );
+        case "select":
+            return (
+                <FormSelect
+                    id={fieldId}
+                    value={(value as string) ?? (field.defaultValue as string) ?? ""}
+                    onChange={(_e, val) => onChange(val)}
+                    validated={validated}
+                >
+                    <FormSelectOption key="" value="" label="Select..." isDisabled />
+                    {(field.options ?? []).map((opt) => (
+                        <FormSelectOption
+                            key={opt.value}
+                            value={opt.value}
+                            label={opt.label}
+                        />
+                    ))}
+                </FormSelect>
+            );
+        case "number":
+            return (
+                <TextInput
+                    id={fieldId}
+                    type="number"
+                    value={value != null ? Number(value) : (field.defaultValue as number) ?? ""}
+                    onChange={(_e, val) => onChange(val === "" ? null : Number(val))}
+                    validated={validated}
+                />
+            );
+        default:
+            return (
+                <TextInput
+                    id={fieldId}
+                    type="text"
+                    value={(value as string) ?? ""}
+                    onChange={(_e, val) => onChange(val)}
+                />
+            );
+    }
+}

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -1367,3 +1367,86 @@ export async function fetchReportTraces(reportId: number): Promise<Trace[]> {
     if (!response.ok) throw new Error(`Failed to fetch report traces: ${response.status}`);
     return response.json();
 }
+
+// ── Inbox ────────────────────────────────────────────────────────
+
+export interface HumanContextReference {
+    label: string;
+    url: string;
+}
+
+export interface HumanContext {
+    title: string;
+    description?: string;
+    references?: HumanContextReference[];
+}
+
+export interface OutputSchemaFieldOption {
+    label: string;
+    value: string;
+}
+
+export interface OutputSchemaField {
+    name: string;
+    type: "text" | "textarea" | "boolean" | "select" | "number";
+    label: string;
+    description?: string;
+    required: boolean;
+    defaultValue?: unknown;
+    options?: OutputSchemaFieldOption[];
+}
+
+export interface OutputSchema {
+    fields: OutputSchemaField[];
+}
+
+export interface InboxItem {
+    id: number;
+    projectId: number;
+    projectName?: string;
+    actionType: string;
+    status: string;
+    input?: string;
+    humanContext?: HumanContext;
+    outputSchema?: OutputSchema;
+    createdOn: string;
+    eventId?: number;
+    traceId?: string;
+}
+
+export interface InboxCount {
+    count: number;
+}
+
+export async function fetchInboxItems(page = 1, limit = 20): Promise<SearchResults<InboxItem>> {
+    const params = new URLSearchParams();
+    params.set("page", String(page));
+    params.set("limit", String(limit));
+    const response = await fetch(`${API}/inbox?${params}`);
+    if (!response.ok) throw new Error(`Failed to fetch inbox items: ${response.status}`);
+    return response.json();
+}
+
+export async function fetchInboxCount(): Promise<InboxCount> {
+    const response = await fetch(`${API}/inbox/count`);
+    if (!response.ok) throw new Error(`Failed to fetch inbox count: ${response.status}`);
+    return response.json();
+}
+
+export async function fetchInboxItem(taskId: number): Promise<InboxItem> {
+    const response = await fetch(`${API}/inbox/${taskId}`);
+    if (!response.ok) throw new Error(`Failed to fetch inbox item: ${response.status}`);
+    return response.json();
+}
+
+export async function completeInboxItem(taskId: number, data: Record<string, unknown>): Promise<void> {
+    const response = await fetch(`${API}/inbox/${taskId}/complete`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+    });
+    if (!response.ok) {
+        const error = await response.text();
+        throw new Error(`Failed to complete inbox item: ${error}`);
+    }
+}

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -1427,6 +1427,23 @@ export async function fetchInboxItems(page = 1, limit = 20): Promise<SearchResul
     return response.json();
 }
 
+export interface NewInboxItem {
+    projectId: number;
+    actionType: string;
+    humanContext: HumanContext;
+    outputSchema?: OutputSchema;
+}
+
+export async function createInboxItem(data: NewInboxItem): Promise<InboxItem> {
+    const response = await fetch(`${API}/inbox`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+    });
+    if (!response.ok) throw new Error(`Failed to create inbox item: ${response.status}`);
+    return response.json();
+}
+
 export async function fetchInboxCount(): Promise<InboxCount> {
     const response = await fetch(`${API}/inbox/count`);
     if (!response.ok) throw new Error(`Failed to fetch inbox count: ${response.status}`);

--- a/ui/src/pages/InboxPage.tsx
+++ b/ui/src/pages/InboxPage.tsx
@@ -1,0 +1,365 @@
+import { useState, useEffect, useCallback } from "react";
+import { Link } from "react-router-dom";
+import {
+    Alert,
+    Button,
+    Content,
+    EmptyState,
+    EmptyStateBody,
+    ExpandableSection,
+    Label,
+    Modal,
+    ModalBody,
+    ModalFooter,
+    ModalHeader,
+    PageSection,
+    Pagination,
+    Split,
+    SplitItem,
+    Title,
+    Toolbar,
+    ToolbarContent,
+    ToolbarItem,
+} from "@patternfly/react-core";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+import SyncAltIcon from "@patternfly/react-icons/dist/esm/icons/sync-alt-icon";
+import ExternalLinkAltIcon from "@patternfly/react-icons/dist/esm/icons/external-link-alt-icon";
+import {
+    type InboxItem,
+    fetchInboxItems,
+    fetchInboxItem,
+    completeInboxItem,
+} from "../config/api";
+import { sseClient, type AxiomSseEvent } from "../config/sse";
+import { FromNow } from "../components/FromNow";
+import { DynamicFormRenderer } from "../components/DynamicFormRenderer";
+
+export function InboxPage() {
+    const [items, setItems] = useState<InboxItem[]>([]);
+    const [totalCount, setTotalCount] = useState(0);
+    const [page, setPage] = useState(1);
+    const [perPage, setPerPage] = useState(20);
+    const [loading, setLoading] = useState(true);
+
+    // Detail modal state
+    const [selectedItem, setSelectedItem] = useState<InboxItem | null>(null);
+    const [formValues, setFormValues] = useState<Record<string, unknown>>({});
+    const [formErrors, setFormErrors] = useState<Record<string, string>>({});
+    const [submitting, setSubmitting] = useState(false);
+    const [submitError, setSubmitError] = useState<string | null>(null);
+
+    const loadData = useCallback(() => {
+        setLoading(true);
+        fetchInboxItems(page, perPage)
+            .then((results) => {
+                setItems(results.items);
+                setTotalCount(results.totalCount);
+            })
+            .catch(console.error)
+            .finally(() => setLoading(false));
+    }, [page, perPage]);
+
+    useEffect(() => { loadData(); }, [loadData]);
+
+    // SSE: auto-refresh on inbox changes
+    useEffect(() => {
+        const unsubscribe = sseClient.subscribe((event: AxiomSseEvent) => {
+            if (event.type === "inbox-updated" || event.type === "task-updated") {
+                loadData();
+            }
+        });
+        return unsubscribe;
+    }, [loadData]);
+
+    const openDetail = (item: InboxItem) => {
+        // Fetch full detail (may include enriched data)
+        fetchInboxItem(item.id)
+            .then((detail) => {
+                setSelectedItem(detail);
+                setFormValues(buildDefaultValues(detail));
+                setFormErrors({});
+                setSubmitError(null);
+            })
+            .catch(console.error);
+    };
+
+    const closeDetail = () => {
+        setSelectedItem(null);
+        setFormValues({});
+        setFormErrors({});
+        setSubmitError(null);
+    };
+
+    const validateForm = (): boolean => {
+        const errors: Record<string, string> = {};
+
+        if (!selectedItem?.outputSchema) {
+            const response = formValues["response"];
+            if (!response || (typeof response === "string" && response.trim() === "")) {
+                errors["response"] = "Response is required";
+            }
+        } else {
+            for (const field of selectedItem.outputSchema.fields) {
+                if (field.required) {
+                    const value = formValues[field.name];
+                    if (value === undefined || value === null || value === "") {
+                        errors[field.name] = `${field.label} is required`;
+                    }
+                }
+            }
+        }
+
+        setFormErrors(errors);
+        return Object.keys(errors).length === 0;
+    };
+
+    const handleSubmit = () => {
+        if (!selectedItem) return;
+        if (!validateForm()) return;
+
+        setSubmitting(true);
+        setSubmitError(null);
+
+        completeInboxItem(selectedItem.id, formValues)
+            .then(() => {
+                closeDetail();
+                loadData();
+            })
+            .catch((err) => {
+                setSubmitError(err.message || "Failed to submit response");
+            })
+            .finally(() => setSubmitting(false));
+    };
+
+    const getTitle = (item: InboxItem): string => {
+        return item.humanContext?.title || item.actionType;
+    };
+
+    return (
+        <PageSection>
+            <Title headingLevel="h1" size="lg" style={{ marginBottom: "16px" }}>
+                Inbox
+            </Title>
+
+            <Toolbar>
+                <ToolbarContent>
+                    <ToolbarItem>
+                        <Button variant="control" aria-label="Refresh" onClick={loadData}>
+                            <SyncAltIcon />
+                        </Button>
+                    </ToolbarItem>
+                    <ToolbarItem variant="pagination" align={{ default: "alignEnd" }}>
+                        <Pagination
+                            itemCount={totalCount}
+                            page={page}
+                            perPage={perPage}
+                            onSetPage={(_e, p) => setPage(p)}
+                            onPerPageSelect={(_e, pp) => { setPerPage(pp); setPage(1); }}
+                            isCompact
+                        />
+                    </ToolbarItem>
+                </ToolbarContent>
+            </Toolbar>
+
+            <div>
+                {loading ? (
+                    <EmptyState>
+                        <EmptyStateBody>Loading inbox...</EmptyStateBody>
+                    </EmptyState>
+                ) : items.length === 0 ? (
+                    <EmptyState>
+                        <EmptyStateBody>
+                            No tasks need your attention. When AI agents need your input,
+                            tasks will appear here.
+                        </EmptyStateBody>
+                    </EmptyState>
+                ) : (
+                    <Table aria-label="Inbox items" variant="compact">
+                        <Thead>
+                            <Tr>
+                                <Th>Title</Th>
+                                <Th>Project</Th>
+                                <Th>Action Type</Th>
+                                <Th>Created</Th>
+                                <Th />
+                            </Tr>
+                        </Thead>
+                        <Tbody>
+                            {items.map((item) => (
+                                <Tr
+                                    key={item.id}
+                                    isClickable
+                                    onRowClick={() => openDetail(item)}
+                                >
+                                    <Td>
+                                        <strong>{getTitle(item)}</strong>
+                                    </Td>
+                                    <Td>
+                                        <Link
+                                            to={`/projects/${item.projectId}`}
+                                            onClick={(e) => e.stopPropagation()}
+                                        >
+                                            {item.projectName || `Project #${item.projectId}`}
+                                        </Link>
+                                    </Td>
+                                    <Td>
+                                        <Label isCompact color="orange">
+                                            {item.actionType}
+                                        </Label>
+                                    </Td>
+                                    <Td>
+                                        <FromNow date={item.createdOn} />
+                                    </Td>
+                                    <Td>
+                                        <Button
+                                            variant="primary"
+                                            size="sm"
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                openDetail(item);
+                                            }}
+                                        >
+                                            Respond
+                                        </Button>
+                                    </Td>
+                                </Tr>
+                            ))}
+                        </Tbody>
+                    </Table>
+                )}
+            </div>
+
+            {/* Detail / Response Modal */}
+            {selectedItem && (
+                <Modal
+                    isOpen
+                    onClose={closeDetail}
+                    variant="large"
+                >
+                    <ModalHeader title={getTitle(selectedItem)} />
+                    <ModalBody>
+                        {/* Context section */}
+                        {selectedItem.humanContext?.description && (
+                            <Content style={{ marginBottom: "16px" }}>
+                                <p>{selectedItem.humanContext.description}</p>
+                            </Content>
+                        )}
+
+                        {/* Reference links */}
+                        {selectedItem.humanContext?.references &&
+                            selectedItem.humanContext.references.length > 0 && (
+                            <div style={{ marginBottom: "16px" }}>
+                                <Split hasGutter>
+                                    {selectedItem.humanContext.references.map((ref, i) => (
+                                        <SplitItem key={i}>
+                                            <Button
+                                                variant="link"
+                                                isInline
+                                                component="a"
+                                                href={ref.url}
+                                                target="_blank"
+                                                icon={<ExternalLinkAltIcon />}
+                                                iconPosition="end"
+                                            >
+                                                {ref.label}
+                                            </Button>
+                                        </SplitItem>
+                                    ))}
+                                </Split>
+                            </div>
+                        )}
+
+                        {/* Project info */}
+                        <div style={{ marginBottom: "16px" }}>
+                            <Split hasGutter>
+                                <SplitItem>
+                                    <strong>Project:</strong>{" "}
+                                    <Link to={`/projects/${selectedItem.projectId}`}>
+                                        {selectedItem.projectName ||
+                                            `Project #${selectedItem.projectId}`}
+                                    </Link>
+                                </SplitItem>
+                                <SplitItem>
+                                    <strong>Action Type:</strong>{" "}
+                                    <Label isCompact color="orange">
+                                        {selectedItem.actionType}
+                                    </Label>
+                                </SplitItem>
+                            </Split>
+                        </div>
+
+                        {/* Manager input (collapsible) */}
+                        {selectedItem.input && (
+                            <ExpandableSection
+                                toggleText="Manager Input"
+                                style={{ marginBottom: "16px" }}
+                            >
+                                <Content>
+                                    <pre style={{
+                                        whiteSpace: "pre-wrap",
+                                        wordBreak: "break-word",
+                                        fontSize: "0.9em",
+                                        background: "var(--pf-t--global--background--color--secondary--default)",
+                                        padding: "12px",
+                                        borderRadius: "4px",
+                                    }}>
+                                        {selectedItem.input}
+                                    </pre>
+                                </Content>
+                            </ExpandableSection>
+                        )}
+
+                        {/* Response form */}
+                        <Title headingLevel="h3" size="md" style={{ marginBottom: "8px" }}>
+                            Your Response
+                        </Title>
+                        <DynamicFormRenderer
+                            schema={selectedItem.outputSchema}
+                            values={formValues}
+                            onChange={setFormValues}
+                            errors={formErrors}
+                        />
+
+                        {submitError && (
+                            <Alert
+                                variant="danger"
+                                title="Submission failed"
+                                isInline
+                                style={{ marginTop: "16px" }}
+                            >
+                                {submitError}
+                            </Alert>
+                        )}
+                    </ModalBody>
+                    <ModalFooter>
+                        <Button
+                            variant="primary"
+                            onClick={handleSubmit}
+                            isLoading={submitting}
+                            isDisabled={submitting}
+                        >
+                            Submit Response
+                        </Button>
+                        <Button variant="link" onClick={closeDetail} isDisabled={submitting}>
+                            Cancel
+                        </Button>
+                    </ModalFooter>
+                </Modal>
+            )}
+        </PageSection>
+    );
+}
+
+function buildDefaultValues(item: InboxItem): Record<string, unknown> {
+    const values: Record<string, unknown> = {};
+    if (item.outputSchema?.fields) {
+        for (const field of item.outputSchema.fields) {
+            if (field.defaultValue !== undefined && field.defaultValue !== null) {
+                values[field.name] = field.defaultValue;
+            } else if (field.type === "boolean") {
+                values[field.name] = false;
+            }
+        }
+    }
+    return values;
+}


### PR DESCRIPTION
Closes #69

## Summary

- Adds a **Human Task Inbox** — a first-class UI for viewing and responding to tasks
  that require human input, with structured forms instead of raw text
- New `humanContext` and `outputSchema` fields on tasks allow the AI Manager to specify
  what it needs from the user and what form fields to present
- Inbox appears as a top-level nav item with a live badge count via SSE

## Changes

### Backend (Java / Quarkus)
- **TaskEntity**: Added `human_context` and `output_schema` TEXT columns (V23 migration)
- **REST API**: 4 new endpoints — `GET /inbox`, `GET /inbox/count`,
  `GET /inbox/{taskId}`, `POST /inbox/{taskId}/complete` with server-side validation
- **SSE**: New `inbox-updated` event type fired on AwaitingInput status transitions
- **Manager**: Updated `ManagerDecision` record, JSON schema, and system prompt to
  support structured human task creation with context and output schemas

### Frontend (React / PatternFly 6)
- **InboxPage**: Task list with detail modal for responding
- **DynamicFormRenderer**: Reusable component rendering forms from OutputSchema
  (text, textarea, boolean, select, number field types)
- **AppSidebar**: Inbox nav item with live Badge count updated via SSE
- Falls back to freeform text area when no output schema is defined

### New files
- `InboxResourceImpl.java` — REST implementation
- `InboxResponseValidator.java` — schema-based response validation
- `DynamicFormRenderer.tsx` — dynamic form component
- `InboxPage.tsx` — inbox page with list + modal
- `V23__add_human_task_fields.sql` — database migration

## Test plan
- [x] Maven build passes (all 260 tests green)
- [x] Frontend TypeScript compiles with zero errors
- [ ] Create a task with `humanContext` and `outputSchema` JSON, verify it appears in
      `GET /inbox` and the detail modal renders the form correctly
- [ ] Submit a structured response, verify validation (required fields, select options)
- [ ] Verify freeform fallback when `outputSchema` is null
- [ ] Verify sidebar badge count updates in real-time via SSE
- [ ] Verify existing `/respond` endpoint still works (backward compatibility)