### PR TITLE
Add browser notifications for assistant permission requests

### DIFF
--- a/ui/src/components/assistant/AssistantChatPanel.tsx
+++ b/ui/src/components/assistant/AssistantChatPanel.tsx
@@ -33,6 +33,7 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
     const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const reconnectDelayRef = useRef(1000);
     const sessionEndedRef = useRef(false);
+    const activeNotificationsRef = useRef<Map<string, Notification>>(new Map());
 
     // Keep callback refs so the EventSource effect doesn't re-run when
     // parent-supplied callbacks change identity (e.g. inline arrow functions).
@@ -196,7 +197,7 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
                     if (document.hidden
                             && "Notification" in window
                             && Notification.permission === "granted") {
-                        const toolName = data.toolName as string;
+                        const toolName = data.toolName;
                         let title = "Action required";
                         let body = `${toolName} needs your approval`;
                         if (toolName === "ExitPlanMode") {
@@ -213,7 +214,9 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
                         notification.onclick = () => {
                             window.focus();
                             notification.close();
+                            activeNotificationsRef.current.delete(data.requestId);
                         };
+                        activeNotificationsRef.current.set(data.requestId, notification);
                     }
                 } catch {
                     // ignore
@@ -223,6 +226,8 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
             es.addEventListener("permission_resolved", (e) => {
                 try {
                     const data = JSON.parse(e.data);
+                    activeNotificationsRef.current.get(data.permissionId)?.close();
+                    activeNotificationsRef.current.delete(data.permissionId);
                     setMessages((prev) => {
                         const match = prev.find((m) => m.permissionId === data.permissionId);
                         if (match?.toolName === "ExitPlanMode") {

--- a/ui/src/components/assistant/AssistantChatPanel.tsx
+++ b/ui/src/components/assistant/AssistantChatPanel.tsx
@@ -50,6 +50,12 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
     }, []);
 
     useEffect(() => {
+        if ("Notification" in window && Notification.permission === "default") {
+            Notification.requestPermission();
+        }
+    }, []);
+
+    useEffect(() => {
         sessionEndedRef.current = false;
         setConnectionLost(false);
         reconnectDelayRef.current = 1000;
@@ -186,6 +192,29 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
                         }];
                     });
                     setIsProcessing(false);
+
+                    if (document.hidden
+                            && "Notification" in window
+                            && Notification.permission === "granted") {
+                        const toolName = data.toolName as string;
+                        let title = "Action required";
+                        let body = `${toolName} needs your approval`;
+                        if (toolName === "ExitPlanMode") {
+                            title = "Plan ready for review";
+                            body = "An assistant plan is waiting for your approval.";
+                        } else if (toolName === "AskUserQuestion") {
+                            title = "Question from assistant";
+                            body = "The assistant is asking you a question.";
+                        }
+                        const notification = new Notification(title, {
+                            body,
+                            tag: `axiom-permission-${data.requestId}`,
+                        });
+                        notification.onclick = () => {
+                            window.focus();
+                            notification.close();
+                        };
+                    }
                 } catch {
                     // ignore
                 }


### PR DESCRIPTION
## Summary

- Fire desktop notifications via the browser Notification API when an assistant session needs
  user action (tool permission, plan approval, or a question) and the Axiom tab is not focused
- Request notification permission once when the chat panel mounts
- Clicking a notification brings the Axiom tab to the foreground
- Uses `tag` to deduplicate notifications for the same permission request

## Test plan

- [ ] Open an assistant session, switch to a different tab, and trigger a tool that requires
      permission — verify a desktop notification appears
- [ ] Click the notification and verify the Axiom tab is focused
- [ ] Verify no notification fires when the Axiom tab is already in the foreground
- [ ] Verify the browser permission prompt appears on first use