### PR TITLE
Multiplex assistant SSE via SharedWorker to eliminate browser connection limits

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSession.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSession.java
@@ -423,6 +423,13 @@ public class AssistantSession {
     }
 
     /**
+     * @return the number of events in the session's event history
+     */
+    public int getEventCount() {
+        return eventHistory.size();
+    }
+
+    /**
      * Adds an auto-approval rule for matching tool permissions.
      *
      * @param toolName the tool name to match

--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSessionManager.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSessionManager.java
@@ -12,6 +12,7 @@ import io.apitomy.axiom.core.entities.ProjectEntity;
 import io.apitomy.axiom.core.entities.ToolsetEntity;
 import io.apitomy.axiom.core.services.EnvironmentResolver;
 import io.apitomy.axiom.core.services.WorkspaceService;
+import jakarta.enterprise.event.Event;
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -80,6 +81,9 @@ public class AssistantSessionManager {
 
     @Inject
     WorkspaceService workspaceService;
+
+    @Inject
+    Event<io.apitomy.axiom.core.events.SseEvent> sseEventEmitter;
 
     private final Map<String, AssistantSession> sessions = new ConcurrentHashMap<>();
     private final AtomicInteger sessionCount = new AtomicInteger();
@@ -205,6 +209,19 @@ public class AssistantSessionManager {
                 session.addEvent(new AssistantEventParser.SseEvent("assistant_text", welcomeData));
             }
 
+            // CDI bridge: broadcast assistant events to the global SSE channel
+            session.addListener(event -> {
+                try {
+                    int eventIndex = session.getEventCount() - 1;
+                    sseEventEmitter.fire(
+                            io.apitomy.axiom.core.events.SseEvent.assistantSessionEvent(
+                                    session.getId(), event.type(),
+                                    event.toJson(), eventIndex));
+                } catch (Exception e) {
+                    LOG.debugf("Failed to broadcast assistant event: %s", e.getMessage());
+                }
+            });
+
             // Config Assistant validation listener
             if ("axiom-config-assistant".equals(templateId)) {
                 session.addListener(createValidationListener(session));
@@ -252,7 +269,12 @@ public class AssistantSessionManager {
         if (session != null) {
             sessionCount.decrementAndGet();
             session.destroy();
-            recordUsage(session);
+            try {
+                recordUsage(session);
+            } catch (Exception e) {
+                LOG.debugf("Could not record usage for session %s: %s",
+                        sessionId, e.getMessage());
+            }
             contextBuilder.deleteSessionDirectory(session.getSessionDirectory());
             LOG.infof("Destroyed assistant session %s (cost=$%.4f, turns=%d)",
                     sessionId, session.getTotalCostUsd(), session.getTurnCount());

--- a/app/src/main/java/io/apitomy/axiom/app/rest/AssistantResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/AssistantResourceImpl.java
@@ -45,7 +45,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 /**
@@ -137,6 +138,13 @@ public class AssistantResourceImpl implements AssistantResource {
      * SSE event stream for an assistant session. This method overloads the
      * generated interface method to add {@code @Context} SSE parameters.
      * Supports {@code Last-Event-Id} for resuming after a reconnect.
+     *
+     * <p>Event delivery is decoupled from event dispatch via a per-connection
+     * {@link LinkedBlockingQueue}. The listener registered with the session
+     * performs a non-blocking {@code offer()} so that the session's
+     * {@code eventLock} is never held while writing to the SSE sink. A
+     * dedicated drainer virtual thread polls the queue and calls
+     * {@code sink.send()}, ensuring only one thread ever writes to the sink.
      */
     @GET
     @Path("/sessions/{sessionId}/events")
@@ -158,72 +166,64 @@ public class AssistantResourceImpl implements AssistantResource {
 
         long lastEventId = parseLastEventId(headers);
 
-        // Stream live events — ID assigned via a counter seeded after snapshot
-        AtomicLong liveIdCounter = new AtomicLong();
+        LinkedBlockingQueue<SseEvent> eventQueue = new LinkedBlockingQueue<>(4096);
+
         Consumer<SseEvent> listener = event -> {
-            if (sink.isClosed()) return;
-            OutboundSseEvent sseEvent = sse.newEventBuilder()
-                    .id(String.valueOf(liveIdCounter.getAndIncrement()))
-                    .name(event.type())
-                    .data(event.toJson())
-                    .build();
-            sink.send(sseEvent);
+            if (!eventQueue.offer(event)) {
+                LOG.warnf("SSE event queue full for session %s, forcing reconnect",
+                        sessionId);
+                try { sink.close(); } catch (Exception ignored) { }
+            }
         };
 
-        // Atomically snapshot history and register the listener so no events
-        // emitted between replay and registration are lost.
         List<SseEvent> history = session.addListenerWithHistory(listener, lastEventId);
 
-        // Seed the live counter: replayed events start at (lastEventId + 1),
-        // so live events continue from (lastEventId + 1 + history.size).
-        long replayStartId = lastEventId + 1;
-        liveIdCounter.set(replayStartId + history.size());
+        Thread.ofVirtual().name("sse-drainer-" + sessionId).start(() -> {
+            try {
+                long nextId = lastEventId + 1;
 
-        // Replay history
-        for (int i = 0; i < history.size(); i++) {
-            if (sink.isClosed()) {
-                session.removeListener(listener);
-                return;
-            }
-            SseEvent event = history.get(i);
-            OutboundSseEvent sseEvent = sse.newEventBuilder()
-                    .id(String.valueOf(replayStartId + i))
-                    .name(event.type())
-                    .data(event.toJson())
-                    .build();
-            sink.send(sseEvent);
-        }
-
-        sink.send(sse.newEventBuilder().comment("connected").build());
-
-        OutboundSseEvent heartbeat = sse.newEventBuilder().comment("heartbeat").build();
-        Thread.ofVirtual().name("sse-keepalive-" + sessionId).start(() -> {
-            int tick = 0;
-            while (!sink.isClosed() && session.isAlive()) {
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    break;
+                for (SseEvent event : history) {
+                    if (sink.isClosed()) return;
+                    sink.send(buildSseEvent(sse, event, nextId++));
                 }
-                tick++;
-                if (tick >= 15) {
-                    tick = 0;
-                    if (!sink.isClosed()) {
-                        try {
-                            sink.send(heartbeat);
-                        } catch (Exception e) {
-                            break;
+
+                if (!sink.isClosed()) {
+                    sink.send(sse.newEventBuilder().comment("connected").build());
+                }
+
+                int idleSeconds = 0;
+                while (!sink.isClosed()
+                        && (session.isAlive() || !eventQueue.isEmpty())) {
+                    SseEvent event = eventQueue.poll(1, TimeUnit.SECONDS);
+                    if (event != null) {
+                        sink.send(buildSseEvent(sse, event, nextId++));
+                        idleSeconds = 0;
+                        List<SseEvent> batch = new ArrayList<>();
+                        eventQueue.drainTo(batch);
+                        for (SseEvent e : batch) {
+                            if (sink.isClosed()) return;
+                            sink.send(buildSseEvent(sse, e, nextId++));
+                        }
+                    } else {
+                        idleSeconds++;
+                        if (idleSeconds >= 15) {
+                            idleSeconds = 0;
+                            if (!sink.isClosed()) {
+                                sink.send(sse.newEventBuilder()
+                                        .comment("heartbeat").build());
+                            }
                         }
                     }
                 }
-            }
-            session.removeListener(listener);
-            if (!sink.isClosed()) {
-                try {
-                    sink.close();
-                } catch (Exception e) {
-                    // Ignore
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (Exception e) {
+                LOG.debugf("SSE drainer ended for session %s: %s",
+                        sessionId, e.getMessage());
+            } finally {
+                session.removeListener(listener);
+                if (!sink.isClosed()) {
+                    try { sink.close(); } catch (Exception ignored) { }
                 }
             }
         });
@@ -244,12 +244,57 @@ public class AssistantResourceImpl implements AssistantResource {
         }
     }
 
+    /**
+     * Builds an outbound SSE event with a numeric ID, event name, and JSON data.
+     */
+    private OutboundSseEvent buildSseEvent(Sse sse, SseEvent event, long id) {
+        return sse.newEventBuilder()
+                .id(String.valueOf(id))
+                .name(event.type())
+                .data(event.toJson())
+                .build();
+    }
+
     /** {@inheritDoc} */
     @Override
     public void streamAssistantEvents(String sessionId) {
         // This method is called when the SSE-aware overload doesn't match
         // (e.g., non-SSE client). Check the session exists for a clean 404.
         requireSession(sessionId);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void getAssistantSessionHistory(String sessionId) {
+        // Overridden below with @Context injection for Response building.
+    }
+
+    /**
+     * Returns the full event history for an assistant session as a JSON array.
+     * Each element contains eventType, eventData, and eventIndex.
+     */
+    @GET
+    @Path("/sessions/{sessionId}/history")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getAssistantSessionHistoryWithResponse(
+            @PathParam("sessionId") String sessionId) {
+        AssistantSession session = sessionManager.getSession(sessionId);
+        if (session == null) {
+            throw new WebApplicationException("Session not found: " + sessionId, 404);
+        }
+
+        List<SseEvent> history = session.getEventHistory();
+        StringBuilder json = new StringBuilder("[");
+        for (int i = 0; i < history.size(); i++) {
+            if (i > 0) json.append(",");
+            SseEvent event = history.get(i);
+            json.append("{\"eventType\":\"").append(event.type()).append("\",")
+                    .append("\"eventData\":").append(event.toJson()).append(",")
+                    .append("\"eventIndex\":").append(i).append("}");
+        }
+        json.append("]");
+
+        return Response.ok(json.toString(), MediaType.APPLICATION_JSON).build();
     }
 
     /** {@inheritDoc} */

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -15,9 +15,9 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 # --- Database (persist profile + prod: H2 file-based, survives restarts) ---
 # Activate with: -Dquarkus.profile=persist  or  QUARKUS_PROFILE=persist
 # Production mode uses the same file-based H2 database automatically.
-%persist.quarkus.datasource.jdbc.url=jdbc:h2:file:${user.home}/.axiom/data/axiom;AUTO_SERVER=TRUE
+%persist.quarkus.datasource.jdbc.url=jdbc:h2:file:${user.home}/.axiom/data/axiom;AUTO_SERVER=TRUE;DB_CLOSE_ON_EXIT=FALSE
 %persist.quarkus.hibernate-orm.database.generation=none
-%prod.quarkus.datasource.jdbc.url=jdbc:h2:file:${user.home}/.axiom/data/axiom;AUTO_SERVER=TRUE
+%prod.quarkus.datasource.jdbc.url=jdbc:h2:file:${user.home}/.axiom/data/axiom;AUTO_SERVER=TRUE;DB_CLOSE_ON_EXIT=FALSE
 %prod.quarkus.hibernate-orm.database.generation=none
 
 # --- Flyway (schema migration for persistent databases) ---
@@ -77,7 +77,7 @@ axiom.opencode.timeout-seconds=600
 
 # --- AI Assistant ---
 # Maximum concurrent interactive assistant sessions
-axiom.assistant.max-sessions=3
+axiom.assistant.max-sessions=12
 
 # --- Workspaces ---
 # Root directory for project git clones

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -4102,6 +4102,35 @@
           }
         }
       ]
+    },
+    "/assistant/sessions/{sessionId}/history": {
+      "get": {
+        "tags": [
+          "assistant"
+        ],
+        "summary": "Get the event history for an assistant session",
+        "description": "Returns the full event history for an assistant session as a JSON array. Each element contains the event type, event data, and a numeric index. Used by the UI to populate the initial state when subscribing to a session via the multiplexed SSE channel.",
+        "operationId": "getAssistantSessionHistory",
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "description": "The assistant session ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The session event history as a JSON array"
+          },
+          "404": {
+            "description": "Session not found"
+          }
+        }
+      }
     }
   },
   "components": {

--- a/core/src/main/java/io/apitomy/axiom/core/events/SseEvent.java
+++ b/core/src/main/java/io/apitomy/axiom/core/events/SseEvent.java
@@ -121,6 +121,25 @@ public record SseEvent(
                         + ",\"count\":" + count + "}");
     }
 
+    /**
+     * Creates an assistant-session-event that wraps an assistant event for
+     * broadcast via the global SSE channel.
+     *
+     * @param sessionId the assistant session ID
+     * @param eventType the assistant event type (e.g. "assistant_text", "tool_use")
+     * @param eventData the assistant event payload as a JSON string
+     * @param eventIndex the event's position in the session's event history
+     * @return a new SSE event
+     */
+    public static SseEvent assistantSessionEvent(String sessionId, String eventType,
+                                                  String eventData, int eventIndex) {
+        return new SseEvent("assistant-session-event",
+                "{\"sessionId\":\"" + sessionId + "\","
+                        + "\"eventType\":\"" + eventType + "\","
+                        + "\"eventData\":" + eventData + ","
+                        + "\"eventIndex\":" + eventIndex + "}");
+    }
+
     private static String escapeJson(String s) {
         if (s == null) return "";
         return s.replace("\\", "\\\\")

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -74,9 +74,10 @@ export function App() {
         };
     }, []);
 
+    const isAssistantPage = location.pathname.startsWith("/assistant");
+
     const hasCheckErrors = startupChecks != null &&
         startupChecks.some((c) => c.status === "error");
-    const isAssistantPage = location.pathname.startsWith("/assistant");
     const isBreakout = new URLSearchParams(location.search).get("breakout") === "true";
 
     return (

--- a/ui/src/components/assistant/AssistantChatPanel.tsx
+++ b/ui/src/components/assistant/AssistantChatPanel.tsx
@@ -1,13 +1,13 @@
 import { useState, useEffect, useCallback, useRef } from "react";
-import { Alert } from "@patternfly/react-core";
 import { AssistantMessageList, type ChatMessage } from "./AssistantMessageList";
 import { AssistantMessageInput } from "./AssistantMessageInput";
 import {
-    assistantEventsUrl,
     sendAssistantMessage,
     respondToAssistantPermission,
     createAutoApproval,
+    fetchAssistantSessionHistory,
 } from "../../config/api";
+import { sseClient } from "../../config/sse";
 import { randomThinkingMessage } from "./thinkingMessages";
 
 export type SessionMode = "normal" | "plan";
@@ -28,15 +28,9 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
     const [isProcessing, setIsProcessing] = useState(false);
     const [processingText, setProcessingText] = useState("");
     const [slashCommands, setSlashCommands] = useState<string[]>([]);
-    const [connectionLost, setConnectionLost] = useState(false);
-    const eventSourceRef = useRef<EventSource | null>(null);
-    const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const reconnectDelayRef = useRef(1000);
     const sessionEndedRef = useRef(false);
-    const activeNotificationsRef = useRef<Map<string, Notification>>(new Map());
+    const lastSeenIndexRef = useRef(-1);
 
-    // Keep callback refs so the EventSource effect doesn't re-run when
-    // parent-supplied callbacks change identity (e.g. inline arrow functions).
     const onItemsChangedRef = useRef(onItemsChanged);
     const onModeChangeRef = useRef(onModeChange);
     const onModelDetectedRef = useRef(onModelDetected);
@@ -56,258 +50,218 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
         }
     }, []);
 
-    useEffect(() => {
-        sessionEndedRef.current = false;
-        setConnectionLost(false);
-        reconnectDelayRef.current = 1000;
-
-        const url = assistantEventsUrl(sessionId);
-
-        function connect() {
-            setMessages([]);
-
-            const es = new EventSource(url);
-            eventSourceRef.current = es;
-
-            es.onopen = () => {
-                setConnectionLost(false);
-                reconnectDelayRef.current = 1000;
-            };
-
-            es.addEventListener("session_init", (e) => {
-                try {
-                    const data = JSON.parse(e.data);
-                    if (Array.isArray(data.slashCommands)) {
-                        setSlashCommands(data.slashCommands);
-                    }
-                    if (data.model) {
-                        onModelDetectedRef.current?.(data.model);
-                    }
-                } catch {
-                    // ignore
+    const processEvent = useCallback((eventType: string, data: Record<string, unknown>) => {
+        switch (eventType) {
+            case "session_init":
+                if (Array.isArray(data.slashCommands)) {
+                    setSlashCommands(data.slashCommands as string[]);
                 }
-            });
-
-            es.addEventListener("assistant_text", (e) => {
-                try {
-                    const data = JSON.parse(e.data);
-                    if (data.text) {
-                        setMessages((prev) => {
-                            const last = prev[prev.length - 1];
-                            if (last && last.type === "assistant") {
-                                return [...prev.slice(0, -1), { ...last, content: data.text }];
-                            }
-                            return [...prev, { id: String(++messageIdCounter), type: "assistant", content: data.text }];
-                        });
-                        setProcessingText(randomThinkingMessage());
-                    }
-                } catch {
-                    // ignore
+                if (data.model) {
+                    onModelDetectedRef.current?.(data.model as string);
                 }
-            });
+                break;
 
-            es.addEventListener("user_message", (e) => {
-                try {
-                    const data = JSON.parse(e.data);
-                    if (data.content) {
-                        setMessages((prev) => {
-                            const last = prev[prev.length - 1];
-                            if (last && last.type === "user" && last.content === data.content) {
-                                return prev;
-                            }
-                            return [...prev, { id: String(++messageIdCounter), type: "user", content: data.content }];
-                        });
-                        setIsProcessing(true);
-                    }
-                } catch {
-                    // ignore
-                }
-            });
-
-            es.addEventListener("thinking", () => {
-                setProcessingText(
-                    randomThinkingMessage()
-                );
-            });
-
-            es.addEventListener("tool_use", (e) => {
-                try {
-                    const data = JSON.parse(e.data);
-                    addMessage({
-                        type: "tool_use",
-                        toolName: data.name,
-                        toolInput: data.input,
-                        toolUseId: data.id,
+            case "assistant_text":
+                if (data.text) {
+                    setMessages((prev) => {
+                        const last = prev[prev.length - 1];
+                        if (last && last.type === "assistant") {
+                            return [...prev.slice(0, -1), { ...last, content: data.text as string }];
+                        }
+                        return [...prev, { id: String(++messageIdCounter), type: "assistant", content: data.text as string }];
                     });
                     setProcessingText(randomThinkingMessage());
-                    if (data.name === "EnterPlanMode") {
-                        onModeChangeRef.current?.("plan");
-                    }
-                } catch {
-                    // ignore
                 }
-            });
+                break;
 
-            es.addEventListener("tool_result", (e) => {
-                try {
-                    const data = JSON.parse(e.data);
-                    setMessages((prev) =>
-                        prev.map((m) =>
-                            m.type === "tool_use" && m.toolUseId === data.toolUseId
-                                ? { ...m, toolResult: data.stdout || data.stderr || "", isError: !!data.stderr && !data.stdout }
-                                : m
-                        )
+            case "user_message":
+                if (data.content) {
+                    setMessages((prev) => {
+                        const last = prev[prev.length - 1];
+                        if (last && last.type === "user" && last.content === data.content) {
+                            return prev;
+                        }
+                        return [...prev, { id: String(++messageIdCounter), type: "user", content: data.content as string }];
+                    });
+                    setIsProcessing(true);
+                }
+                break;
+
+            case "thinking":
+                setProcessingText(randomThinkingMessage());
+                break;
+
+            case "tool_use":
+                addMessage({
+                    type: "tool_use",
+                    toolName: data.name as string,
+                    toolInput: data.input as Record<string, unknown>,
+                    toolUseId: data.id as string,
+                });
+                setProcessingText(randomThinkingMessage());
+                if (data.name === "EnterPlanMode") {
+                    onModeChangeRef.current?.("plan");
+                }
+                break;
+
+            case "tool_result":
+                setMessages((prev) =>
+                    prev.map((m) =>
+                        m.type === "tool_use" && m.toolUseId === data.toolUseId
+                            ? { ...m, toolResult: (data.stdout || data.stderr || "") as string, isError: !!data.stderr && !data.stdout }
+                            : m
+                    )
+                );
+                onItemsChangedRef.current?.();
+                break;
+
+            case "permission_request":
+                setMessages((prev) => {
+                    const lastToolIdx = prev.findLastIndex(
+                        (m) => m.type === "tool_use" && m.toolName === data.toolName && !m.permissionId
                     );
-                    onItemsChangedRef.current?.();
-                } catch {
-                    // ignore
-                }
-            });
-
-            es.addEventListener("permission_request", (e) => {
-                try {
-                    const data = JSON.parse(e.data);
-
-                    // Attach permission to the matching tool_use block
-                    setMessages((prev) => {
-                        const lastToolIdx = prev.findLastIndex(
-                            (m) => m.type === "tool_use" && m.toolName === data.toolName && !m.permissionId
-                        );
-                        if (lastToolIdx >= 0) {
-                            const updated = [...prev];
-                            updated[lastToolIdx] = {
-                                ...updated[lastToolIdx],
-                                permissionId: data.requestId,
-                                permissionResolved: false,
-                                toolInput: data.toolInput || updated[lastToolIdx].toolInput,
-                            };
-                            return updated;
-                        }
-                        // Fallback: add as standalone if no matching tool_use
-                        return [...prev, {
-                            id: String(++messageIdCounter),
-                            type: "permission_request" as const,
-                            permissionId: data.requestId,
-                            toolName: data.toolName,
-                            toolInput: data.toolInput,
-                        }];
-                    });
-                    setIsProcessing(false);
-
-                    if (document.hidden
-                            && "Notification" in window
-                            && Notification.permission === "granted") {
-                        const toolName = data.toolName;
-                        let title = "Action required";
-                        let body = `${toolName} needs your approval`;
-                        if (toolName === "ExitPlanMode") {
-                            title = "Plan ready for review";
-                            body = "An assistant plan is waiting for your approval.";
-                        } else if (toolName === "AskUserQuestion") {
-                            title = "Question from assistant";
-                            body = "The assistant is asking you a question.";
-                        }
-                        const notification = new Notification(title, {
-                            body,
-                            tag: `axiom-permission-${data.requestId}`,
-                        });
-                        notification.onclick = () => {
-                            window.focus();
-                            notification.close();
-                            activeNotificationsRef.current.delete(data.requestId);
+                    if (lastToolIdx >= 0) {
+                        const updated = [...prev];
+                        updated[lastToolIdx] = {
+                            ...updated[lastToolIdx],
+                            permissionId: data.requestId as string,
+                            permissionResolved: false,
+                            toolInput: (data.toolInput as Record<string, unknown>) || updated[lastToolIdx].toolInput,
                         };
-                        activeNotificationsRef.current.set(data.requestId, notification);
+                        return updated;
                     }
-                } catch {
-                    // ignore
-                }
-            });
-
-            es.addEventListener("permission_resolved", (e) => {
-                try {
-                    const data = JSON.parse(e.data);
-                    activeNotificationsRef.current.get(data.permissionId)?.close();
-                    activeNotificationsRef.current.delete(data.permissionId);
-                    setMessages((prev) => {
-                        const match = prev.find((m) => m.permissionId === data.permissionId);
-                        if (match?.toolName === "ExitPlanMode") {
-                            onModeChangeRef.current?.("normal");
-                        }
-                        return prev.map((m) =>
-                            m.permissionId === data.permissionId
-                                ? { ...m, permissionResolved: true, permissionAllowed: data.allow }
-                                : m
-                        );
-                    });
-                } catch {
-                    // ignore
-                }
-            });
-
-            es.addEventListener("turn_complete", (e) => {
+                    return [...prev, {
+                        id: String(++messageIdCounter),
+                        type: "permission_request" as const,
+                        permissionId: data.requestId as string,
+                        toolName: data.toolName as string,
+                        toolInput: data.toolInput as Record<string, unknown>,
+                    }];
+                });
                 setIsProcessing(false);
-                try {
-                    const data = JSON.parse(e.data);
-                    if (data.costUsd != null) {
-                        onCostUpdateRef.current?.(data.costUsd, data.inputTokens ?? 0, data.outputTokens ?? 0);
-                    }
-                } catch {
-                    // ignore
-                }
-            });
 
-            es.addEventListener("session_ended", () => {
+                if (document.hidden
+                        && "Notification" in window
+                        && Notification.permission === "granted") {
+                    const toolName = data.toolName as string;
+                    let title = "Action required";
+                    let body = `${toolName} needs your approval`;
+                    if (toolName === "ExitPlanMode") {
+                        title = "Plan ready for review";
+                        body = "An assistant plan is waiting for your approval.";
+                    } else if (toolName === "AskUserQuestion") {
+                        title = "Question from assistant";
+                        body = "The assistant is asking you a question.";
+                    }
+                    const notification = new Notification(title, {
+                        body,
+                        tag: `axiom-permission-${data.requestId}`,
+                    });
+                    notification.onclick = () => {
+                        window.focus();
+                        notification.close();
+                    };
+                }
+                break;
+
+            case "permission_resolved":
+                setMessages((prev) => {
+                    const match = prev.find((m) => m.permissionId === data.permissionId);
+                    if (match?.toolName === "ExitPlanMode") {
+                        onModeChangeRef.current?.("normal");
+                    }
+                    return prev.map((m) =>
+                        m.permissionId === data.permissionId
+                            ? { ...m, permissionResolved: true, permissionAllowed: data.allow as boolean }
+                            : m
+                    );
+                });
+                break;
+
+            case "turn_complete":
+                setIsProcessing(false);
+                if (data.costUsd != null) {
+                    onCostUpdateRef.current?.(
+                        data.costUsd as number,
+                        (data.inputTokens ?? 0) as number,
+                        (data.outputTokens ?? 0) as number
+                    );
+                }
+                break;
+
+            case "session_ended":
                 sessionEndedRef.current = true;
                 setIsProcessing(false);
-            });
+                break;
 
-            es.addEventListener("unhandled_event", (e) => {
-                try {
-                    const data = JSON.parse(e.data);
-                    addMessage({
-                        type: "warning",
-                        content: `Unhandled event type: ${data.rawType}`,
-                    });
-                } catch {
-                    // ignore
-                }
-            });
+            case "unhandled_event":
+                addMessage({
+                    type: "warning",
+                    content: `Unhandled event type: ${data.rawType}`,
+                });
+                break;
 
-            es.addEventListener("session_error", (e) => {
-                try {
-                    const data = JSON.parse(e.data);
-                    addMessage({ type: "system", content: data.message || "Session error" });
-                } catch {
-                    // ignore
-                }
+            case "session_error":
+                addMessage({ type: "system", content: (data.message as string) || "Session error" });
                 setIsProcessing(false);
-            });
-
-            es.onerror = () => {
-                es.close();
-                eventSourceRef.current = null;
-                if (sessionEndedRef.current) return;
-                setConnectionLost(true);
-                setIsProcessing(false);
-                reconnectTimerRef.current = setTimeout(() => {
-                    reconnectTimerRef.current = null;
-                    connect();
-                }, reconnectDelayRef.current);
-                reconnectDelayRef.current = Math.min(reconnectDelayRef.current * 2, 30000);
-            };
+                break;
         }
+    }, [addMessage]);
 
-        connect();
+    useEffect(() => {
+        sessionEndedRef.current = false;
+        lastSeenIndexRef.current = -1;
+        setMessages([]);
+
+        sseClient.connect();
+
+        let cancelled = false;
+        const buffer: { eventType: string; eventData: Record<string, unknown>; eventIndex: number }[] = [];
+        let historyLoaded = false;
+
+        const unsubscribe = sseClient.subscribeSession(sessionId,
+            (eventType, eventData, eventIndex) => {
+                if (cancelled) return;
+                if (!historyLoaded) {
+                    buffer.push({ eventType, eventData, eventIndex });
+                    return;
+                }
+                if (eventIndex <= lastSeenIndexRef.current) return;
+                lastSeenIndexRef.current = eventIndex;
+                processEvent(eventType, eventData);
+            }
+        );
+
+        fetchAssistantSessionHistory(sessionId)
+            .then((history) => {
+                if (cancelled) return;
+                for (const event of history) {
+                    processEvent(event.eventType, event.eventData);
+                    lastSeenIndexRef.current = Math.max(lastSeenIndexRef.current, event.eventIndex);
+                }
+                historyLoaded = true;
+                for (const event of buffer) {
+                    if (event.eventIndex <= lastSeenIndexRef.current) continue;
+                    lastSeenIndexRef.current = event.eventIndex;
+                    processEvent(event.eventType, event.eventData);
+                }
+                buffer.length = 0;
+            })
+            .catch((err) => {
+                if (cancelled) return;
+                console.error("Failed to fetch session history:", err);
+                historyLoaded = true;
+                for (const event of buffer) {
+                    processEvent(event.eventType, event.eventData);
+                }
+                buffer.length = 0;
+            });
 
         return () => {
-            eventSourceRef.current?.close();
-            eventSourceRef.current = null;
-            if (reconnectTimerRef.current) {
-                clearTimeout(reconnectTimerRef.current);
-                reconnectTimerRef.current = null;
-            }
+            cancelled = true;
+            unsubscribe();
         };
-    }, [sessionId, addMessage]);
+    }, [sessionId, processEvent]);
 
     const handleSend = useCallback(async (message: string) => {
         addMessage({ type: "user", content: message });
@@ -371,11 +325,6 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
             flex: "1 1 0",
             minHeight: 0,
         }}>
-            {connectionLost && (
-                <Alert variant="warning" isInline isPlain
-                    title="Connection lost — reconnecting..."
-                    style={{ flexShrink: 0 }} />
-            )}
             <AssistantMessageList
                 messages={messages}
                 onPermissionRespond={handlePermissionRespond}

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -1271,6 +1271,20 @@ export async function fetchAssistantSession(id: string): Promise<AssistantSessio
     return response.json();
 }
 
+export interface AssistantHistoryEvent {
+    eventType: string;
+    eventData: Record<string, unknown>;
+    eventIndex: number;
+}
+
+export async function fetchAssistantSessionHistory(
+    sessionId: string
+): Promise<AssistantHistoryEvent[]> {
+    const response = await fetch(`${API}/assistant/sessions/${sessionId}/history`);
+    if (!response.ok) throw new Error(`Failed to fetch session history: ${response.status}`);
+    return response.json();
+}
+
 export async function deleteAssistantSession(id: string): Promise<void> {
     const response = await fetch(`${API}/assistant/sessions/${id}`, { method: "DELETE" });
     if (!response.ok) throw new Error(`Failed to delete session: ${response.status}`);

--- a/ui/src/config/sse-worker.ts
+++ b/ui/src/config/sse-worker.ts
@@ -1,0 +1,133 @@
+const _self = self as unknown as SharedWorkerGlobalScope;
+
+const PREFIX = "[SSE Worker]";
+
+const ports = new Set<MessagePort>();
+let eventSource: EventSource | null = null;
+let baseUrl = "";
+let reconnectDelay = 1000;
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let closed = false;
+let eventCount = 0;
+
+function broadcast(message: unknown) {
+    for (const port of ports) {
+        try {
+            port.postMessage(message);
+        } catch {
+            console.warn(`${PREFIX} Failed to post to port, removing`);
+            ports.delete(port);
+        }
+    }
+}
+
+function connectSse() {
+    if (eventSource) {
+        console.log(`${PREFIX} EventSource already exists, skipping connect`);
+        return;
+    }
+
+    closed = false;
+    eventCount = 0;
+    const url = `${baseUrl}/api/v1/sse`;
+    console.log(`${PREFIX} Connecting to ${url} (${ports.size} tab(s) connected)`);
+    eventSource = new EventSource(url);
+
+    eventSource.onopen = () => {
+        reconnectDelay = 1000;
+        console.log(`${PREFIX} EventSource connected`);
+        broadcast({ type: "connected" });
+    };
+
+    eventSource.onmessage = (e) => {
+        try {
+            const parsed = JSON.parse(e.data);
+            const event = {
+                type: parsed.type as string,
+                data: typeof parsed.data === "string"
+                    ? JSON.parse(parsed.data)
+                    : parsed.data ?? {},
+            };
+            eventCount++;
+            if (eventCount <= 5 || eventCount % 100 === 0) {
+                console.log(`${PREFIX} Event #${eventCount}: ${event.type}` +
+                    (event.type === "assistant-session-event"
+                        ? ` (session=${event.data.sessionId}, eventType=${event.data.eventType})`
+                        : "")
+                    + ` → broadcasting to ${ports.size} tab(s)`);
+            }
+            broadcast({ type: "event", event });
+        } catch {
+            console.warn(`${PREFIX} Failed to parse SSE event:`, e.data);
+        }
+    };
+
+    eventSource.onerror = () => {
+        if (closed) {
+            console.log(`${PREFIX} EventSource error after intentional close, ignoring`);
+            return;
+        }
+        console.warn(`${PREFIX} EventSource error, closing connection`);
+        eventSource?.close();
+        eventSource = null;
+        broadcast({ type: "disconnected" });
+
+        if (ports.size > 0) {
+            console.log(`${PREFIX} Scheduling reconnect in ${reconnectDelay}ms`
+                + ` (${ports.size} tab(s) still connected)`);
+            reconnectTimer = setTimeout(() => {
+                reconnectTimer = null;
+                if (!closed && ports.size > 0) connectSse();
+            }, reconnectDelay);
+            reconnectDelay = Math.min(reconnectDelay * 2, 30000);
+        } else {
+            console.log(`${PREFIX} No tabs connected, skipping reconnect`);
+        }
+    };
+}
+
+function disconnectSse() {
+    console.log(`${PREFIX} Disconnecting (no tabs remaining)`);
+    closed = true;
+    if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+    }
+    eventSource?.close();
+    eventSource = null;
+}
+
+_self.onconnect = (e: MessageEvent) => {
+    const port = e.ports[0];
+    ports.add(port);
+    console.log(`${PREFIX} Tab connected (${ports.size} total)`);
+
+    port.onmessage = (msg) => {
+        const data = msg.data;
+        switch (data.type) {
+            case "init":
+                if (data.baseUrl !== undefined) {
+                    baseUrl = data.baseUrl;
+                    console.log(`${PREFIX} Initialized with baseUrl="${baseUrl}"`);
+                }
+                break;
+            case "connect":
+                console.log(`${PREFIX} Tab requested SSE connect`);
+                connectSse();
+                break;
+            case "disconnect":
+                ports.delete(port);
+                console.log(`${PREFIX} Tab disconnected (${ports.size} remaining)`);
+                if (ports.size === 0) {
+                    disconnectSse();
+                }
+                break;
+            default:
+                console.warn(`${PREFIX} Unknown message type: ${data.type}`);
+        }
+    };
+
+    port.start();
+};
+
+console.log(`${PREFIX} SharedWorker started`);

--- a/ui/src/config/sse.ts
+++ b/ui/src/config/sse.ts
@@ -9,35 +9,93 @@ export interface AxiomSseEvent {
 }
 
 /**
- * Callback type for SSE event listeners.
+ * Callback type for global SSE event listeners.
  */
 export type SseListener = (event: AxiomSseEvent) => void;
 
 /**
+ * Callback type for assistant session event listeners.
+ * Receives the assistant event type, its data payload, and a monotonic index.
+ */
+export type SessionEventListener = (
+    eventType: string,
+    eventData: Record<string, unknown>,
+    eventIndex: number
+) => void;
+
+/**
  * Manages a Server-Sent Events connection to the Axiom backend.
- * Automatically reconnects on disconnection with exponential backoff.
+ *
+ * When the browser supports SharedWorker, a single worker owns the EventSource
+ * and broadcasts events to all tabs via MessagePort. This means exactly 1 SSE
+ * connection exists regardless of how many tabs/windows are open, avoiding the
+ * browser's HTTP/1.1 6-connection-per-origin limit.
+ *
+ * Falls back to a direct EventSource per tab when SharedWorker is unavailable.
  */
 export class SseClient {
+    private worker: SharedWorker | null = null;
     private eventSource: EventSource | null = null;
     private listeners: SseListener[] = [];
+    private sessionListeners: Map<string, SessionEventListener[]> = new Map();
     private reconnectDelay = 1000;
-    private maxReconnectDelay = 30000;
     private closed = false;
+    private connected = false;
+
+    private get useSharedWorker(): boolean {
+        return typeof SharedWorker !== "undefined";
+    }
 
     /**
-     * Connects to the SSE endpoint and starts receiving events.
+     * Connects to the SSE endpoint. Uses a SharedWorker if available,
+     * otherwise falls back to a direct EventSource.
      */
     connect(): void {
-        if (this.eventSource) {
-            this.eventSource.close();
-        }
-
+        if (this.connected) return;
+        this.connected = true;
         this.closed = false;
+
+        if (this.useSharedWorker) {
+            this.connectViaWorker();
+        } else {
+            this.connectDirect();
+        }
+    }
+
+    private connectViaWorker(): void {
+        if (this.worker) return;
+
+        this.worker = new SharedWorker(
+            new URL("./sse-worker.ts", import.meta.url),
+            { type: "module", name: "sse-shared-worker" }
+        );
+
+        this.worker.port.onmessage = (e) => {
+            const msg = e.data;
+            switch (msg.type) {
+                case "event":
+                    this.dispatchEvent(msg.event);
+                    break;
+                case "connected":
+                    this.reconnectDelay = 1000;
+                    break;
+                case "disconnected":
+                    break;
+            }
+        };
+
+        this.worker.port.start();
+        this.worker.port.postMessage({ type: "init", baseUrl: getApiBaseUrl() });
+        this.worker.port.postMessage({ type: "connect" });
+    }
+
+    private connectDirect(): void {
+        if (this.eventSource) return;
+
         const url = `${getApiBaseUrl()}/api/v1/sse`;
         this.eventSource = new EventSource(url);
 
         this.eventSource.onopen = () => {
-            console.log("SSE connected");
             this.reconnectDelay = 1000;
         };
 
@@ -50,30 +108,40 @@ export class SseClient {
                         ? JSON.parse(parsed.data)
                         : parsed.data ?? {},
                 };
-                console.log("[SSE] Event received:", axiomEvent.type, axiomEvent.data);
-                this.listeners.forEach((listener) => listener(axiomEvent));
-            } catch (e) {
-                console.warn("[SSE] Failed to parse event:", event.data);
+                this.dispatchEvent(axiomEvent);
+            } catch {
+                // ignore
             }
         };
 
         this.eventSource.onerror = () => {
             if (this.closed) return;
-            console.warn(`SSE disconnected, reconnecting in ${this.reconnectDelay}ms`);
             this.eventSource?.close();
             this.eventSource = null;
             setTimeout(() => {
-                if (!this.closed) this.connect();
+                if (!this.closed) this.connectDirect();
             }, this.reconnectDelay);
-            this.reconnectDelay = Math.min(
-                this.reconnectDelay * 2,
-                this.maxReconnectDelay
-            );
+            this.reconnectDelay = Math.min(this.reconnectDelay * 2, 30000);
         };
     }
 
+    private dispatchEvent(event: AxiomSseEvent): void {
+        if (event.type === "assistant-session-event") {
+            const sessionId = event.data.sessionId as string;
+            const eventType = event.data.eventType as string;
+            const eventData = event.data.eventData as Record<string, unknown>;
+            const eventIndex = event.data.eventIndex as number;
+            const sessionCbs = this.sessionListeners.get(sessionId);
+            if (sessionCbs) {
+                sessionCbs.forEach((cb) => cb(eventType, eventData, eventIndex));
+            }
+        } else {
+            this.listeners.forEach((listener) => listener(event));
+        }
+    }
+
     /**
-     * Adds a listener that will be called for every SSE event.
+     * Adds a global listener that will be called for every non-session SSE event.
      *
      * @param listener the callback function
      * @returns an unsubscribe function
@@ -86,12 +154,51 @@ export class SseClient {
     }
 
     /**
+     * Subscribes to events for a specific assistant session. Events are
+     * routed by session ID from the multiplexed global SSE channel.
+     *
+     * @param sessionId the assistant session ID to subscribe to
+     * @param listener the callback receiving (eventType, eventData, eventIndex)
+     * @returns an unsubscribe function
+     */
+    subscribeSession(sessionId: string, listener: SessionEventListener): () => void {
+        let callbacks = this.sessionListeners.get(sessionId);
+        if (!callbacks) {
+            callbacks = [];
+            this.sessionListeners.set(sessionId, callbacks);
+        }
+        callbacks.push(listener);
+
+        return () => {
+            const cbs = this.sessionListeners.get(sessionId);
+            if (cbs) {
+                const filtered = cbs.filter((cb) => cb !== listener);
+                if (filtered.length === 0) {
+                    this.sessionListeners.delete(sessionId);
+                } else {
+                    this.sessionListeners.set(sessionId, filtered);
+                }
+            }
+        };
+    }
+
+    /**
      * Disconnects from the SSE endpoint.
      */
     disconnect(): void {
         this.closed = true;
-        this.eventSource?.close();
-        this.eventSource = null;
+        this.connected = false;
+
+        if (this.worker) {
+            this.worker.port.postMessage({ type: "disconnect" });
+            this.worker.port.close();
+            this.worker = null;
+        }
+
+        if (this.eventSource) {
+            this.eventSource.close();
+            this.eventSource = null;
+        }
     }
 }
 

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -16,5 +16,6 @@
         "noFallthroughCasesInSwitch": true,
         "noUncheckedSideEffectImports": true
     },
-    "include": ["src"]
+    "include": ["src"],
+    "exclude": ["src/config/sse-worker.ts"]
 }

--- a/ui/tsconfig.worker.json
+++ b/ui/tsconfig.worker.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2023", "WebWorker"],
+    "strict": true,
+    "skipLibCheck": true,
+    "isolatedModules": true
+  },
+  "include": ["src/config/sse-worker.ts"]
+}


### PR DESCRIPTION
## Summary

- Route all assistant session events through the existing global SSE channel (`/api/v1/sse`) via
  a CDI bridge listener, eliminating per-session SSE connections
- Add a SharedWorker (`sse-worker.ts`) that owns the single `EventSource` and broadcasts events
  to all browser tabs via `MessagePort` — exactly 1 SSE connection regardless of how many
  tabs/windows are open
- Rewrite `SseClient` to communicate with the SharedWorker internally while keeping the same
  public API (`connect`, `disconnect`, `subscribe`, `subscribeSession`) — no consumer changes
- Add `GET /assistant/sessions/{sessionId}/history` REST endpoint for initial catch-up when
  subscribing to a session
- Add queue-based SSE drainer in `AssistantResourceImpl` to decouple `eventLock` from
  `sink.send()`, preventing server-side thread contention
- Fix `destroySession` to gracefully handle H2 database shutdown; add `DB_CLOSE_ON_EXIT=FALSE`
  to prevent H2 shutdown hook from racing with Quarkus
- Fix React StrictMode double-mount duplication by adding a `cancelled` flag to the history
  fetch effect

## Test plan

- [ ] Open 10+ assistant breakout windows simultaneously — verify all are responsive and the UI
      does not freeze
- [ ] Verify only 1 SSE connection exists across all tabs (check `chrome://inspect/#workers`
      for the `sse-shared-worker` instance)
- [ ] Open a session, send messages, navigate away and back — verify no message duplication
- [ ] Open a breakout window for a session with existing conversation — verify history loads
      correctly without duplicates
- [ ] Verify dashboard real-time updates still work (project-updated, task-updated events)
- [ ] End a session and verify cleanup (drainer thread exits, listener removed)
- [ ] Ctrl-C Axiom shutdown — verify clean shutdown without H2 stack traces