### PR TITLE
Remove duplicate Javadoc on AssistantItem record

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSessionManager.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSessionManager.java
@@ -457,13 +457,6 @@ public class AssistantSessionManager {
      *
      * @param type the item type directory (tools, action-types, report-definitions)
      * @param name the item name (file name without .json)
-     * @param validationErrors list of validation errors (empty if valid)
-     */
-    /**
-     * Describes a generated configuration item with its validation status.
-     *
-     * @param type the item type directory (tools, action-types, report-definitions)
-     * @param name the item name (file name without .json)
      * @param errors validation errors that block apply
      * @param warnings advisory messages that don't block apply
      */


### PR DESCRIPTION
## Summary
- Removes the stale 3-param Javadoc block on the `AssistantItem` record in `AssistantSessionManager.java`
- The outdated block documented a `validationErrors` param that no longer exists
- The retained Javadoc correctly documents the current 4-param signature (`type`, `name`, `errors`, `warnings`)

Fixes #78