### PR TITLE
Add project-scoped AI Assistant (#86)

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/SeedDataInitializer.java
+++ b/app/src/main/java/io/apitomy/axiom/app/SeedDataInitializer.java
@@ -44,44 +44,14 @@ public class SeedDataInitializer {
 
         LOG.info("Seeding built-in action types");
 
-        seedActionType("analyze",
-                "Read and understand an issue, assess complexity, and identify affected "
-                        + "components. Use this action when an issue is complex enough to require a "
-                        + "full structured analysis with issue summary, findings, "
-                        + "complexity assessment, and recommended next steps. This is a read-only "
-                        + "action — no code changes are made.",
-                "actor", true, true, READ_ONLY_TOOLS,
-                """
-                You are analyzing a GitHub issue. Read the issue details and produce \
-                a structured analysis.
-
-                ## Instructions
-                1. Read and understand the issue described below
-                2. If you need to examine the code, clone the repository first: \
-                   git clone https://github.com/{{repository}}.git {{workDir}}/repo
-                3. Produce a summary with the following sections:
-                   - **Issue Summary**: What is being asked or reported
-                   - **Findings**: What you discovered
-                   - **Complexity Assessment**: Low/Medium/High with justification
-                   - **Recommendations**: Suggested next steps
-                4. Do NOT make any code changes — this is a read-only analysis
-                5. Post the analysis as a comment on the GitHub issue
-
-                ## Issue
-                {{issueRef}} in {{repository}}
-
-                ## Work Directory
-                {{workDir}}
-
-                ## Context from Manager
-                {{managerInput}}
-                """);
-
         seedActionType("auto-tag",
                 "Determine and apply appropriate labels/tags to a GitHub issue. Use this "
                         + "when a new issue is created and needs categorization (e.g. bug, "
                         + "feature, documentation, question, good-first-issue).",
-                "actor", false, true, READ_PLUS_MCP_TOOLS,
+                "actor", false, true,
+                "@Read-Only Tools,"
+                        + "mcp__axiom-tools__list_github_labels,"
+                        + "mcp__axiom-tools__apply_github_labels",
                 """
                 You are tagging a GitHub issue with appropriate labels.
 
@@ -103,158 +73,6 @@ public class SeedDataInitializer {
                 {{managerInput}}
                 """);
 
-        seedActionType("implement",
-                "Write code to address the issue by creating a feature branch, making "
-                        + "changes, and opening a pull request. Use this when an analysis has "
-                        + "been completed and the issue requires code changes (bug fixes or "
-                        + "feature implementations). Should not be triggered directly from "
-                        + "an incoming event — typically follows a completed 'analyze' or "
-                        + "'propose' task.",
-                "actor", true, true, WRITE_TOOLS,
-                """
-                You are implementing a code change to address a GitHub issue.
-
-                ## Instructions
-                1. Clone the repository: \
-                   git clone https://github.com/{{repository}}.git {{workDir}}/repo \
-                   && cd {{workDir}}/repo
-                2. Read the issue and understand what needs to be done
-                3. Examine the codebase
-                4. Create a feature branch: git checkout -b agent/issue-<number>
-                5. Make the necessary code changes
-                6. Commit with a descriptive message referencing the issue
-                7. Push the branch: git push -u origin agent/issue-<number>
-                8. Open a pull request: gh pr create --title "..." --body "Closes #<number>"
-
-                ## Issue
-                {{issueRef}} in {{repository}}
-
-                ## Work Directory
-                {{workDir}}
-
-                ## Context from Manager
-                {{managerInput}}
-                """);
-
-        seedActionType("propose",
-                "Draft a proposal or design document for addressing a complex issue. Use "
-                        + "this for issues that require architectural decisions or significant "
-                        + "changes before implementation begins. Produces a design proposal "
-                        + "with approach, files to change, risks, and estimated effort. "
-                        + "Read-only — no code changes are made.",
-                "actor", true, true, READ_ONLY_TOOLS,
-                """
-                You are drafting a proposal for how to address a GitHub issue.
-
-                ## Instructions
-                1. Read the issue and understand the requirements
-                2. If you need to examine the code, clone the repository first: \
-                   git clone https://github.com/{{repository}}.git {{workDir}}/repo
-                3. Produce a design proposal with:
-                   - **Approach**: How you would solve this
-                   - **Files to Change**: Which files would be modified
-                   - **Risks**: Potential issues or trade-offs
-                   - **Estimated Effort**: Rough assessment of complexity
-                4. Do NOT make any code changes — this is a read-only proposal
-
-                ## Issue
-                {{issueRef}} in {{repository}}
-
-                ## Work Directory
-                {{workDir}}
-
-                ## Context from Manager
-                {{managerInput}}
-                """);
-
-        seedActionType("review",
-                "Review a pull request or code change for correctness, style, and "
-                        + "potential issues. Use this when a PR is opened or updated, or "
-                        + "when an 'implement' task has been completed and the resulting "
-                        + "code needs review. Read-only — produces a review summary but "
-                        + "does not modify code.",
-                "actor", true, true, READ_ONLY_TOOLS,
-                """
-                You are reviewing code changes related to a GitHub issue.
-
-                ## Instructions
-                1. If you need to examine the code, clone the repository first: \
-                   git clone https://github.com/{{repository}}.git {{workDir}}/repo
-                2. Examine the changes
-                3. Review for correctness, style, and potential issues
-                4. Produce a review summary with:
-                   - **Summary**: What the changes do
-                   - **Issues Found**: Any bugs, style issues, or concerns
-                   - **Suggestions**: Improvements or alternatives
-                5. Do NOT make any code changes
-
-                ## Issue
-                {{issueRef}} in {{repository}}
-
-                ## Work Directory
-                {{workDir}}
-
-                ## Context from Manager
-                {{managerInput}}
-                """);
-
-        seedActionType("respond",
-                "Reply to a comment or review feedback on a GitHub issue or pull "
-                        + "request. Use this when a previous task failed to post its "
-                        + "findings, or when review feedback requires a follow-up response "
-                        + "with code changes. Can make code changes and post comments.",
-                "actor", true, true, WRITE_TOOLS,
-                """
-                You are responding to feedback on a GitHub issue or pull request.
-
-                ## Instructions
-                1. If you need to work with the code, clone the repository first: \
-                   git clone https://github.com/{{repository}}.git {{workDir}}/repo \
-                   && cd {{workDir}}/repo
-                2. Read the feedback or comment described below
-                3. If code changes are requested, make them and commit
-                4. Post a response on the issue:
-                   a. Write your comment to /tmp/gh-comment.md using the Write tool
-                   b. Then run: gh issue comment <number> --repo {{repository}} --body-file /tmp/gh-comment.md
-                5. If you cannot post the comment, include the full response text in your output
-
-                ## Issue
-                {{issueRef}} in {{repository}}
-
-                ## Work Directory
-                {{workDir}}
-
-                ## Context from Manager
-                {{managerInput}}
-                """);
-
-        seedActionType("answer-question",
-                "Answer a question asked by a user on a GitHub issue. Use this when "
-                        + "the issue body or a comment contains a question (indicated by "
-                        + "question marks, 'how do I', 'what is', etc.). The actor examines "
-                        + "the repository to find the answer and posts it as a comment on "
-                        + "the issue. Can be triggered directly from issue-created events "
-                        + "when the issue is clearly a question.",
-                "actor", false, true, READ_PLUS_MCP_TOOLS,
-                """
-                You are answering a question on a GitHub issue.
-
-                ## Instructions
-                1. Read the question described below
-                2. Examine the repository to find the answer
-                3. Post your answer directly on the issue using the \
-                post_github_comment tool with the repository, issue number, \
-                and your answer as the body
-                4. Keep your answer concise, friendly, and informative
-                5. If you cannot post the comment, include the full answer in your output
-
-                ## Issue
-                {{issueRef}} in {{repository}}
-
-                ## Context from Manager
-                {{managerInput}}
-                """);
-
         seedActionType("close-project",
                 "Mark the project as completed. Use this script action when an "
                         + "issue-closed event is received, indicating the issue has "
@@ -265,19 +83,8 @@ public class SeedDataInitializer {
                 curl -s -X POST "{{apiBaseUrl}}/projects/{{projectId}}/close"
                 """);
 
-        seedActionType("reopen-project",
-                "Re-open a completed project. Use this script action when an "
-                        + "issue-reopened event is received, indicating the issue "
-                        + "needs further attention after being previously closed.",
-                "script", true, false, null, null,
-                """
-                #!/bin/bash
-                curl -s -X POST "{{apiBaseUrl}}/projects/{{projectId}}/reopen"
-                """);
-
         LOG.infof("Seeded %d built-in action types", ActionTypeEntity.count());
 
-        // Seed tools, toolsets, actors, manager config, test event source, and report definitions
         seedTools();
         seedToolsets();
         ensureAxiomSdkToolset();
@@ -293,18 +100,6 @@ public class SeedDataInitializer {
             LOG.info("Tools already exist, skipping tool seed data");
             return;
         }
-
-        // Post GitHub Comment tool
-        ToolDefinitionEntity postComment = new ToolDefinitionEntity();
-        postComment.name = "post_github_comment";
-        postComment.description = "Post a comment on a GitHub issue. The comment body is written "
-                + "to a temp file to avoid shell quoting issues.";
-
-        postComment.parameters = "[{\"name\":\"repo\",\"type\":\"string\",\"description\":\"Repository in owner/name format\",\"required\":true},"
-                + "{\"name\":\"issue_number\",\"type\":\"number\",\"description\":\"Issue number\",\"required\":true},"
-                + "{\"name\":\"body\",\"type\":\"string\",\"description\":\"Comment body (markdown)\",\"required\":true}]";
-        postComment.scriptTemplate = "gh issue comment {{issue_number}} --repo {{repo}} --body-file {{body_file}}";
-        postComment.persist();
 
         // List GitHub Labels tool
         ToolDefinitionEntity listLabels = new ToolDefinitionEntity();
@@ -328,19 +123,6 @@ public class SeedDataInitializer {
                 + "{\"name\":\"labels\",\"type\":\"string\",\"description\":\"Comma-separated label names to apply\",\"required\":true}]";
         addLabels.scriptTemplate = "gh issue edit {{issue_number}} --repo {{repo}} --add-label \"{{labels}}\"";
         addLabels.persist();
-
-        // Create GitHub PR tool
-        ToolDefinitionEntity createPr = new ToolDefinitionEntity();
-        createPr.name = "create_github_pr";
-        createPr.description = "Create a pull request on GitHub. The PR body is written "
-                + "to a temp file to avoid shell quoting issues.";
-
-        createPr.parameters = "[{\"name\":\"repo\",\"type\":\"string\",\"description\":\"Repository in owner/name format\",\"required\":true},"
-                + "{\"name\":\"title\",\"type\":\"string\",\"description\":\"PR title\",\"required\":true},"
-                + "{\"name\":\"body\",\"type\":\"string\",\"description\":\"PR description (markdown)\",\"required\":true},"
-                + "{\"name\":\"head\",\"type\":\"string\",\"description\":\"Branch to merge from\",\"required\":true}]";
-        createPr.scriptTemplate = "gh pr create --repo {{repo}} --title \"{{title}}\" --body-file {{body_file}} --head {{head}}";
-        createPr.persist();
 
         // List GitHub Issues tool (for reports)
         ToolDefinitionEntity listIssues = new ToolDefinitionEntity();
@@ -369,7 +151,6 @@ public class SeedDataInitializer {
         listPrs.persist();
 
         LOG.infof("Seeded %d built-in tools", ToolDefinitionEntity.count());
-
     }
 
     private void seedToolsets() {
@@ -387,33 +168,14 @@ public class SeedDataInitializer {
                         "Bash(git log *)", "Bash(git diff *)", "Bash(git show *)",
                         "Bash(git status *)", "Bash(git branch *)"));
 
-        seedToolset("Read + MCP Tools",
-                "Read-only tools plus MCP tools for commenting and labeling",
-                String.join(",",
-                        "@Read-Only Tools",
-                        "mcp__axiom-tools__post_github_comment",
-                        "mcp__axiom-tools__list_github_labels",
-                        "mcp__axiom-tools__apply_github_labels"));
-
         seedToolset("Write Tools",
-                "Full read/write tools plus git and MCP tools for implementation tasks",
+                "Full read/write tools plus git tools for implementation tasks",
                 String.join(",",
                         "@Read-Only Tools",
                         "Edit", "Write",
                         "Bash(git add *)", "Bash(git commit *)", "Bash(git checkout *)",
                         "Bash(git switch *)", "Bash(git push *)", "Bash(git merge *)",
-                        "Bash(mkdir *)", "Bash(cp *)", "Bash(mv *)",
-                        "mcp__axiom-tools__post_github_comment",
-                        "mcp__axiom-tools__create_github_pr"));
-
-        seedToolset("Report Tools",
-                "Read-only tools plus GitHub CLI and MCP tools for report generation",
-                String.join(",",
-                        "@Read-Only Tools",
-                        "Bash(gh issue *)", "Bash(gh pr *)", "Bash(gh api *)",
-                        "Bash(gh repo *)", "Bash(date *)",
-                        "mcp__axiom-tools__list_github_issues",
-                        "mcp__axiom-tools__list_github_prs"));
+                        "Bash(mkdir *)", "Bash(cp *)", "Bash(mv *)"));
 
         LOG.infof("Seeded %d toolsets", ToolsetEntity.count());
     }
@@ -462,7 +224,7 @@ public class SeedDataInitializer {
         actor.name = "Blinky";
         actor.description = "AI agent powered by Claude Code CLI";
         actor.type = "ai-agent";
-        actor.capabilities = "analyze,auto-tag,implement,propose,review,respond,answer-question";
+        actor.capabilities = "auto-tag";
         actor.persist();
         LOG.infof("Seeded actor: %s (%s)", actor.name, actor.type);
 
@@ -470,7 +232,7 @@ public class SeedDataInitializer {
         actor.name = "Clyde";
         actor.description = "AI agent powered by Claude Code CLI";
         actor.type = "ai-agent";
-        actor.capabilities = "analyze,auto-tag,implement,propose,review,respond,answer-question";
+        actor.capabilities = "auto-tag";
         actor.persist();
         LOG.infof("Seeded actor: %s (%s)", actor.name, actor.type);
     }
@@ -507,8 +269,6 @@ public class SeedDataInitializer {
                 source.name, source.pollInterval);
     }
 
-    // Action types reference toolsets by name using the @ToolsetName syntax.
-    // At execution time, ToolsetResolver expands these into individual tools.
     private void seedSecrets() {
         if (SecretEntity.count() > 0) {
             LOG.info("Secrets already exist, skipping secret seed data");
@@ -543,10 +303,6 @@ public class SeedDataInitializer {
         }
     }
 
-    private static final String READ_ONLY_TOOLS = "@Read-Only Tools";
-    private static final String READ_PLUS_MCP_TOOLS = "@Read + MCP Tools";
-    private static final String WRITE_TOOLS = "@Write Tools";
-
     private void seedReportDefinitions() {
         if (ReportDefinitionEntity.count() > 0) {
             LOG.info("Report definitions already exist, skipping seed data");
@@ -555,7 +311,10 @@ public class SeedDataInitializer {
 
         Instant now = Instant.now();
 
-        String reportTools = "@Report Tools";
+        String reportTools = "@Read-Only Tools,"
+                + "Bash(gh issue *),Bash(gh pr *),Bash(gh api *),Bash(gh repo *),Bash(date *),"
+                + "mcp__axiom-tools__list_github_issues,"
+                + "mcp__axiom-tools__list_github_prs";
 
         ReportDefinitionEntity daily = new ReportDefinitionEntity();
         daily.name = "Daily GitHub Activity";
@@ -585,58 +344,6 @@ public class SeedDataInitializer {
         daily.createdOn = now;
         daily.updatedOn = now;
         daily.persist();
-
-        ReportDefinitionEntity prsAwaitingReview = new ReportDefinitionEntity();
-        prsAwaitingReview.name = "PRs Awaiting Review";
-        prsAwaitingReview.description = "Lists all open pull requests that are waiting for code review.";
-        prsAwaitingReview.schedule = "daily";
-        prsAwaitingReview.scheduleTime = "09:00";
-        prsAwaitingReview.timeWindow = "last-7d";
-        prsAwaitingReview.enabled = false;
-        prsAwaitingReview.allowedTools = reportTools;
-        prsAwaitingReview.promptTemplate = """
-                Generate a report of pull requests awaiting review for: {{repositories}}
-
-                Use the list_github_prs tool to list all open PRs, then filter for those \
-                that have no approving review (reviewDecision is not "APPROVED").
-
-                Include:
-                1. **Summary** — total open PRs, how many awaiting review, how many drafts
-                2. **PRs Awaiting Review** — table with PR #, title, author, created date, age in days
-                3. **Draft PRs** — table with PR #, title, author
-
-                Format all PR references as clickable markdown links.
-                Sort by age (oldest first) to highlight stale PRs.
-                """;
-        prsAwaitingReview.createdOn = now;
-        prsAwaitingReview.updatedOn = now;
-        prsAwaitingReview.persist();
-
-        ReportDefinitionEntity issuesAwaiting = new ReportDefinitionEntity();
-        issuesAwaiting.name = "Issues Awaiting Response";
-        issuesAwaiting.description = "Lists open issues that may need attention from the development team.";
-        issuesAwaiting.schedule = "weekly";
-        issuesAwaiting.scheduleTime = "08:00";
-        issuesAwaiting.timeWindow = "last-7d";
-        issuesAwaiting.enabled = false;
-        issuesAwaiting.allowedTools = reportTools;
-        issuesAwaiting.promptTemplate = """
-                Generate a report of open issues that may need attention for: {{repositories}}
-
-                Use the list_github_issues tool to list all open issues.
-
-                Include:
-                1. **Summary** — total open issues, new this period, oldest unresolved
-                2. **New Issues (this period)** — table with issue #, title, author, labels, age
-                3. **Oldest Open Issues** — top 10 oldest open issues by creation date
-                4. **Issues by Label** — breakdown of open issue count by label
-
-                Format all issue references as clickable markdown links.
-                Highlight issues older than 30 days as potentially stale.
-                """;
-        issuesAwaiting.createdOn = now;
-        issuesAwaiting.updatedOn = now;
-        issuesAwaiting.persist();
 
         LOG.infof("Seeded %d report definitions (all disabled by default)",
                 ReportDefinitionEntity.count());

--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSession.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSession.java
@@ -67,6 +67,8 @@ public class AssistantSession {
     private final CopyOnWriteArrayList<Consumer<SseEvent>> listeners = new CopyOnWriteArrayList<>();
     private final Object eventLock = new Object();
     private final CopyOnWriteArrayList<AutoApprovalRule> autoApprovalRules = new CopyOnWriteArrayList<>();
+    private final Long projectId;
+    private final String projectName;
 
     /**
      * A session-scoped rule for automatically approving tool permissions.
@@ -92,10 +94,13 @@ public class AssistantSession {
      * @param workingDirectory the Claude Code working directory
      * @param command the full command line for the Claude Code subprocess
      * @param environment resolved environment variables to inject into the subprocess
+     * @param projectId optional project ID if session is scoped to a project
+     * @param projectName optional project name if session is scoped to a project
      */
     public AssistantSession(String name, String templateId, Path sessionDirectory,
                              Path workingDirectory, List<String> command,
-                             Map<String, String> environment) {
+                             Map<String, String> environment, Long projectId,
+                             String projectName) {
         this.id = UUID.randomUUID().toString();
         this.name = name;
         this.templateId = templateId;
@@ -107,6 +112,8 @@ public class AssistantSession {
         this.status = Status.STARTING;
         this.createdAt = Instant.now();
         this.lastActivityAt = this.createdAt;
+        this.projectId = projectId;
+        this.projectName = projectName;
     }
 
     /**
@@ -399,6 +406,20 @@ public class AssistantSession {
     /** Returns the number of completed turns. */
     public int getTurnCount() {
         return turnCount;
+    }
+
+    /**
+     * @return the project ID if this session is scoped to a project, null otherwise
+     */
+    public Long getProjectId() {
+        return projectId;
+    }
+
+    /**
+     * @return the project name if this session is scoped to a project, null otherwise
+     */
+    public String getProjectName() {
+        return projectName;
     }
 
     /**

--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSessionManager.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSessionManager.java
@@ -8,8 +8,10 @@ import io.apitomy.axiom.app.ImportExportService;
 import io.apitomy.axiom.app.assistant.AssistantEventParser.SseEvent;
 import io.apitomy.axiom.core.entities.AiUsageEntity;
 import io.apitomy.axiom.core.entities.McpServerEntity;
+import io.apitomy.axiom.core.entities.ProjectEntity;
 import io.apitomy.axiom.core.entities.ToolsetEntity;
 import io.apitomy.axiom.core.services.EnvironmentResolver;
+import io.apitomy.axiom.core.services.WorkspaceService;
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -76,6 +78,9 @@ public class AssistantSessionManager {
     @Inject
     EnvironmentResolver environmentResolver;
 
+    @Inject
+    WorkspaceService workspaceService;
+
     private final Map<String, AssistantSession> sessions = new ConcurrentHashMap<>();
     private final AtomicInteger sessionCount = new AtomicInteger();
 
@@ -86,12 +91,14 @@ public class AssistantSessionManager {
      *
      * @param name the user-visible session name
      * @param templateId the template to create the session from
+     * @param projectId optional project ID to scope the session to
      * @return the started session
      * @throws IOException if the session cannot be created
      * @throws IllegalStateException if the AI engine is not Claude Code or the
      *         session limit has been reached
      */
-    public AssistantSession createSession(String name, String templateId) throws IOException {
+    public AssistantSession createSession(String name, String templateId,
+                                          Long projectId) throws IOException {
         if (!"claude-code".equals(aiEngine)) {
             throw new IllegalStateException(
                     "The AI Assistant requires Claude Code as the active AI engine. "
@@ -111,9 +118,18 @@ public class AssistantSessionManager {
                 throw new IllegalArgumentException("Template not found: " + templateId);
             }
 
+            // Look up project if scoped
+            ProjectEntity project = null;
+            if (projectId != null) {
+                project = ProjectEntity.findById(projectId);
+                if (project == null) {
+                    throw new IllegalArgumentException("Project not found: " + projectId);
+                }
+            }
+
             // Resolve MCP servers from template
             Map<String, AssistantContextBuilder.McpServerConfig> mcpConfigs =
-                    resolveMcpServers(template);
+                    resolveMcpServers(template, project);
 
             // Resolve allowed tools from template
             List<String> resolvedAllowedTools = resolveAllowedTools(template);
@@ -133,6 +149,13 @@ public class AssistantSessionManager {
                     throw new IOException("Template working directory does not exist: "
                             + template.workingDirectory());
                 }
+            } else if (project != null) {
+                Path projectWorkspace = workspaceService.getWorkspacePath(project);
+                if (Files.isDirectory(projectWorkspace)) {
+                    workDir = projectWorkspace;
+                } else {
+                    workDir = contextBuilder.createWorkingDirectory(sessionDir, templateId);
+                }
             } else {
                 workDir = contextBuilder.createWorkingDirectory(sessionDir, templateId);
             }
@@ -144,23 +167,41 @@ public class AssistantSessionManager {
             }
 
             // Resolve environment variables (with secret substitution)
-            Map<String, String> resolvedEnv =
-                    environmentResolver.hasCustomEnvironment(template.environment())
-                            ? environmentResolver.resolve(template.environment())
-                            : Map.of();
+            Map<String, String> resolvedEnv = new LinkedHashMap<>();
+            if (environmentResolver.hasCustomEnvironment(template.environment())) {
+                resolvedEnv.putAll(environmentResolver.resolve(template.environment()));
+            }
 
-            List<String> command = buildCommand(workDir, sessionDir, template.systemPrompt(),
+            // Inject project environment variables
+            if (project != null) {
+                resolvedEnv.put("AXIOM_PROJECT_ID", String.valueOf(project.id));
+                resolvedEnv.put("AXIOM_PROJECT_NAME", project.name);
+                resolvedEnv.put("AXIOM_ISSUE_REF", project.issueRef);
+                resolvedEnv.put("AXIOM_REPOSITORY", project.repository);
+            }
+
+            // Build system prompt, augmenting with project context if applicable
+            String systemPrompt = buildSystemPrompt(template, project);
+
+            // Build welcome message, substituting project placeholders
+            String welcomeMessage = template.welcomeMessage();
+            if (project != null && welcomeMessage != null) {
+                welcomeMessage = welcomeMessage.replace("{{projectName}}", project.name);
+            }
+
+            List<String> command = buildCommand(workDir, sessionDir, systemPrompt,
                     template.model(), resolvedAllowedTools, mcpConfig != null);
 
             String sessionName = name != null && !name.isBlank() ? name : "Assistant Session";
+            String projectName = project != null ? project.name : null;
             AssistantSession session = new AssistantSession(sessionName, templateId, sessionDir,
-                    workDir, command, resolvedEnv);
+                    workDir, command, resolvedEnv, projectId, projectName);
             session.start();
 
             // Add welcome message to event history so it replays on reconnect
-            if (template.welcomeMessage() != null && !template.welcomeMessage().isBlank()) {
+            if (welcomeMessage != null && !welcomeMessage.isBlank()) {
                 ObjectNode welcomeData = objectMapper.createObjectNode();
-                welcomeData.put("text", template.welcomeMessage());
+                welcomeData.put("text", welcomeMessage);
                 session.addEvent(new AssistantEventParser.SseEvent("assistant_text", welcomeData));
             }
 
@@ -412,6 +453,51 @@ public class AssistantSessionManager {
         }
     }
 
+    /**
+     * Builds the system prompt, augmenting the template prompt with project context
+     * if a project is specified.
+     */
+    private String buildSystemPrompt(SessionTemplateService.SessionTemplate template,
+                                     ProjectEntity project) {
+        String prompt = template.systemPrompt() != null ? template.systemPrompt() : "";
+
+        if (project == null) {
+            return prompt;
+        }
+
+        StringBuilder context = new StringBuilder();
+        context.append("\n\n## Project Context\n\n");
+        context.append("This session is scoped to the following project:\n\n");
+        context.append("- **Name**: ").append(project.name).append("\n");
+        if (project.description != null && !project.description.isBlank()) {
+            context.append("- **Description**: ").append(project.description).append("\n");
+        }
+        context.append("- **Type**: ").append(project.type).append("\n");
+        context.append("- **Status**: ").append(project.status).append("\n");
+        context.append("- **Issue Source**: ").append(project.issueSource).append("\n");
+        context.append("- **Issue Reference**: ").append(project.issueRef).append("\n");
+        context.append("- **Repository**: ").append(project.repository).append("\n");
+        if (project.labels != null && !project.labels.isEmpty()) {
+            context.append("- **Labels**: ").append(String.join(", ", project.labels)).append("\n");
+        }
+        context.append("\nUse the project-scoped MCP tools (prefixed with `axiom_project_`) to ")
+                .append("access project tasks, discussion thread, events, and traces.\n");
+
+        String projectContext = context.toString();
+
+        // Substitute {{projectContext}} placeholder if present, otherwise append
+        if (prompt.contains("{{projectContext}}")) {
+            prompt = prompt.replace("{{projectContext}}", projectContext);
+        } else {
+            prompt = prompt + projectContext;
+        }
+
+        // Substitute {{projectName}} placeholder
+        prompt = prompt.replace("{{projectName}}", project.name);
+
+        return prompt;
+    }
+
     private List<String> buildCommand(Path workDir, Path sessionDir, String systemPrompt,
                                        String model, List<String> allowedTools,
                                        boolean hasMcpConfig) {
@@ -564,20 +650,26 @@ public class AssistantSessionManager {
     }
 
     private Map<String, AssistantContextBuilder.McpServerConfig> resolveMcpServers(
-            SessionTemplateService.SessionTemplate template) throws IOException {
+            SessionTemplateService.SessionTemplate template,
+            ProjectEntity project) throws IOException {
         Map<String, AssistantContextBuilder.McpServerConfig> configs = new LinkedHashMap<>();
 
         for (String serverName : template.mcpServers()) {
             if ("@axiom-assistant".equals(serverName)) {
-                // Special built-in MCP server for the Config Assistant
+                // Special built-in MCP server for the assistant
                 Path mcpServerDir = ensureAssistantMcpServerInstalled();
                 String serverJsPath = mcpServerDir.resolve("server.js")
                         .toAbsolutePath().toString();
                 String apiUrl = "http://localhost:" + httpPort + "/api/v1";
+                Map<String, String> env = new LinkedHashMap<>();
+                env.put("AXIOM_API_URL", apiUrl);
+                if (project != null) {
+                    env.put("AXIOM_PROJECT_ID", String.valueOf(project.id));
+                }
                 configs.put("axiom", new AssistantContextBuilder.McpServerConfig(
                         "node",
                         List.of(serverJsPath),
-                        Map.of("AXIOM_API_URL", apiUrl)));
+                        env));
             } else {
                 // Resolve from database
                 McpServerEntity entity = McpServerEntity.find("name", serverName).firstResult();

--- a/app/src/main/java/io/apitomy/axiom/app/assistant/SessionTemplateService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/SessionTemplateService.java
@@ -31,6 +31,7 @@ public class SessionTemplateService {
     private static final String[] BUILT_IN_FILES = {
             "axiom-config-assistant.json",
             "general-assistant.json",
+            "project-assistant.json",
     };
 
     @Inject

--- a/app/src/main/java/io/apitomy/axiom/app/rest/AssistantResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/AssistantResourceImpl.java
@@ -88,7 +88,7 @@ public class AssistantResourceImpl implements AssistantResource {
         }
         try {
             AssistantSession session = sessionManager.createSession(
-                    data.getName(), data.getTemplateId());
+                    data.getName(), data.getTemplateId(), data.getProjectId());
             return toSessionInfo(session);
         } catch (IllegalArgumentException e) {
             throw new WebApplicationException(e.getMessage(), 404);
@@ -494,6 +494,8 @@ public class AssistantResourceImpl implements AssistantResource {
         info.setTotalInputTokens(session.getTotalInputTokens());
         info.setTotalOutputTokens(session.getTotalOutputTokens());
         info.setTurnCount(session.getTurnCount());
+        info.setProjectId(session.getProjectId());
+        info.setProjectName(session.getProjectName());
         return info;
     }
 

--- a/app/src/main/resources/templates/assistant-templates/project-assistant.json
+++ b/app/src/main/resources/templates/assistant-templates/project-assistant.json
@@ -1,0 +1,25 @@
+{
+  "templateId": "project-assistant",
+  "name": "Project Assistant",
+  "description": "An AI assistant scoped to a specific Axiom project, with access to the project's workspace, tasks, discussion thread, events, and traces.",
+  "systemPrompt": "# Project Assistant\n\nYou are an AI assistant working within the context of a specific Axiom project.\nYou have access to the project's workspace directory, and you can query project\ndata using the project-scoped MCP tools.\n\n{{projectContext}}\n\n## Available Project Tools\n\nYou have access to the following project-scoped MCP tools:\n\n- **axiom_project_get_details** — get the full project metadata\n- **axiom_project_list_tasks** — list all tasks with status and assigned actor\n- **axiom_project_get_task** — get detailed info about a specific task\n- **axiom_project_get_thread** — read the discussion thread\n- **axiom_project_add_thread_entry** — post a new entry to the discussion thread\n- **axiom_project_list_events** — list events related to this project\n- **axiom_project_list_traces** — list activity traces for debugging\n\n## Guidelines\n\n- Use the project tools to understand context before making changes.\n- When working with code, follow the conventions of the project repository.\n- Ask clarifying questions when the request is ambiguous.\n- If you're unsure about something, say so rather than guessing.\n- Post important findings or decisions to the project thread using\n  `axiom_project_add_thread_entry` so they are visible to the team.",
+  "welcomeMessage": "Hi! I'm your assistant for the **{{projectName}}** project. I have access to the project workspace and can query tasks, events, and the discussion thread. What would you like to work on?",
+  "workingDirectory": null,
+  "mcpServers": ["@axiom-assistant"],
+  "allowedTools": [
+    "Read(*)", "Write(*)", "Edit(*)",
+    "Bash(*)",
+    "WebSearch(*)", "WebFetch(*)",
+    "mcp__axiom__axiom_project_get_details",
+    "mcp__axiom__axiom_project_list_tasks",
+    "mcp__axiom__axiom_project_get_task",
+    "mcp__axiom__axiom_project_get_thread",
+    "mcp__axiom__axiom_project_add_thread_entry",
+    "mcp__axiom__axiom_project_list_events",
+    "mcp__axiom__axiom_project_list_traces",
+    "mcp__axiom__axiom_list_tools",
+    "mcp__axiom__axiom_get_tool",
+    "mcp__axiom__axiom_list_action_types",
+    "mcp__axiom__axiom_get_action_type"
+  ]
+}

--- a/app/src/main/resources/templates/axiom-assistant-mcp/server.js
+++ b/app/src/main/resources/templates/axiom-assistant-mcp/server.js
@@ -14,13 +14,18 @@ function log(level, message, data) {
 }
 
 const AXIOM_API_URL = process.env.AXIOM_API_URL || "http://localhost:9090/api/v1";
+const AXIOM_PROJECT_ID = process.env.AXIOM_PROJECT_ID;
 
-async function axiomApi(method, path) {
+async function axiomApi(method, path, body) {
     const url = `${AXIOM_API_URL}${path}`;
     const opts = {
         method,
         headers: { "Accept": "application/json" },
     };
+    if (body !== undefined) {
+        opts.headers["Content-Type"] = "application/json";
+        opts.body = JSON.stringify(body);
+    }
     const resp = await fetch(url, opts);
     const text = await resp.text();
     if (!resp.ok) {
@@ -257,9 +262,81 @@ const TOOLS = [
     },
 ];
 
+if (AXIOM_PROJECT_ID) {
+    const projectId = AXIOM_PROJECT_ID;
+    TOOLS.push(
+        {
+            name: "axiom_project_get_details",
+            description: "Get full details of the project this session is scoped to, including name, description, type, status, issue reference, repository, and labels",
+            parameters: [],
+            handler: async () => {
+                return await axiomApi("GET", `/projects/${encodeURIComponent(projectId)}`);
+            },
+        },
+        {
+            name: "axiom_project_list_tasks",
+            description: "List all tasks for this project with their status, assigned actor, and action type",
+            parameters: [],
+            handler: async () => {
+                return await axiomApi("GET", `/projects/${encodeURIComponent(projectId)}/tasks`);
+            },
+        },
+        {
+            name: "axiom_project_get_task",
+            description: "Get detailed information about a specific project task including input, output, and execution log",
+            parameters: [
+                { name: "taskId", type: "string", description: "The task ID to retrieve", required: true },
+            ],
+            handler: async (args) => {
+                return await axiomApi("GET", `/projects/${encodeURIComponent(projectId)}/tasks/${encodeURIComponent(args.taskId)}`);
+            },
+        },
+        {
+            name: "axiom_project_get_thread",
+            description: "Read the project's discussion thread entries",
+            parameters: [],
+            handler: async () => {
+                return await axiomApi("GET", `/projects/${encodeURIComponent(projectId)}/thread`);
+            },
+        },
+        {
+            name: "axiom_project_add_thread_entry",
+            description: "Post a new entry to the project's discussion thread",
+            parameters: [
+                { name: "content", type: "string", description: "The thread entry content", required: true },
+            ],
+            handler: async (args) => {
+                return await axiomApi("POST", `/projects/${encodeURIComponent(projectId)}/thread`, {
+                    authorType: "assistant",
+                    authorId: "axiom-assistant",
+                    entryType: "comment",
+                    content: args.content,
+                });
+            },
+        },
+        {
+            name: "axiom_project_list_events",
+            description: "List events that triggered or relate to this project",
+            parameters: [],
+            handler: async () => {
+                return await axiomApi("GET", `/projects/${encodeURIComponent(projectId)}/events`);
+            },
+        },
+        {
+            name: "axiom_project_list_traces",
+            description: "List activity traces for this project for debugging and review",
+            parameters: [],
+            handler: async () => {
+                return await axiomApi("GET", `/projects/${encodeURIComponent(projectId)}/traces`);
+            },
+        },
+    );
+}
+
 log("INFO", "Axiom Assistant MCP server started", {
     toolCount: TOOLS.length,
     axiomApiUrl: AXIOM_API_URL,
+    projectId: AXIOM_PROJECT_ID || null,
 });
 
 const server = new Server({ name: "axiom-assistant", version: "1.0.0" }, {

--- a/app/src/test/java/io/apitomy/axiom/app/ActionResourceTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/ActionResourceTest.java
@@ -23,28 +23,27 @@ class ActionResourceTest {
             .then()
                 .statusCode(200)
                 .contentType(ContentType.JSON)
-                .body("$.size()", greaterThanOrEqualTo(9))
-                .body("name", hasItems("analyze", "implement", "review", "close-project"));
+                .body("$.size()", greaterThanOrEqualTo(2))
+                .body("name", hasItems("auto-tag", "close-project"));
     }
 
     @Test
     void testGetSeedActionType() {
-        // Get the "analyze" action type by listing and finding it
         int id = given()
             .when()
                 .get(ACTION_TYPES_PATH)
             .then()
                 .statusCode(200)
-                .extract().path("find { it.name == 'analyze' }.id");
+                .extract().path("find { it.name == 'auto-tag' }.id");
 
         given()
             .when()
                 .get(ACTION_TYPES_PATH + "/" + id)
             .then()
                 .statusCode(200)
-                .body("name", equalTo("analyze"))
+                .body("name", equalTo("auto-tag"))
                 .body("executionMode", equalTo("actor"))
-                .body("userTriggerable", equalTo(true))
+                .body("userTriggerable", equalTo(false))
                 .body("emitsEvent", equalTo(true));
     }
 

--- a/app/src/test/java/io/apitomy/axiom/app/McpConfigGeneratorTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/McpConfigGeneratorTest.java
@@ -127,21 +127,21 @@ class McpConfigGeneratorTest {
         assertTrue(tools.isArray(), "Tools should be a JSON array");
         assertTrue(tools.size() >= 4, "Should have at least 4 seeded script tools");
 
-        boolean hasPostComment = false;
         boolean hasListLabels = false;
         boolean hasApplyLabels = false;
-        boolean hasCreatePr = false;
+        boolean hasListIssues = false;
+        boolean hasListPrs = false;
         for (JsonNode tool : tools) {
             String name = tool.get("name").asText();
-            if ("post_github_comment".equals(name)) hasPostComment = true;
             if ("list_github_labels".equals(name)) hasListLabels = true;
             if ("apply_github_labels".equals(name)) hasApplyLabels = true;
-            if ("create_github_pr".equals(name)) hasCreatePr = true;
+            if ("list_github_issues".equals(name)) hasListIssues = true;
+            if ("list_github_prs".equals(name)) hasListPrs = true;
         }
-        assertTrue(hasPostComment, "Should contain post_github_comment tool");
         assertTrue(hasListLabels, "Should contain list_github_labels tool");
         assertTrue(hasApplyLabels, "Should contain apply_github_labels tool");
-        assertTrue(hasCreatePr, "Should contain create_github_pr tool");
+        assertTrue(hasListIssues, "Should contain list_github_issues tool");
+        assertTrue(hasListPrs, "Should contain list_github_prs tool");
     }
 
     @Test
@@ -153,21 +153,21 @@ class McpConfigGeneratorTest {
                 .get("args").get(1).asText();
         JsonNode tools = objectMapper.readTree(Files.readString(Path.of(toolsJsonPath)));
 
-        JsonNode postCommentTool = null;
+        JsonNode applyLabelsTool = null;
         for (JsonNode tool : tools) {
-            if ("post_github_comment".equals(tool.get("name").asText())) {
-                postCommentTool = tool;
+            if ("apply_github_labels".equals(tool.get("name").asText())) {
+                applyLabelsTool = tool;
                 break;
             }
         }
-        assertNotNull(postCommentTool, "post_github_comment tool should exist");
-        assertTrue(postCommentTool.has("description"), "Tool should have description");
-        assertTrue(postCommentTool.has("scriptTemplate"), "Tool should have scriptTemplate");
-        assertTrue(postCommentTool.has("parameters"), "Tool should have parameters");
+        assertNotNull(applyLabelsTool, "apply_github_labels tool should exist");
+        assertTrue(applyLabelsTool.has("description"), "Tool should have description");
+        assertTrue(applyLabelsTool.has("scriptTemplate"), "Tool should have scriptTemplate");
+        assertTrue(applyLabelsTool.has("parameters"), "Tool should have parameters");
 
-        JsonNode params = postCommentTool.get("parameters");
+        JsonNode params = applyLabelsTool.get("parameters");
         assertTrue(params.isArray(), "Parameters should be an array");
-        assertTrue(params.size() >= 3, "post_github_comment should have at least 3 parameters");
+        assertTrue(params.size() >= 3, "apply_github_labels should have at least 3 parameters");
 
         for (JsonNode param : params) {
             assertTrue(param.has("name"), "Parameter should have name");
@@ -216,7 +216,7 @@ class McpConfigGeneratorTest {
     @Test
     void testOnlyScriptToolsNoSdkServer() throws Exception {
         Path configFile = generator.generateMcpConfig(9016L, Map.of(),
-                List.of("mcp__axiom-tools__post_github_comment"));
+                List.of("mcp__axiom-tools__list_github_labels"));
         assertNotNull(configFile);
 
         JsonNode config = objectMapper.readTree(Files.readString(configFile));

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -6087,6 +6087,15 @@
             "format": "int32",
             "description": "Number of completed turns",
             "type": "integer"
+          },
+          "projectId": {
+            "format": "int64",
+            "description": "Project ID if session is scoped to a project",
+            "type": "integer"
+          },
+          "projectName": {
+            "description": "Project name if session is scoped to a project",
+            "type": "string"
           }
         }
       },
@@ -6103,6 +6112,11 @@
           "templateId": {
             "description": "Template ID to create the session from",
             "type": "string"
+          },
+          "projectId": {
+            "format": "int64",
+            "description": "Optional project ID to scope the session to a specific project",
+            "type": "integer"
           }
         }
       },

--- a/ui/src/components/assistant/AssistantToolUseBlock.tsx
+++ b/ui/src/components/assistant/AssistantToolUseBlock.tsx
@@ -6,8 +6,12 @@ import {
     Flex,
     FlexItem,
     Label,
+    Modal,
+    ModalBody,
+    ModalHeader,
     TextInput,
 } from "@patternfly/react-core";
+import SearchPlusIcon from "@patternfly/react-icons/dist/esm/icons/search-plus-icon";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { Light as SyntaxHighlighter } from "react-syntax-highlighter";
@@ -51,6 +55,7 @@ export function AssistantToolUseBlock({
     const [isExpanded, setIsExpanded] = useState(false);
     const [showPatternUI, setShowPatternUI] = useState(false);
     const [customPattern, setCustomPattern] = useState("");
+    const [isPlanModalOpen, setIsPlanModalOpen] = useState(false);
 
     const needsPermission = permissionId && !permissionResolved;
     const isAskUser = toolName === "AskUserQuestion";
@@ -155,10 +160,25 @@ export function AssistantToolUseBlock({
                 }}>
                     {needsPermission ? (
                         <>
-                            <div style={{ fontWeight: 600, marginBottom: 8 }}>
-                                Plan ready for review
-                            </div>
-                            {input?.plan && (
+                            <Flex alignItems={{ default: "alignItemsCenter" }}
+                                style={{ marginBottom: 8 }}>
+                                <FlexItem>
+                                    <span style={{ fontWeight: 600 }}>
+                                        Plan ready for review
+                                    </span>
+                                </FlexItem>
+                                {!!input?.plan && (
+                                    <FlexItem>
+                                        <Button variant="plain" size="sm"
+                                            aria-label="View plan in full screen"
+                                            onClick={() => setIsPlanModalOpen(true)}
+                                            style={{ padding: "2px 6px" }}>
+                                            <SearchPlusIcon />
+                                        </Button>
+                                    </FlexItem>
+                                )}
+                            </Flex>
+                            {!!input?.plan && (
                                 <div className="assistant-markdown" style={{
                                     marginBottom: 10,
                                     padding: "12px 16px",
@@ -193,9 +213,43 @@ export function AssistantToolUseBlock({
                             </Flex>
                         </>
                     ) : (
-                        <span style={{ color: permissionAllowed ? "#3e8635" : "#c9190b", fontStyle: "italic" }}>
-                            {permissionAllowed ? "Plan approved" : "Plan rejected"}
-                        </span>
+                        <Flex alignItems={{ default: "alignItemsCenter" }}>
+                            <FlexItem>
+                                <span style={{ color: permissionAllowed ? "#3e8635" : "#c9190b",
+                                    fontStyle: "italic" }}>
+                                    {permissionAllowed ? "Plan approved" : "Plan rejected"}
+                                </span>
+                            </FlexItem>
+                            {!!input?.plan && (
+                                <FlexItem>
+                                    <Button variant="plain" size="sm"
+                                        aria-label="View plan"
+                                        onClick={() => setIsPlanModalOpen(true)}
+                                        style={{ padding: "2px 6px" }}>
+                                        <SearchPlusIcon />
+                                    </Button>
+                                </FlexItem>
+                            )}
+                        </Flex>
+                    )}
+                    {!!input?.plan && (
+                        <Modal
+                            isOpen={isPlanModalOpen}
+                            onClose={() => setIsPlanModalOpen(false)}
+                            variant="large"
+                            aria-label="Plan details"
+                        >
+                            <ModalHeader title="Plan" />
+                            <ModalBody>
+                                <Content>
+                                    <div className="assistant-markdown">
+                                        <Markdown remarkPlugins={[remarkGfm]}>
+                                            {input.plan as string}
+                                        </Markdown>
+                                    </div>
+                                </Content>
+                            </ModalBody>
+                        </Modal>
                     )}
                 </div>
             )}

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -1230,6 +1230,8 @@ export interface AssistantSessionInfo {
     totalInputTokens?: number;
     totalOutputTokens?: number;
     turnCount?: number;
+    projectId?: number;
+    projectName?: string;
 }
 
 export interface AssistantItem {
@@ -1241,12 +1243,13 @@ export interface AssistantItem {
 
 export async function createAssistantSession(
     templateId: string,
-    name?: string
+    name?: string,
+    projectId?: number
 ): Promise<AssistantSessionInfo> {
     const response = await fetch(`${API}/assistant/sessions`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name, templateId }),
+        body: JSON.stringify({ name, templateId, projectId }),
     });
     if (!response.ok) {
         const body = await response.json().catch(() => null);

--- a/ui/src/pages/AssistantPage.tsx
+++ b/ui/src/pages/AssistantPage.tsx
@@ -314,6 +314,14 @@ export function AssistantPage() {
                                 <div style={{ fontWeight: 600, fontSize: "14px" }}>{s.name}</div>
                                 <div style={{ fontSize: "12px", color: "#6a6e73", marginTop: 2 }}>
                                     {templateMap[s.templateId] || s.templateId}
+                                    {s.projectName && (
+                                        <>
+                                            {" · "}
+                                            <Label isCompact color="teal">
+                                                {s.projectName}
+                                            </Label>
+                                        </>
+                                    )}
                                     {" · "}
                                     Created {new Date(s.createdAt).toLocaleString()}
                                 </div>

--- a/ui/src/pages/AssistantSessionPage.tsx
+++ b/ui/src/pages/AssistantSessionPage.tsx
@@ -272,6 +272,16 @@ export function AssistantSessionPage() {
                             </Label>
                         </Tooltip>
                     )}
+                    {session.projectId && session.projectName && (
+                        <Label
+                            color="teal"
+                            isCompact
+                            style={{ marginLeft: 10, cursor: "pointer" }}
+                            onClick={() => navigate(`/projects/${session.projectId}`)}
+                        >
+                            {session.projectName}
+                        </Label>
+                    )}
                 </FlexItem>
                 <FlexItem>
                     {isConfigAssistant && (

--- a/ui/src/pages/ProjectDetailPage.tsx
+++ b/ui/src/pages/ProjectDetailPage.tsx
@@ -37,6 +37,7 @@ import {
     Title,
 } from "@patternfly/react-core";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+import ChatIcon from "@patternfly/react-icons/dist/esm/icons/chat-icon";
 import PlayIcon from "@patternfly/react-icons/dist/esm/icons/play-icon";
 import SyncAltIcon from "@patternfly/react-icons/dist/esm/icons/sync-alt-icon";
 import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
@@ -58,6 +59,7 @@ import {
     fetchProjectMetrics,
     fetchProjectTasks,
     fetchThreadEntries,
+    createAssistantSession,
     createTask,
     deleteProject,
     updateProject,
@@ -218,6 +220,18 @@ export function ProjectDetailPage() {
                         style={{ marginRight: "8px" }}
                     >
                         <SyncAltIcon />
+                    </Button>
+                    <Button
+                        variant="secondary"
+                        icon={<ChatIcon />}
+                        onClick={() => {
+                            createAssistantSession("project-assistant", project.name, project.id)
+                                .then(session => navigate(`/assistant/${session.id}`))
+                                .catch(err => console.error("Failed to create project assistant session", err));
+                        }}
+                        style={{ marginRight: "8px" }}
+                    >
+                        Assistant
                     </Button>
                     <Button
                         variant="secondary"


### PR DESCRIPTION
## Summary

- Add project-scoped assistant sessions: a `projectId` field threads through the OpenAPI spec,
  REST layer, session manager, and UI so assistant sessions can be linked to a specific project
- When a project-scoped session is created, the assistant automatically inherits the project's
  workspace as its working directory, receives project metadata in the system prompt, and gets
  7 project-specific MCP tools (get details, list tasks, get/post thread, list events/traces)
- Add "Assistant" button to the project detail page toolbar that creates a project-scoped session
  and navigates directly to it
- Show teal project name badge in the session list and a clickable project link in the session
  toolbar for easy navigation between project and assistant
- Add a built-in "Project Assistant" template with `{{projectContext}}` placeholder substitution
- Add plan viewer modal: a magnifying glass icon on ExitPlanMode blocks opens the plan in a large
  modal for easier reading
- Slim down seed data: remove unused action types, toolsets, tools, and report definitions

## Related Issue

Fixes #86

## Test Plan

- [ ] From a project detail page, click "Assistant" and verify a session is created with the
      project name, correct working directory, and project context in the system prompt
- [ ] In a project assistant session, verify project-scoped MCP tools are available and return
      correct data (e.g. `axiom_project_get_details`, `axiom_project_list_tasks`)
- [ ] Verify the teal project badge appears in the session list and links to the project page
      from the session toolbar
- [ ] Verify the plan viewer modal opens when clicking the magnifying glass icon on an
      ExitPlanMode block and displays the full plan as rendered markdown
- [ ] Verify non-project sessions still work exactly as before (no regressions)
- [ ] Verify the seed data initializer creates only the expected action types (auto-tag,
      close-project) and tools