### PR TITLE
Migrate AI Assistant inline styles to CSS classes for theme support

### DIFF
--- a/ui/src/components/assistant/AssistantMessageInput.css
+++ b/ui/src/components/assistant/AssistantMessageInput.css
@@ -1,0 +1,44 @@
+/* Message input bar */
+.axiom-message-input {
+    position: relative;
+    flex-shrink: 0;
+}
+
+.axiom-message-input__bar {
+    padding: 12px 16px;
+    border-top: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
+}
+
+/* Slash command dropdown */
+.axiom-message-input__dropdown {
+    position: absolute;
+    bottom: 100%;
+    left: 16px;
+    right: 16px;
+    max-height: 250px;
+    overflow-y: auto;
+    background-color: var(--pf-t--global--background--color--primary--default, #fff);
+    border: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
+    border-radius: 6px;
+    box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.1);
+    z-index: 100;
+    margin-bottom: 4px;
+}
+
+.axiom-message-input__dropdown-item {
+    padding: 8px 12px;
+    cursor: pointer;
+    background-color: transparent;
+    font-size: 13px;
+    font-family: monospace;
+    border-bottom: 1px solid var(--pf-t--global--border--color--default, #eee);
+}
+
+.axiom-message-input__dropdown-item:last-child {
+    border-bottom: none;
+}
+
+.axiom-message-input__dropdown-item[data-selected="true"],
+.axiom-message-input__dropdown-item:hover {
+    background-color: var(--pf-t--global--background--color--secondary--default, #f0f0f0);
+}

--- a/ui/src/components/assistant/AssistantMessageInput.css
+++ b/ui/src/components/assistant/AssistantMessageInput.css
@@ -31,7 +31,7 @@
     background-color: transparent;
     font-size: 13px;
     font-family: monospace;
-    border-bottom: 1px solid var(--pf-t--global--border--color--default, #eee);
+    border-bottom: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
 }
 
 .axiom-message-input__dropdown-item:last-child {

--- a/ui/src/components/assistant/AssistantMessageInput.tsx
+++ b/ui/src/components/assistant/AssistantMessageInput.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from "react";
 import { TextArea, Button, Flex, FlexItem } from "@patternfly/react-core";
 import PaperPlaneIcon from "@patternfly/react-icons/dist/esm/icons/paper-plane-icon";
+import "./AssistantMessageInput.css";
 
 interface AssistantMessageInputProps {
     onSend: (message: string) => void;
@@ -111,38 +112,15 @@ export function AssistantMessageInput({ onSend, disabled, slashCommands = [] }: 
     };
 
     return (
-        <div style={{ position: "relative", flexShrink: 0 }}>
+        <div className="axiom-message-input">
             {showDropdown && (
-                <div
-                    ref={dropdownRef}
-                    style={{
-                        position: "absolute",
-                        bottom: "100%",
-                        left: 16,
-                        right: 16,
-                        maxHeight: 250,
-                        overflowY: "auto",
-                        backgroundColor: "white",
-                        border: "1px solid #d2d2d2",
-                        borderRadius: "6px",
-                        boxShadow: "0 -4px 12px rgba(0,0,0,0.1)",
-                        zIndex: 100,
-                        marginBottom: 4,
-                    }}
-                >
+                <div ref={dropdownRef} className="axiom-message-input__dropdown">
                     {filteredCommands.map((cmd, i) => (
                         <div
                             key={cmd}
+                            className="axiom-message-input__dropdown-item"
+                            data-selected={i === selectedIndex || undefined}
                             onClick={() => selectCommand(cmd)}
-                            style={{
-                                padding: "8px 12px",
-                                cursor: "pointer",
-                                backgroundColor: i === selectedIndex ? "#f0f0f0" : "transparent",
-                                fontSize: "13px",
-                                fontFamily: "monospace",
-                                borderBottom: i < filteredCommands.length - 1
-                                    ? "1px solid #eee" : "none",
-                            }}
                             onMouseEnter={() => setSelectedIndex(i)}
                         >
                             /{cmd}
@@ -150,7 +128,7 @@ export function AssistantMessageInput({ onSend, disabled, slashCommands = [] }: 
                     ))}
                 </div>
             )}
-            <Flex style={{ padding: "12px 16px", borderTop: "1px solid #d2d2d2" }}>
+            <Flex className="axiom-message-input__bar">
                 <FlexItem grow={{ default: "grow" }}>
                     <TextArea
                         ref={textAreaRef}

--- a/ui/src/components/assistant/AssistantMessageList.css
+++ b/ui/src/components/assistant/AssistantMessageList.css
@@ -1,3 +1,89 @@
+:root {
+    --axiom--color--warning--bg: #fdf7e7;
+    --axiom--color--warning--border: #f0d67b;
+    --axiom--color--warning--text: #795600;
+}
+
+/* Message list container */
+.axiom-message-list {
+    flex: 1 1 0;
+    min-height: 0;
+    overflow-y: auto;
+    padding: 16px;
+}
+
+/* System and thinking messages */
+.axiom-message-list__system,
+.axiom-message-list__thinking {
+    padding: 8px 12px;
+    margin: 4px 0;
+    font-size: 13px;
+    color: var(--pf-t--global--text--color--subtle, #6a6e73);
+    font-style: italic;
+}
+
+/* Warning messages */
+.axiom-message-list__warning {
+    padding: 8px 12px;
+    margin: 4px 8px;
+    font-size: 13px;
+    color: var(--axiom--color--warning--text, #795600);
+    background-color: var(--axiom--color--warning--bg, #fdf7e7);
+    border: 1px solid var(--axiom--color--warning--border, #f0d67b);
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.axiom-message-list__warning-icon {
+    color: var(--axiom--color--warning--text, #795600);
+}
+
+/* User message */
+.axiom-message-list__user-row {
+    display: flex;
+    justify-content: flex-end;
+    margin: 8px 0;
+}
+
+.axiom-message-list__user-bubble {
+    max-width: 80%;
+    padding: 10px 14px;
+    border-radius: 12px 12px 2px 12px;
+    background-color: var(--pf-t--global--color--brand--default, #0066cc);
+    color: var(--pf-t--global--background--color--primary--default, #fff);
+    white-space: pre-wrap;
+    font-size: 14px;
+}
+
+/* Assistant message */
+.axiom-message-list__assistant-row {
+    display: flex;
+    justify-content: flex-start;
+    margin: 8px 0;
+}
+
+.axiom-message-list__assistant-bubble {
+    max-width: 80%;
+    padding: 10px 14px;
+    border-radius: 12px 12px 12px 2px;
+    background-color: var(--pf-t--global--background--color--secondary--default, #f0f0f0);
+    font-size: 14px;
+}
+
+/* Processing spinner */
+.axiom-message-list__processing {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px;
+    margin: 8px 0;
+    font-size: 13px;
+    color: var(--pf-t--global--text--color--subtle, #6a6e73);
+}
+
+/* Markdown table styles */
 .assistant-markdown table {
     border-collapse: collapse;
     width: 100%;
@@ -8,20 +94,20 @@
 .assistant-markdown th {
     text-align: left;
     padding: 6px 10px;
-    border-bottom: 2px solid #d2d2d2;
-    background-color: #f0f0f0;
+    border-bottom: 2px solid var(--pf-t--global--border--color--default, #d2d2d2);
+    background-color: var(--pf-t--global--background--color--secondary--default, #f0f0f0);
     font-weight: 600;
 }
 
 .assistant-markdown td {
     padding: 6px 10px;
-    border-bottom: 1px solid #e0e0e0;
+    border-bottom: 1px solid var(--pf-t--global--border--color--default, #e0e0e0);
 }
 
 .assistant-markdown tr:nth-child(even) {
-    background-color: #fafafa;
+    background-color: var(--pf-t--global--background--color--secondary--default, #fafafa);
 }
 
 .assistant-markdown tr:hover {
-    background-color: #f0f5fa;
+    background-color: var(--pf-t--global--background--color--secondary--hover, #f0f5fa);
 }

--- a/ui/src/components/assistant/AssistantMessageList.css
+++ b/ui/src/components/assistant/AssistantMessageList.css
@@ -1,9 +1,3 @@
-:root {
-    --axiom--color--warning--bg: #fdf7e7;
-    --axiom--color--warning--border: #f0d67b;
-    --axiom--color--warning--text: #795600;
-}
-
 /* Message list container */
 .axiom-message-list {
     flex: 1 1 0;
@@ -101,7 +95,7 @@
 
 .assistant-markdown td {
     padding: 6px 10px;
-    border-bottom: 1px solid var(--pf-t--global--border--color--default, #e0e0e0);
+    border-bottom: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
 }
 
 .assistant-markdown tr:nth-child(even) {

--- a/ui/src/components/assistant/AssistantMessageList.tsx
+++ b/ui/src/components/assistant/AssistantMessageList.tsx
@@ -38,62 +38,28 @@ export function AssistantMessageList({ messages, onPermissionRespond, onCreateAu
     }, [messages.length]);
 
     return (
-        <div style={{
-            flex: "1 1 0",
-            minHeight: 0,
-            overflowY: "auto",
-            padding: "16px",
-        }}>
+        <div className="axiom-message-list">
             {messages.map((msg) => {
                 switch (msg.type) {
                     case "system":
                         return (
-                            <div key={msg.id} style={{
-                                padding: "8px 12px",
-                                margin: "4px 0",
-                                fontSize: "13px",
-                                color: "#6a6e73",
-                                fontStyle: "italic",
-                            }}>
+                            <div key={msg.id} className="axiom-message-list__system">
                                 {msg.content}
                             </div>
                         );
 
                     case "warning":
                         return (
-                            <div key={msg.id} style={{
-                                padding: "8px 12px",
-                                margin: "4px 8px",
-                                fontSize: "13px",
-                                color: "#795600",
-                                backgroundColor: "#fdf7e7",
-                                border: "1px solid #f0d67b",
-                                borderRadius: "4px",
-                                display: "flex",
-                                alignItems: "center",
-                                gap: "8px",
-                            }}>
-                                <ExclamationTriangleIcon color="#795600" />
+                            <div key={msg.id} className="axiom-message-list__warning">
+                                <ExclamationTriangleIcon className="axiom-message-list__warning-icon" />
                                 {msg.content}
                             </div>
                         );
 
                     case "user":
                         return (
-                            <div key={msg.id} style={{
-                                display: "flex",
-                                justifyContent: "flex-end",
-                                margin: "8px 0",
-                            }}>
-                                <div style={{
-                                    maxWidth: "80%",
-                                    padding: "10px 14px",
-                                    borderRadius: "12px 12px 2px 12px",
-                                    backgroundColor: "#0066cc",
-                                    color: "white",
-                                    whiteSpace: "pre-wrap",
-                                    fontSize: "14px",
-                                }}>
+                            <div key={msg.id} className="axiom-message-list__user-row">
+                                <div className="axiom-message-list__user-bubble">
                                     {msg.content}
                                 </div>
                             </div>
@@ -101,18 +67,8 @@ export function AssistantMessageList({ messages, onPermissionRespond, onCreateAu
 
                     case "assistant":
                         return (
-                            <div key={msg.id} style={{
-                                display: "flex",
-                                justifyContent: "flex-start",
-                                margin: "8px 0",
-                            }}>
-                                <div className="assistant-markdown" style={{
-                                    maxWidth: "80%",
-                                    padding: "10px 14px",
-                                    borderRadius: "12px 12px 12px 2px",
-                                    backgroundColor: "#f0f0f0",
-                                    fontSize: "14px",
-                                }}>
+                            <div key={msg.id} className="axiom-message-list__assistant-row">
+                                <div className="assistant-markdown axiom-message-list__assistant-bubble">
                                     <Content>
                                         <Markdown remarkPlugins={[remarkGfm]}>
                                             {msg.content?.trim() || ""}
@@ -140,13 +96,7 @@ export function AssistantMessageList({ messages, onPermissionRespond, onCreateAu
 
                     case "thinking":
                         return (
-                            <div key={msg.id} style={{
-                                padding: "8px 12px",
-                                margin: "4px 0",
-                                fontSize: "13px",
-                                color: "#6a6e73",
-                                fontStyle: "italic",
-                            }}>
+                            <div key={msg.id} className="axiom-message-list__thinking">
                                 Thinking...
                             </div>
                         );
@@ -168,15 +118,7 @@ export function AssistantMessageList({ messages, onPermissionRespond, onCreateAu
                 }
             })}
             {isProcessing && (
-                <div style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: "8px",
-                    padding: "12px",
-                    margin: "8px 0",
-                    fontSize: "13px",
-                    color: "#6a6e73",
-                }}>
+                <div className="axiom-message-list__processing">
                     <Spinner size="md" />
                     <span>{processingText || "Claude is working..."}</span>
                 </div>

--- a/ui/src/components/assistant/AssistantToolUseBlock.css
+++ b/ui/src/components/assistant/AssistantToolUseBlock.css
@@ -1,0 +1,194 @@
+:root {
+    --axiom--color--warning--bg: #fdf7e7;
+    --axiom--color--success--bg: #f3faf3;
+    --axiom--color--success--border: #c6e3c6;
+    --axiom--color--danger--bg: #fef3f2;
+}
+
+/* Block wrapper */
+.axiom-tool-use {
+    margin: 4px 0;
+    border-radius: 6px;
+    overflow: hidden;
+}
+
+.axiom-tool-use[data-border="plan"] {
+    border: 2px solid var(--pf-t--global--color--status--success--default, #3e8635);
+}
+
+.axiom-tool-use[data-border="ask"] {
+    border: 2px solid var(--pf-t--global--color--status--info--default, #2b9af3);
+}
+
+.axiom-tool-use[data-border="permission"] {
+    border: 2px solid var(--pf-t--global--color--nonstatus--orange--default, #f0ab00);
+}
+
+/* Expandable header */
+.axiom-tool-use__header {
+    padding: 8px 12px;
+    background-color: var(--pf-t--global--background--color--secondary--default, #f0f0f0);
+    font-size: 13px;
+}
+
+/* Input preview text */
+.axiom-tool-use__input-preview {
+    margin-left: 8px;
+    color: var(--pf-t--global--text--color--subtle, #6a6e73);
+    font-size: 12px;
+}
+
+/* Section labels (Input, Result) */
+.axiom-tool-use__section-label {
+    font-size: 11px;
+    color: var(--pf-t--global--text--color--subtle, #6a6e73);
+    font-weight: 600;
+    margin-bottom: 4px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.axiom-tool-use__section-label--error {
+    color: var(--pf-t--global--color--status--danger--default, #c9190b);
+}
+
+/* Code blocks (SyntaxHighlighter wrapper) */
+.axiom-tool-use__code pre {
+    margin: 0;
+    border-radius: 4px;
+    font-size: 12px;
+    max-height: 250px;
+    overflow: auto;
+}
+
+.axiom-tool-use__code--error pre {
+    background-color: var(--axiom--color--danger--bg, #fef3f2) !important;
+}
+
+/* Result divider */
+.axiom-tool-use__result-divider {
+    border-top: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
+    margin-top: 8px;
+    padding-top: 8px;
+}
+
+/* Ask user section */
+.axiom-tool-use__ask-section {
+    border-top: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
+}
+
+/* Plan approval section */
+.axiom-tool-use__plan-section {
+    padding: 10px 12px;
+    background-color: var(--axiom--color--success--bg, #f3faf3);
+    border-top: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
+    font-size: 13px;
+}
+
+.axiom-tool-use__plan-section[data-resolved="true"] {
+    background-color: var(--pf-t--global--background--color--secondary--default, #f0f0f0);
+}
+
+.axiom-tool-use__plan-review-header {
+    margin-bottom: 8px;
+}
+
+.axiom-tool-use__plan-review-title {
+    font-weight: 600;
+}
+
+.axiom-tool-use__plan-content {
+    margin-bottom: 10px;
+    padding: 12px 16px;
+    background-color: var(--pf-t--global--background--color--primary--default, #fff);
+    border-radius: 4px;
+    border: 1px solid var(--axiom--color--success--border, #c6e3c6);
+    max-height: 300px;
+    overflow: auto;
+    font-size: 13px;
+}
+
+.axiom-tool-use__plan-approve-btn {
+    background-color: var(--pf-t--global--color--status--success--default, #3e8635);
+    border-color: var(--pf-t--global--color--status--success--default, #3e8635);
+}
+
+.axiom-tool-use__plan-status--approved {
+    color: var(--pf-t--global--color--status--success--default, #3e8635);
+    font-style: italic;
+}
+
+.axiom-tool-use__plan-status--rejected {
+    color: var(--pf-t--global--color--status--danger--default, #c9190b);
+    font-style: italic;
+}
+
+.axiom-tool-use__view-plan-btn {
+    padding: 2px 6px;
+}
+
+/* Permission section */
+.axiom-tool-use__permission-section {
+    padding: 10px 12px;
+    background-color: var(--axiom--color--warning--bg, #fdf7e7);
+    border-top: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
+    font-size: 13px;
+}
+
+.axiom-tool-use__permission-section[data-resolved="true"] {
+    background-color: var(--pf-t--global--background--color--secondary--default, #f0f0f0);
+}
+
+.axiom-tool-use__permission-title {
+    font-weight: 600;
+    margin-bottom: 6px;
+}
+
+.axiom-tool-use__context-summary {
+    margin-bottom: 8px;
+    padding: 6px 10px;
+    background-color: var(--pf-t--global--background--color--primary--default, #fff);
+    border-radius: 4px;
+    border: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
+    font-family: monospace;
+    font-size: 12px;
+    white-space: pre-wrap;
+    word-break: break-all;
+    max-height: 120px;
+    overflow: auto;
+}
+
+.axiom-tool-use__permission-status--granted {
+    color: var(--pf-t--global--text--color--subtle, #6a6e73);
+    font-style: italic;
+}
+
+.axiom-tool-use__permission-status--denied {
+    color: var(--pf-t--global--color--status--danger--default, #c9190b);
+    font-style: italic;
+}
+
+/* Pattern UI */
+.axiom-tool-use__pattern-ui {
+    padding: 8px 10px;
+    background-color: var(--pf-t--global--background--color--primary--default, #fff);
+    border-radius: 4px;
+    border: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
+}
+
+.axiom-tool-use__pattern-hint {
+    font-size: 12px;
+    color: var(--pf-t--global--text--color--subtle, #6a6e73);
+    margin-bottom: 6px;
+}
+
+.axiom-tool-use__pattern-suggestion {
+    margin-right: 6px;
+    margin-bottom: 4px;
+}
+
+.axiom-tool-use__pattern-custom-row {
+    margin-top: 6px;
+    align-items: center;
+    gap: 6px;
+}

--- a/ui/src/components/assistant/AssistantToolUseBlock.css
+++ b/ui/src/components/assistant/AssistantToolUseBlock.css
@@ -1,8 +1,11 @@
 :root {
     --axiom--color--warning--bg: #fdf7e7;
+    --axiom--color--warning--border: #f0d67b;
+    --axiom--color--warning--text: #795600;
     --axiom--color--success--bg: #f3faf3;
     --axiom--color--success--border: #c6e3c6;
     --axiom--color--danger--bg: #fef3f2;
+    --axiom--color--orange--bg: #fffaf0;
 }
 
 /* Block wrapper */

--- a/ui/src/components/assistant/AssistantToolUseBlock.tsx
+++ b/ui/src/components/assistant/AssistantToolUseBlock.tsx
@@ -19,6 +19,7 @@ import json from "react-syntax-highlighter/dist/esm/languages/hljs/json";
 import bash from "react-syntax-highlighter/dist/esm/languages/hljs/bash";
 import { stackoverflowLight } from "react-syntax-highlighter/dist/esm/styles/hljs";
 import { AssistantAskUserQuestion } from "./AssistantAskUserQuestion";
+import "./AssistantToolUseBlock.css";
 
 SyntaxHighlighter.registerLanguage("json", json);
 SyntaxHighlighter.registerLanguage("bash", bash);
@@ -60,8 +61,8 @@ export function AssistantToolUseBlock({
     const needsPermission = permissionId && !permissionResolved;
     const isAskUser = toolName === "AskUserQuestion";
     const isPlanApproval = toolName === "ExitPlanMode";
-    const borderColor = needsPermission
-        ? (isPlanApproval ? "#3e8635" : isAskUser ? "#2b9af3" : "#f0ab00")
+    const borderVariant = needsPermission
+        ? (isPlanApproval ? "plan" : isAskUser ? "ask" : "permission")
         : undefined;
 
     const inputPreview = input
@@ -70,35 +71,9 @@ export function AssistantToolUseBlock({
 
     const contextSummary = getContextSummary(toolName, input);
 
-    const codeStyle = {
-        margin: 0,
-        borderRadius: "4px",
-        fontSize: "12px",
-        maxHeight: "250px",
-        overflow: "auto",
-    };
-
-    const sectionLabelStyle: React.CSSProperties = {
-        fontSize: "11px",
-        color: "#6a6e73",
-        fontWeight: 600,
-        marginBottom: 4,
-        textTransform: "uppercase",
-        letterSpacing: "0.5px",
-    };
-
     return (
-        <div style={{
-            margin: "4px 0",
-            borderRadius: "6px",
-            overflow: "hidden",
-            border: borderColor ? `2px solid ${borderColor}` : undefined,
-        }}>
-            <div style={{
-                padding: "8px 12px",
-                backgroundColor: "#f0f0f0",
-                fontSize: "13px",
-            }}>
+        <div className="axiom-tool-use" data-border={borderVariant || undefined}>
+            <div className="axiom-tool-use__header">
                 <ExpandableSection
                     toggleContent={
                         <span>
@@ -106,7 +81,7 @@ export function AssistantToolUseBlock({
                                 {toolName}
                             </Label>
                             {inputPreview && (
-                                <span style={{ marginLeft: 8, color: "#6a6e73", fontSize: "12px" }}>
+                                <span className="axiom-tool-use__input-preview">
                                     {inputPreview}{input && JSON.stringify(input).length > 100 ? "..." : ""}
                                 </span>
                             )}
@@ -118,49 +93,39 @@ export function AssistantToolUseBlock({
                 >
                     {input && (
                         <div>
-                            <div style={sectionLabelStyle}>Input</div>
-                            <SyntaxHighlighter
-                                language="json"
-                                style={stackoverflowLight}
-                                customStyle={codeStyle}
-                                wrapLongLines
-                            >
-                                {JSON.stringify(input, null, 2)}
-                            </SyntaxHighlighter>
+                            <div className="axiom-tool-use__section-label">Input</div>
+                            <div className="axiom-tool-use__code">
+                                <SyntaxHighlighter
+                                    language="json"
+                                    style={stackoverflowLight}
+                                    wrapLongLines
+                                >
+                                    {JSON.stringify(input, null, 2)}
+                                </SyntaxHighlighter>
+                            </div>
                         </div>
                     )}
                     {result && (
-                        <div style={{
-                            ...(input ? {
-                                borderTop: "1px solid #d2d2d2",
-                                marginTop: 8,
-                                paddingTop: 8,
-                            } : {}),
-                        }}>
-                            <div style={{
-                                ...sectionLabelStyle,
-                                ...(isError ? { color: "#c9190b" } : {}),
-                            }}>
+                        <div className={input ? "axiom-tool-use__result-divider" : undefined}>
+                            <div className={`axiom-tool-use__section-label${isError ? " axiom-tool-use__section-label--error" : ""}`}>
                                 {isError ? "Error" : "Result"}
                             </div>
-                            <SyntaxHighlighter
-                                language={isJson(result) ? "json" : "bash"}
-                                style={stackoverflowLight}
-                                customStyle={{
-                                    ...codeStyle,
-                                    ...(isError ? { backgroundColor: "#fef3f2" } : {}),
-                                }}
-                                wrapLongLines
-                            >
-                                {isJson(result) ? formatJson(result) : result}
-                            </SyntaxHighlighter>
+                            <div className={`axiom-tool-use__code${isError ? " axiom-tool-use__code--error" : ""}`}>
+                                <SyntaxHighlighter
+                                    language={isJson(result) ? "json" : "bash"}
+                                    style={stackoverflowLight}
+                                    wrapLongLines
+                                >
+                                    {isJson(result) ? formatJson(result) : result}
+                                </SyntaxHighlighter>
+                            </div>
                         </div>
                     )}
                 </ExpandableSection>
             </div>
 
             {permissionId && isAskUser && Array.isArray(input?.questions) && (
-                <div style={{ borderTop: "1px solid #d2d2d2" }}>
+                <div className="axiom-tool-use__ask-section">
                     <AssistantAskUserQuestion
                         permissionId={permissionId}
                         questions={input.questions as {
@@ -176,18 +141,14 @@ export function AssistantToolUseBlock({
             )}
 
             {permissionId && isPlanApproval && (
-                <div style={{
-                    padding: "10px 12px",
-                    backgroundColor: needsPermission ? "#f3faf3" : "#f0f0f0",
-                    borderTop: "1px solid #d2d2d2",
-                    fontSize: "13px",
-                }}>
+                <div className="axiom-tool-use__plan-section"
+                    data-resolved={!needsPermission ? "true" : undefined}>
                     {needsPermission ? (
                         <>
                             <Flex alignItems={{ default: "alignItemsCenter" }}
-                                style={{ marginBottom: 8 }}>
+                                className="axiom-tool-use__plan-review-header">
                                 <FlexItem>
-                                    <span style={{ fontWeight: 600 }}>
+                                    <span className="axiom-tool-use__plan-review-title">
                                         Plan ready for review
                                     </span>
                                 </FlexItem>
@@ -196,23 +157,14 @@ export function AssistantToolUseBlock({
                                         <Button variant="plain" size="sm"
                                             aria-label="View plan in full screen"
                                             onClick={() => setIsPlanModalOpen(true)}
-                                            style={{ padding: "2px 6px" }}>
+                                            className="axiom-tool-use__view-plan-btn">
                                             <SearchPlusIcon />
                                         </Button>
                                     </FlexItem>
                                 )}
                             </Flex>
                             {!!input?.plan && (
-                                <div className="assistant-markdown" style={{
-                                    marginBottom: 10,
-                                    padding: "12px 16px",
-                                    backgroundColor: "white",
-                                    borderRadius: "4px",
-                                    border: "1px solid #c6e3c6",
-                                    maxHeight: "300px",
-                                    overflow: "auto",
-                                    fontSize: "13px",
-                                }}>
+                                <div className="assistant-markdown axiom-tool-use__plan-content">
                                     <Content>
                                         <Markdown remarkPlugins={[remarkGfm]}>
                                             {input.plan as string}
@@ -223,7 +175,7 @@ export function AssistantToolUseBlock({
                             <Flex>
                                 <FlexItem>
                                     <Button variant="primary" size="sm"
-                                        style={{ backgroundColor: "#3e8635", borderColor: "#3e8635" }}
+                                        className="axiom-tool-use__plan-approve-btn"
                                         onClick={() => onPermissionRespond?.(permissionId, true, input)}>
                                         Approve Plan
                                     </Button>
@@ -239,8 +191,9 @@ export function AssistantToolUseBlock({
                     ) : (
                         <Flex alignItems={{ default: "alignItemsCenter" }}>
                             <FlexItem>
-                                <span style={{ color: permissionAllowed ? "#3e8635" : "#c9190b",
-                                    fontStyle: "italic" }}>
+                                <span className={permissionAllowed
+                                    ? "axiom-tool-use__plan-status--approved"
+                                    : "axiom-tool-use__plan-status--rejected"}>
                                     {permissionAllowed ? "Plan approved" : "Plan rejected"}
                                 </span>
                             </FlexItem>
@@ -249,7 +202,7 @@ export function AssistantToolUseBlock({
                                     <Button variant="plain" size="sm"
                                         aria-label="View plan"
                                         onClick={() => setIsPlanModalOpen(true)}
-                                        style={{ padding: "2px 6px" }}>
+                                        className="axiom-tool-use__view-plan-btn">
                                         <SearchPlusIcon />
                                     </Button>
                                 </FlexItem>
@@ -279,31 +232,15 @@ export function AssistantToolUseBlock({
             )}
 
             {permissionId && !isAskUser && !isPlanApproval && (
-                <div style={{
-                    padding: "10px 12px",
-                    backgroundColor: needsPermission ? "#fdf7e7" : "#f0f0f0",
-                    borderTop: "1px solid #d2d2d2",
-                    fontSize: "13px",
-                }}>
+                <div className="axiom-tool-use__permission-section"
+                    data-resolved={!needsPermission ? "true" : undefined}>
                     {needsPermission ? (
                         <>
-                            <div style={{ fontWeight: 600, marginBottom: 6 }}>
+                            <div className="axiom-tool-use__permission-title">
                                 Permission required
                             </div>
                             {contextSummary && (
-                                <div style={{
-                                    marginBottom: 8,
-                                    padding: "6px 10px",
-                                    backgroundColor: "white",
-                                    borderRadius: "4px",
-                                    border: "1px solid #d2d2d2",
-                                    fontFamily: "monospace",
-                                    fontSize: "12px",
-                                    whiteSpace: "pre-wrap",
-                                    wordBreak: "break-all",
-                                    maxHeight: "120px",
-                                    overflow: "auto",
-                                }}>
+                                <div className="axiom-tool-use__context-summary">
                                     {contextSummary}
                                 </div>
                             )}
@@ -330,18 +267,13 @@ export function AssistantToolUseBlock({
                                 )}
                             </Flex>
                             {showPatternUI && onCreateAutoApproval && (
-                                <div style={{
-                                    padding: "8px 10px",
-                                    backgroundColor: "white",
-                                    borderRadius: "4px",
-                                    border: "1px solid #d2d2d2",
-                                }}>
-                                    <div style={{ fontSize: "12px", color: "#6a6e73", marginBottom: 6 }}>
+                                <div className="axiom-tool-use__pattern-ui">
+                                    <div className="axiom-tool-use__pattern-hint">
                                         Auto-approve future {toolName} calls matching a pattern:
                                     </div>
                                     {getSuggestedPatterns(toolName, input).map((suggestion) => (
                                         <Button key={suggestion.label} variant="tertiary" size="sm"
-                                            style={{ marginRight: 6, marginBottom: 4 }}
+                                            className="axiom-tool-use__pattern-suggestion"
                                             onClick={() => {
                                                 onCreateAutoApproval(
                                                     toolName, suggestion.fieldName,
@@ -351,7 +283,7 @@ export function AssistantToolUseBlock({
                                             {suggestion.label}
                                         </Button>
                                     ))}
-                                    <Flex style={{ marginTop: 6, alignItems: "center", gap: 6 }}>
+                                    <Flex className="axiom-tool-use__pattern-custom-row">
                                         <FlexItem grow={{ default: "grow" }}>
                                             <TextInput
                                                 value={customPattern}
@@ -380,7 +312,9 @@ export function AssistantToolUseBlock({
                             )}
                         </>
                     ) : (
-                        <span style={{ color: permissionAllowed ? "#6a6e73" : "#c9190b", fontStyle: "italic" }}>
+                        <span className={permissionAllowed
+                            ? "axiom-tool-use__permission-status--granted"
+                            : "axiom-tool-use__permission-status--denied"}>
                             {permissionAllowed ? "Permission granted" : "Permission denied"}
                         </span>
                     )}

--- a/ui/src/pages/AssistantPage.css
+++ b/ui/src/pages/AssistantPage.css
@@ -62,7 +62,7 @@
 .axiom-assistant-page__template-item {
     padding: 12px 16px;
     cursor: pointer;
-    border-bottom: 1px solid var(--pf-t--global--border--color--default, #eee);
+    border-bottom: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
 }
 
 .axiom-assistant-page__template-item:hover {

--- a/ui/src/pages/AssistantPage.css
+++ b/ui/src/pages/AssistantPage.css
@@ -1,0 +1,86 @@
+/* Session list */
+.axiom-assistant-page__sessions {
+    margin-top: 16px;
+}
+
+.axiom-assistant-page__session-card {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 14px 16px;
+    margin-bottom: 8px;
+    border-radius: 8px;
+    border: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
+    cursor: pointer;
+    background-color: var(--pf-t--global--background--color--secondary--default, #fafafa);
+}
+
+.axiom-assistant-page__session-card:hover {
+    background-color: var(--pf-t--global--background--color--secondary--hover, #f0f0f0);
+}
+
+.axiom-assistant-page__session-card__details {
+    flex: 1;
+}
+
+.axiom-assistant-page__session-card__name {
+    font-weight: 600;
+    font-size: 14px;
+}
+
+.axiom-assistant-page__session-card__meta {
+    font-size: 12px;
+    color: var(--pf-t--global--text--color--subtle, #6a6e73);
+    margin-top: 2px;
+}
+
+/* Filter controls */
+.axiom-assistant-page__filter-name {
+    width: 250px;
+}
+
+.axiom-assistant-page__filter-template {
+    width: 220px;
+}
+
+/* Template picker modal */
+.axiom-assistant-page__template-filter {
+    margin-bottom: 12px;
+}
+
+.axiom-assistant-page__template-list {
+    max-height: 400px;
+    overflow-y: auto;
+}
+
+.axiom-assistant-page__template-list__empty {
+    padding: 24px;
+    text-align: center;
+    color: var(--pf-t--global--text--color--subtle, #6a6e73);
+}
+
+.axiom-assistant-page__template-item {
+    padding: 12px 16px;
+    cursor: pointer;
+    border-bottom: 1px solid var(--pf-t--global--border--color--default, #eee);
+}
+
+.axiom-assistant-page__template-item:hover {
+    background-color: var(--pf-t--global--background--color--secondary--hover, #f0f0f0);
+}
+
+.axiom-assistant-page__template-item__name {
+    font-weight: 600;
+    font-size: 14px;
+}
+
+.axiom-assistant-page__template-item__desc {
+    font-size: 13px;
+    color: var(--pf-t--global--text--color--subtle, #6a6e73);
+    margin-top: 2px;
+}
+
+/* Create error alert */
+.axiom-assistant-page__create-error {
+    margin-bottom: 12px;
+}

--- a/ui/src/pages/AssistantPage.tsx
+++ b/ui/src/pages/AssistantPage.tsx
@@ -40,6 +40,7 @@ import {
     type AssistantSessionInfo,
     type SessionTemplate,
 } from "../config/api";
+import "./AssistantPage.css";
 
 const FUN_WORDS = [
     "rocket", "cactus", "penguin", "waffle", "thunder", "mango", "cosmic",
@@ -216,7 +217,7 @@ export function AssistantPage() {
                                     value={filterName}
                                     onChange={(_e, v) => setFilterName(v)}
                                     onClear={() => setFilterName("")}
-                                    style={{ width: 250 }}
+                                    className="axiom-assistant-page__filter-name"
                                 />
                             </ToolbarItem>
                             <ToolbarItem>
@@ -224,7 +225,7 @@ export function AssistantPage() {
                                     value={filterTemplateId}
                                     onChange={(_e, v) => setFilterTemplateId(v)}
                                     aria-label="Filter by template"
-                                    style={{ width: 220 }}
+                                    className="axiom-assistant-page__filter-template"
                                 >
                                     <FormSelectOption value="" label="All templates" />
                                     {uniqueTemplateIds.map((tid) => (
@@ -288,32 +289,16 @@ export function AssistantPage() {
                     </EmptyStateFooter>
                 </EmptyState>
             ) : (
-                <div style={{ marginTop: 16 }}>
+                <div className="axiom-assistant-page__sessions">
                     {filteredSessions.map((s) => (
                         <div
                             key={s.id}
+                            className="axiom-assistant-page__session-card"
                             onClick={() => navigate(`/assistant/${s.id}`)}
-                            style={{
-                                display: "flex",
-                                alignItems: "center",
-                                gap: 12,
-                                padding: "14px 16px",
-                                marginBottom: 8,
-                                borderRadius: 8,
-                                border: "1px solid #d2d2d2",
-                                cursor: "pointer",
-                                backgroundColor: "#fafafa",
-                            }}
-                            onMouseEnter={(e) => {
-                                e.currentTarget.style.backgroundColor = "#f0f0f0";
-                            }}
-                            onMouseLeave={(e) => {
-                                e.currentTarget.style.backgroundColor = "#fafafa";
-                            }}
                         >
-                            <div style={{ flex: 1 }}>
-                                <div style={{ fontWeight: 600, fontSize: "14px" }}>{s.name}</div>
-                                <div style={{ fontSize: "12px", color: "#6a6e73", marginTop: 2 }}>
+                            <div className="axiom-assistant-page__session-card__details">
+                                <div className="axiom-assistant-page__session-card__name">{s.name}</div>
+                                <div className="axiom-assistant-page__session-card__meta">
                                     {templateMap[s.templateId] || s.templateId}
                                     {s.projectName && (
                                         <>
@@ -362,35 +347,25 @@ export function AssistantPage() {
                         value={templateFilter}
                         onChange={(_e, v) => setTemplateFilter(v)}
                         onClear={() => setTemplateFilter("")}
-                        style={{ marginBottom: 12 }}
+                        className="axiom-assistant-page__template-filter"
                     />
-                    <div style={{ maxHeight: 400, overflowY: "auto" }}>
+                    <div className="axiom-assistant-page__template-list">
                         {filteredTemplates.length === 0 ? (
-                            <div style={{ padding: 24, textAlign: "center", color: "#6a6e73" }}>
+                            <div className="axiom-assistant-page__template-list__empty">
                                 No templates match your filter.
                             </div>
                         ) : (
                             filteredTemplates.map((t) => (
                                 <div
                                     key={t.templateId}
+                                    className="axiom-assistant-page__template-item"
                                     onClick={() => handleTemplateSelect(t)}
-                                    style={{
-                                        padding: "12px 16px",
-                                        cursor: "pointer",
-                                        borderBottom: "1px solid #eee",
-                                    }}
-                                    onMouseEnter={(e) =>
-                                        (e.currentTarget.style.backgroundColor = "#f0f0f0")
-                                    }
-                                    onMouseLeave={(e) =>
-                                        (e.currentTarget.style.backgroundColor = "transparent")
-                                    }
                                 >
-                                    <div style={{ fontWeight: 600, fontSize: 14 }}>
+                                    <div className="axiom-assistant-page__template-item__name">
                                         {t.name}
                                     </div>
                                     {t.description && (
-                                        <div style={{ fontSize: 13, color: "#6a6e73", marginTop: 2 }}>
+                                        <div className="axiom-assistant-page__template-item__desc">
                                             {t.description}
                                         </div>
                                     )}
@@ -411,7 +386,7 @@ export function AssistantPage() {
                 <ModalBody>
                     {createError && (
                         <Alert variant="danger" isInline title={createError}
-                            style={{ marginBottom: 12 }} />
+                            className="axiom-assistant-page__create-error" />
                     )}
                     <Form>
                         <FormGroup label="Session Name" fieldId="session-name">

--- a/ui/src/pages/AssistantSessionPage.css
+++ b/ui/src/pages/AssistantSessionPage.css
@@ -1,7 +1,3 @@
-:root {
-    --axiom--color--orange--bg: #fffaf0;
-}
-
 /* Page layout */
 .axiom-session-page {
     display: flex;

--- a/ui/src/pages/AssistantSessionPage.css
+++ b/ui/src/pages/AssistantSessionPage.css
@@ -1,0 +1,145 @@
+:root {
+    --axiom--color--orange--bg: #fffaf0;
+}
+
+/* Page layout */
+.axiom-session-page {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    min-height: 0;
+    flex: 1 1 0;
+    gap: 0;
+}
+
+/* Header bar */
+.axiom-session-page__header {
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
+    align-items: center;
+    flex-shrink: 0;
+    transition: background-color 0.3s ease, border-color 0.3s ease;
+}
+
+.axiom-session-page__header[data-mode="plan"] {
+    border: 1px solid var(--pf-t--global--color--nonstatus--orange--default, #f0ab00);
+    border-radius: 12px 12px 0 0;
+    background-color: var(--axiom--color--orange--bg, #fffaf0);
+}
+
+/* Session name editing */
+.axiom-session-page__name-input {
+    font-weight: 600;
+    font-size: 16px;
+    max-width: 300px;
+}
+
+.axiom-session-page__name-editable {
+    font-weight: 600;
+    font-size: 16px;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.axiom-session-page__name-pencil {
+    font-size: 12px;
+    color: var(--pf-t--global--text--color--subtle, #6a6e73);
+    opacity: 0;
+    transition: opacity 0.15s;
+}
+
+.axiom-session-page__name-editable:hover .axiom-session-page__name-pencil {
+    opacity: 1;
+}
+
+/* Header labels */
+.axiom-session-page__header-label {
+    margin-left: 10px;
+}
+
+.axiom-session-page__header-label--clickable {
+    margin-left: 10px;
+    cursor: pointer;
+}
+
+/* Header actions */
+.axiom-session-page__apply-btn {
+    margin-right: 8px;
+}
+
+.axiom-session-page__shield-btn {
+    margin-right: 4px;
+}
+
+.axiom-session-page__shield-icon {
+    color: var(--pf-t--global--color--status--success--default, #3e8635);
+}
+
+.axiom-session-page__shield-badge {
+    margin-left: 4px;
+}
+
+.axiom-session-page__end-btn {
+    margin-right: 8px;
+}
+
+.axiom-session-page__end-btn--breakout {
+    margin-right: 0;
+}
+
+/* Apply error */
+.axiom-session-page__apply-error {
+    margin: 8px 16px;
+    flex-shrink: 0;
+}
+
+.axiom-session-page__apply-error-pre {
+    white-space: pre-wrap;
+    font-size: 12px;
+}
+
+/* Split panels */
+.axiom-session-page__split-panels {
+    display: flex;
+    flex: 1 1 0;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.axiom-session-page__chat-panel {
+    flex: 1 1 0;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    min-height: 0;
+}
+
+.axiom-session-page__chat-panel--with-sidebar {
+    flex: 7 1 0;
+    border-right: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
+}
+
+.axiom-session-page__items-panel {
+    flex: 3 1 0;
+    overflow-y: auto;
+    min-width: 0;
+    min-height: 0;
+}
+
+/* Auto-approval modal */
+.axiom-session-page__auto-approval-empty {
+    color: var(--pf-t--global--text--color--subtle, #6a6e73);
+    font-style: italic;
+    padding: 16px;
+}
+
+.axiom-session-page__auto-approval-code {
+    font-size: 12px;
+}
+
+/* Apply results */
+.axiom-session-page__apply-result-list {
+    margin-top: 8px;
+}

--- a/ui/src/pages/AssistantSessionPage.tsx
+++ b/ui/src/pages/AssistantSessionPage.tsx
@@ -35,6 +35,7 @@ import {
     type AutoApprovalRule,
     type AssistantApplyResult,
 } from "../config/api";
+import "./AssistantSessionPage.css";
 
 export function AssistantSessionPage() {
     const { sessionId } = useParams<{ sessionId: string }>();
@@ -197,25 +198,10 @@ export function AssistantSessionPage() {
 
     return (
         <PageSection padding={{ default: "noPadding" }} isFilled hasBodyWrapper={false}
-            style={{
-                display: "flex",
-                flexDirection: "column",
-                overflow: "hidden",
-                minHeight: 0,
-                flex: "1 1 0",
-                gap: 0,
-            }}>
+            className="axiom-session-page">
             {/* Header — fixed at top */}
-            <Flex style={{
-                padding: "12px 16px",
-                border: sessionMode === "plan" ? "1px solid #f0ab00" : undefined,
-                borderBottom: sessionMode === "plan" ? "1px solid #f0ab00" : "1px solid #d2d2d2",
-                borderRadius: sessionMode === "plan" ? "12px 12px 0 0" : undefined,
-                alignItems: "center",
-                flexShrink: 0,
-                backgroundColor: sessionMode === "plan" ? "#fffaf0" : undefined,
-                transition: "background-color 0.3s ease, border-color 0.3s ease",
-            }}>
+            <Flex className="axiom-session-page__header"
+                data-mode={sessionMode === "plan" ? "plan" : undefined}>
                 {!isBreakout && (
                     <FlexItem>
                         <Button variant="plain" onClick={() => navigate("/assistant")}>
@@ -234,32 +220,27 @@ export function AssistantSessionPage() {
                                 if (e.key === "Escape") setIsEditingName(false);
                             }}
                             autoFocus
-                            style={{ fontWeight: 600, fontSize: "16px", maxWidth: 300 }}
+                            className="axiom-session-page__name-input"
                         />
                     ) : (
                         <span
-                            className="session-name-editable"
-                            style={{ fontWeight: 600, fontSize: "16px", cursor: "pointer",
-                                display: "inline-flex", alignItems: "center", gap: 6 }}
+                            className="axiom-session-page__name-editable"
                             onClick={() => {
                                 setEditName(session.name);
                                 setIsEditingName(true);
                             }}
                         >
                             {session.name}
-                            <PencilAltIcon className="session-name-pencil"
-                                style={{ fontSize: "12px", color: "#6a6e73", opacity: 0,
-                                    transition: "opacity 0.15s" }} />
-                            <style>{`.session-name-editable:hover .session-name-pencil { opacity: 1 !important; }`}</style>
+                            <PencilAltIcon className="axiom-session-page__name-pencil" />
                         </span>
                     )}
                     {sessionMode === "plan" && (
-                        <Label color="orange" isCompact style={{ marginLeft: 10 }}>
+                        <Label color="orange" isCompact className="axiom-session-page__header-label">
                             Plan Mode
                         </Label>
                     )}
                     {sessionModel && (
-                        <Label color="grey" isCompact style={{ marginLeft: 10 }}>
+                        <Label color="grey" isCompact className="axiom-session-page__header-label">
                             {sessionModel}
                         </Label>
                     )}
@@ -267,7 +248,7 @@ export function AssistantSessionPage() {
                         <Tooltip content={
                             `Tokens in: ${sessionInputTokens.toLocaleString()} / out: ${sessionOutputTokens.toLocaleString()}`
                         }>
-                            <Label color="grey" isCompact style={{ marginLeft: 10 }}>
+                            <Label color="grey" isCompact className="axiom-session-page__header-label">
                                 ${sessionCost.toFixed(4)}
                             </Label>
                         </Tooltip>
@@ -276,7 +257,7 @@ export function AssistantSessionPage() {
                         <Label
                             color="teal"
                             isCompact
-                            style={{ marginLeft: 10, cursor: "pointer" }}
+                            className="axiom-session-page__header-label--clickable"
                             onClick={() => navigate(`/projects/${session.projectId}`)}
                         >
                             {session.projectName}
@@ -290,7 +271,7 @@ export function AssistantSessionPage() {
                             onClick={handleApply}
                             isLoading={applying}
                             isDisabled={applying || itemCount === 0}
-                            style={{ marginRight: 8 }}
+                            className="axiom-session-page__apply-btn"
                         >
                             Apply All
                         </Button>
@@ -298,9 +279,9 @@ export function AssistantSessionPage() {
                     {autoApprovalCount > 0 && (
                         <Tooltip content={`${autoApprovalCount} auto-approval rule(s) active`}>
                             <Button variant="plain" onClick={openAutoApprovalModal}
-                                style={{ marginRight: 4 }}>
-                                <ShieldAltIcon color="#3e8635" />
-                                <Badge isRead style={{ marginLeft: 4 }}>{autoApprovalCount}</Badge>
+                                className="axiom-session-page__shield-btn">
+                                <ShieldAltIcon className="axiom-session-page__shield-icon" />
+                                <Badge isRead className="axiom-session-page__shield-badge">{autoApprovalCount}</Badge>
                             </Button>
                         </Tooltip>
                     )}
@@ -308,7 +289,7 @@ export function AssistantSessionPage() {
                         variant="secondary"
                         isDanger
                         onClick={() => setIsEndConfirmOpen(true)}
-                        style={{ marginRight: isBreakout ? 0 : 8 }}
+                        className={isBreakout ? "axiom-session-page__end-btn--breakout" : "axiom-session-page__end-btn"}
                     >
                         End Session
                     </Button>
@@ -331,27 +312,15 @@ export function AssistantSessionPage() {
                     variant="danger"
                     isInline
                     title="Apply failed"
-                    style={{ margin: "8px 16px", flexShrink: 0 }}
+                    className="axiom-session-page__apply-error"
                 >
-                    <pre style={{ whiteSpace: "pre-wrap", fontSize: "12px" }}>{applyError}</pre>
+                    <pre className="axiom-session-page__apply-error-pre">{applyError}</pre>
                 </Alert>
             )}
 
             {/* Split panels — fills remaining height */}
-            <div style={{
-                display: "flex",
-                flex: "1 1 0",
-                minHeight: 0,
-                overflow: "hidden",
-            }}>
-                <div style={{
-                    flex: isConfigAssistant ? "7 1 0" : "1 1 0",
-                    borderRight: isConfigAssistant ? "1px solid #d2d2d2" : "none",
-                    display: "flex",
-                    flexDirection: "column",
-                    minWidth: 0,
-                    minHeight: 0,
-                }}>
+            <div className="axiom-session-page__split-panels">
+                <div className={`axiom-session-page__chat-panel${isConfigAssistant ? " axiom-session-page__chat-panel--with-sidebar" : ""}`}>
                     <AssistantChatPanel
                         sessionId={sessionId}
                         onItemsChanged={isConfigAssistant ? handleItemsChanged : undefined}
@@ -367,12 +336,7 @@ export function AssistantSessionPage() {
                 </div>
 
                 {isConfigAssistant && (
-                    <div style={{
-                        flex: "3 1 0",
-                        overflowY: "auto",
-                        minWidth: 0,
-                        minHeight: 0,
-                    }}>
+                    <div className="axiom-session-page__items-panel">
                         <AssistantGeneratedItems
                             sessionId={sessionId}
                             refreshTrigger={itemsRefresh}
@@ -420,7 +384,7 @@ export function AssistantSessionPage() {
                         {applyResult && (
                             <div>
                                 <p>The following items were applied:</p>
-                                <ul style={{ marginTop: 8 }}>
+                                <ul className="axiom-session-page__apply-result-list">
                                     {(applyResult.toolsCreated ?? 0) > 0 && <li>{applyResult.toolsCreated} tool(s) created</li>}
                                     {(applyResult.toolsUpdated ?? 0) > 0 && <li>{applyResult.toolsUpdated} tool(s) updated</li>}
                                     {(applyResult.actionTypesCreated ?? 0) > 0 && <li>{applyResult.actionTypesCreated} action type(s) created</li>}
@@ -456,7 +420,7 @@ export function AssistantSessionPage() {
                 <ModalHeader title="Auto-Approval Rules" />
                 <ModalBody>
                     {autoApprovalRules.length === 0 ? (
-                        <div style={{ color: "#6a6e73", fontStyle: "italic", padding: 16 }}>
+                        <div className="axiom-session-page__auto-approval-empty">
                             No auto-approval rules active.
                         </div>
                     ) : (
@@ -475,7 +439,7 @@ export function AssistantSessionPage() {
                                         <Td><Label isCompact>{rule.toolName}</Label></Td>
                                         <Td>{rule.fieldName || "—"}</Td>
                                         <Td>
-                                            <code style={{ fontSize: "12px" }}>
+                                            <code className="axiom-session-page__auto-approval-code">
                                                 {rule.pattern || "(all)"}
                                             </code>
                                         </Td>


### PR DESCRIPTION
## Summary
- Extracts inline style objects from 6 AI Assistant React components into CSS classes using
  PatternFly v6 token variables (`--pf-t--global--*`), enabling dark mode and theming support
- Replaces imperative `onMouseEnter`/`onMouseLeave` hover handlers with CSS `:hover` rules
- Removes injected `<style>` tag from `AssistantSessionPage.tsx`
- Uses `data-*` attribute selectors for conditional states (plan mode, permission borders)
- Follows existing project conventions: `axiom-` BEM naming, fallback values, plain CSS files

## Changes

**4 new CSS files:**
- `ui/src/pages/AssistantPage.css`
- `ui/src/pages/AssistantSessionPage.css`
- `ui/src/components/assistant/AssistantToolUseBlock.css`
- `ui/src/components/assistant/AssistantMessageInput.css`

**1 updated CSS file:**
- `ui/src/components/assistant/AssistantMessageList.css` — hardcoded colors replaced with PF tokens

**6 updated TSX files** — inline styles replaced with CSS classes

## Test plan
- [ ] Verify all AI Assistant pages render identically in light mode (pixel-perfect)
- [ ] Verify hover effects work on session cards, template items, and command dropdown
- [ ] Verify plan mode header displays orange border/background correctly
- [ ] Verify permission and plan approval sections show correct state colors
- [ ] Verify user/assistant chat bubbles retain correct styling
- [ ] Verify warning messages display with correct yellow styling
- [ ] Verify SyntaxHighlighter code blocks render correctly for tool inputs/results
- [ ] Verify error results show red-tinted background

Closes #76