### PR TITLE
Show all templates in session filter dropdown

### DIFF
--- a/ui/src/pages/AssistantPage.tsx
+++ b/ui/src/pages/AssistantPage.tsx
@@ -157,7 +157,8 @@ export function AssistantPage() {
         return true;
     });
 
-    const uniqueTemplateIds = [...new Set(sessions.map((s) => s.templateId))];
+    const uniqueTemplateIds = Object.keys(templateMap)
+        .sort((a, b) => (templateMap[a] || a).localeCompare(templateMap[b] || b));
 
     const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
 


### PR DESCRIPTION
## Summary
- Fixes the template filter dropdown on the AI Assistant session list page to show all available
  templates, not just those with active sessions
- Templates are now sorted alphabetically by name for consistent ordering
- Closes #82

## Details
The dropdown derived its options from `sessions` (only templates with active sessions). Changed it
to use `templateMap` (already populated from `fetchAssistantTemplates()` with all templates). No API
changes needed — the data was already being fetched but not used for the dropdown.

## Test plan
- [ ] Navigate to the AI Assistant page with sessions using only some templates
- [ ] Confirm the filter dropdown lists all available templates, including those with no sessions
- [ ] Select a template with no sessions — verify it shows an empty filtered list
- [ ] Select a template with sessions — verify filtering still works correctly
- [ ] Verify "All templates" option still shows all sessions