### PR TITLE
Allow any template for project assistant sessions

### DIFF
--- a/ui/src/components/assistant/CreateSessionModal.tsx
+++ b/ui/src/components/assistant/CreateSessionModal.tsx
@@ -1,0 +1,202 @@
+import { useState, useEffect, useRef } from "react";
+import {
+    Alert,
+    Button,
+    Form,
+    FormGroup,
+    Modal,
+    ModalBody,
+    ModalFooter,
+    ModalHeader,
+    SearchInput,
+    TextInput,
+} from "@patternfly/react-core";
+import {
+    createAssistantSession,
+    fetchAssistantTemplates,
+    type AssistantSessionInfo,
+    type SessionTemplate,
+} from "../../config/api";
+import "../../pages/AssistantPage.css";
+
+const FUN_WORDS = [
+    "rocket", "cactus", "penguin", "waffle", "thunder", "mango", "cosmic",
+    "pickle", "turbo", "noodle", "galaxy", "biscuit", "phantom", "pretzel",
+    "velvet", "zigzag", "bamboo", "coral", "doodle", "falcon", "gopher",
+    "cobalt", "marble", "nimbus", "orchid", "quartz", "walrus", "tundra",
+    "nebula", "pebble", "saffron", "breeze", "mosaic", "lantern", "crimson",
+    "meadow", "jasper", "harbor", "ember", "frost", "summit", "canyon",
+    "copper", "willow", "sparrow", "clover", "rapids", "flint", "comet",
+    "puzzle", "sphinx", "goblin", "dragon", "wizard", "pirate", "ninja",
+    "viking", "yeti", "kraken", "phoenix", "griffin", "titan", "tempest",
+    "aurora", "blizzard", "cascade", "dynamo", "eclipse", "forge", "horizon",
+];
+
+function generateSessionName(): string {
+    const pick = () => FUN_WORDS[Math.floor(Math.random() * FUN_WORDS.length)];
+    return `${pick()}-${pick()}-${pick()}`;
+}
+
+interface CreateSessionModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onSessionCreated: (session: AssistantSessionInfo) => void;
+    projectId?: number;
+    defaultName?: string;
+}
+
+export function CreateSessionModal({
+    isOpen, onClose, onSessionCreated, projectId, defaultName,
+}: CreateSessionModalProps) {
+    const [templates, setTemplates] = useState<SessionTemplate[]>([]);
+    const [templateFilter, setTemplateFilter] = useState("");
+    const [selectedTemplate, setSelectedTemplate] = useState<SessionTemplate | null>(null);
+    const [isNameModalOpen, setIsNameModalOpen] = useState(false);
+    const [newName, setNewName] = useState("");
+    const [creating, setCreating] = useState(false);
+    const [createError, setCreateError] = useState("");
+    const createButtonRef = useRef<HTMLButtonElement>(null);
+
+    useEffect(() => {
+        if (isOpen) {
+            fetchAssistantTemplates()
+                .then(setTemplates)
+                .catch(console.error);
+            setTemplateFilter("");
+        }
+    }, [isOpen]);
+
+    useEffect(() => {
+        if (isNameModalOpen) {
+            setTimeout(() => createButtonRef.current?.focus(), 100);
+        }
+    }, [isNameModalOpen]);
+
+    const filteredTemplates = templates.filter((t) => {
+        if (!templateFilter) return true;
+        const lower = templateFilter.toLowerCase();
+        return t.name.toLowerCase().includes(lower)
+            || t.description.toLowerCase().includes(lower);
+    });
+
+    const handleTemplateSelect = (template: SessionTemplate) => {
+        setSelectedTemplate(template);
+        setNewName(defaultName || generateSessionName());
+        setIsNameModalOpen(true);
+    };
+
+    const handleCreate = async () => {
+        if (!selectedTemplate) return;
+        setCreating(true);
+        setCreateError("");
+        try {
+            const session = await createAssistantSession(
+                selectedTemplate.templateId, newName || undefined, projectId);
+            setIsNameModalOpen(false);
+            setNewName("");
+            setSelectedTemplate(null);
+            onSessionCreated(session);
+        } catch (err: unknown) {
+            const e = err as { message?: string };
+            setCreateError(e.message || "Failed to create session");
+        } finally {
+            setCreating(false);
+        }
+    };
+
+    const handleClose = () => {
+        setIsNameModalOpen(false);
+        setSelectedTemplate(null);
+        setNewName("");
+        setCreateError("");
+        onClose();
+    };
+
+    return (
+        <>
+            <Modal
+                isOpen={isOpen && !isNameModalOpen}
+                onClose={handleClose}
+                variant="medium"
+                aria-label="Choose template"
+            >
+                <ModalHeader title="Choose a Template" />
+                <ModalBody>
+                    <SearchInput
+                        placeholder="Filter templates..."
+                        value={templateFilter}
+                        onChange={(_e, v) => setTemplateFilter(v)}
+                        onClear={() => setTemplateFilter("")}
+                        className="axiom-assistant-page__template-filter"
+                    />
+                    <div className="axiom-assistant-page__template-list">
+                        {filteredTemplates.length === 0 ? (
+                            <div className="axiom-assistant-page__template-list__empty">
+                                No templates match your filter.
+                            </div>
+                        ) : (
+                            filteredTemplates.map((t) => (
+                                <div
+                                    key={t.templateId}
+                                    className="axiom-assistant-page__template-item"
+                                    onClick={() => handleTemplateSelect(t)}
+                                >
+                                    <div className="axiom-assistant-page__template-item__name">
+                                        {t.name}
+                                    </div>
+                                    {t.description && (
+                                        <div className="axiom-assistant-page__template-item__desc">
+                                            {t.description}
+                                        </div>
+                                    )}
+                                </div>
+                            ))
+                        )}
+                    </div>
+                </ModalBody>
+            </Modal>
+
+            <Modal
+                isOpen={isNameModalOpen}
+                onClose={handleClose}
+                variant="small"
+                aria-label="Name session"
+            >
+                <ModalHeader title="Name Your Session" />
+                <ModalBody>
+                    {createError && (
+                        <Alert variant="danger" isInline title={createError}
+                            className="axiom-assistant-page__create-error" />
+                    )}
+                    <Form>
+                        <FormGroup label="Session Name" fieldId="session-name">
+                            <TextInput
+                                id="session-name"
+                                value={newName}
+                                onChange={(_e, v) => setNewName(v)}
+                                onKeyDown={(e) => {
+                                    if (e.key === "Enter") handleCreate();
+                                }}
+                            />
+                        </FormGroup>
+                    </Form>
+                </ModalBody>
+                <ModalFooter>
+                    <Button
+                        ref={createButtonRef}
+                        variant="primary"
+                        onClick={handleCreate}
+                        isLoading={creating}
+                        isDisabled={creating}
+                        autoFocus
+                    >
+                        Create Session
+                    </Button>
+                    <Button variant="link" onClick={handleClose}>
+                        Cancel
+                    </Button>
+                </ModalFooter>
+            </Modal>
+        </>
+    );
+}

--- a/ui/src/pages/AssistantPage.tsx
+++ b/ui/src/pages/AssistantPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import {
     PageSection,
@@ -23,7 +23,6 @@ import {
     FormGroup,
     FormSelect,
     FormSelectOption,
-    Alert,
     SearchInput,
 } from "@patternfly/react-core";
 import PencilAltIcon from "@patternfly/react-icons/dist/esm/icons/pencil-alt-icon";
@@ -33,32 +32,13 @@ import SyncAltIcon from "@patternfly/react-icons/dist/esm/icons/sync-alt-icon";
 import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
 import {
     fetchAssistantSessions,
-    createAssistantSession,
     deleteAssistantSession,
     renameAssistantSession,
     fetchAssistantTemplates,
     type AssistantSessionInfo,
-    type SessionTemplate,
 } from "../config/api";
+import { CreateSessionModal } from "../components/assistant/CreateSessionModal";
 import "./AssistantPage.css";
-
-const FUN_WORDS = [
-    "rocket", "cactus", "penguin", "waffle", "thunder", "mango", "cosmic",
-    "pickle", "turbo", "noodle", "galaxy", "biscuit", "phantom", "pretzel",
-    "velvet", "zigzag", "bamboo", "coral", "doodle", "falcon", "gopher",
-    "cobalt", "marble", "nimbus", "orchid", "quartz", "walrus", "tundra",
-    "nebula", "pebble", "saffron", "breeze", "mosaic", "lantern", "crimson",
-    "meadow", "jasper", "harbor", "ember", "frost", "summit", "canyon",
-    "copper", "willow", "sparrow", "clover", "rapids", "flint", "comet",
-    "puzzle", "sphinx", "goblin", "dragon", "wizard", "pirate", "ninja",
-    "viking", "yeti", "kraken", "phoenix", "griffin", "titan", "tempest",
-    "aurora", "blizzard", "cascade", "dynamo", "eclipse", "forge", "horizon",
-];
-
-function generateSessionName(): string {
-    const pick = () => FUN_WORDS[Math.floor(Math.random() * FUN_WORDS.length)];
-    return `${pick()}-${pick()}-${pick()}`;
-}
 
 const STATUS_COLORS: Record<string, "blue" | "green" | "red" | "grey"> = {
     starting: "blue",
@@ -71,21 +51,7 @@ export function AssistantPage() {
     const navigate = useNavigate();
     const [sessions, setSessions] = useState<AssistantSessionInfo[]>([]);
     const [loading, setLoading] = useState(true);
-    const [templates, setTemplates] = useState<SessionTemplate[]>([]);
     const [isTemplatePickerOpen, setIsTemplatePickerOpen] = useState(false);
-    const [templateFilter, setTemplateFilter] = useState("");
-    const [selectedTemplate, setSelectedTemplate] = useState<SessionTemplate | null>(null);
-    const [isNameModalOpen, setIsNameModalOpen] = useState(false);
-    const [newName, setNewName] = useState("");
-    const createButtonRef = useRef<HTMLButtonElement>(null);
-
-    useEffect(() => {
-        if (isNameModalOpen) {
-            setTimeout(() => createButtonRef.current?.focus(), 100);
-        }
-    }, [isNameModalOpen]);
-    const [creating, setCreating] = useState(false);
-    const [createError, setCreateError] = useState("");
 
     const [filterName, setFilterName] = useState("");
     const [filterTemplateId, setFilterTemplateId] = useState("");
@@ -107,46 +73,6 @@ export function AssistantPage() {
     useEffect(() => {
         load();
     }, [load]);
-
-    const openTemplatePicker = () => {
-        fetchAssistantTemplates()
-            .then(setTemplates)
-            .catch(console.error);
-        setTemplateFilter("");
-        setIsTemplatePickerOpen(true);
-    };
-
-    const filteredTemplates = templates.filter((t) => {
-        if (!templateFilter) return true;
-        const lower = templateFilter.toLowerCase();
-        return t.name.toLowerCase().includes(lower)
-            || t.description.toLowerCase().includes(lower);
-    });
-
-    const handleTemplateSelect = (template: SessionTemplate) => {
-        setSelectedTemplate(template);
-        setIsTemplatePickerOpen(false);
-        setNewName(generateSessionName());
-        setIsNameModalOpen(true);
-    };
-
-    const handleCreate = async () => {
-        if (!selectedTemplate) return;
-        setCreating(true);
-        setCreateError("");
-        try {
-            const session = await createAssistantSession(selectedTemplate.templateId, newName || undefined);
-            setIsNameModalOpen(false);
-            setNewName("");
-            setSelectedTemplate(null);
-            navigate(`/assistant/${session.id}`);
-        } catch (err: unknown) {
-            const e = err as { message?: string };
-            setCreateError(e.message || "Failed to create session");
-        } finally {
-            setCreating(false);
-        }
-    };
 
     const filteredSessions = sessions.filter((s) => {
         if (filterName && !s.name.toLowerCase().includes(filterName.toLowerCase())) {
@@ -251,7 +177,7 @@ export function AssistantPage() {
                             <Button
                                 variant="primary"
                                 icon={<PlusCircleIcon />}
-                                onClick={openTemplatePicker}
+                                onClick={() => setIsTemplatePickerOpen(true)}
                             >
                                 New Session
                             </Button>
@@ -281,7 +207,7 @@ export function AssistantPage() {
                             <Button
                                 variant="primary"
                                 icon={<PlusCircleIcon />}
-                                onClick={openTemplatePicker}
+                                onClick={() => setIsTemplatePickerOpen(true)}
                             >
                                 New Session
                             </Button>
@@ -334,89 +260,14 @@ export function AssistantPage() {
                 </div>
             )}
 
-            <Modal
+            <CreateSessionModal
                 isOpen={isTemplatePickerOpen}
                 onClose={() => setIsTemplatePickerOpen(false)}
-                variant="medium"
-                aria-label="Choose template"
-            >
-                <ModalHeader title="Choose a Template" />
-                <ModalBody>
-                    <SearchInput
-                        placeholder="Filter templates..."
-                        value={templateFilter}
-                        onChange={(_e, v) => setTemplateFilter(v)}
-                        onClear={() => setTemplateFilter("")}
-                        className="axiom-assistant-page__template-filter"
-                    />
-                    <div className="axiom-assistant-page__template-list">
-                        {filteredTemplates.length === 0 ? (
-                            <div className="axiom-assistant-page__template-list__empty">
-                                No templates match your filter.
-                            </div>
-                        ) : (
-                            filteredTemplates.map((t) => (
-                                <div
-                                    key={t.templateId}
-                                    className="axiom-assistant-page__template-item"
-                                    onClick={() => handleTemplateSelect(t)}
-                                >
-                                    <div className="axiom-assistant-page__template-item__name">
-                                        {t.name}
-                                    </div>
-                                    {t.description && (
-                                        <div className="axiom-assistant-page__template-item__desc">
-                                            {t.description}
-                                        </div>
-                                    )}
-                                </div>
-                            ))
-                        )}
-                    </div>
-                </ModalBody>
-            </Modal>
-
-            <Modal
-                isOpen={isNameModalOpen}
-                onClose={() => setIsNameModalOpen(false)}
-                variant="small"
-                aria-label="Name session"
-            >
-                <ModalHeader title="Name Your Session" />
-                <ModalBody>
-                    {createError && (
-                        <Alert variant="danger" isInline title={createError}
-                            className="axiom-assistant-page__create-error" />
-                    )}
-                    <Form>
-                        <FormGroup label="Session Name" fieldId="session-name">
-                            <TextInput
-                                id="session-name"
-                                value={newName}
-                                onChange={(_e, v) => setNewName(v)}
-                                onKeyDown={(e) => {
-                                    if (e.key === "Enter") handleCreate();
-                                }}
-                            />
-                        </FormGroup>
-                    </Form>
-                </ModalBody>
-                <ModalFooter>
-                    <Button
-                        ref={createButtonRef}
-                        variant="primary"
-                        onClick={handleCreate}
-                        isLoading={creating}
-                        isDisabled={creating}
-                        autoFocus
-                    >
-                        Create Session
-                    </Button>
-                    <Button variant="link" onClick={() => setIsNameModalOpen(false)}>
-                        Cancel
-                    </Button>
-                </ModalFooter>
-            </Modal>
+                onSessionCreated={(session) => {
+                    setIsTemplatePickerOpen(false);
+                    navigate(`/assistant/${session.id}`);
+                }}
+            />
 
             <Modal
                 isOpen={deleteTarget !== null}

--- a/ui/src/pages/ProjectDetailPage.tsx
+++ b/ui/src/pages/ProjectDetailPage.tsx
@@ -59,7 +59,6 @@ import {
     fetchProjectMetrics,
     fetchProjectTasks,
     fetchThreadEntries,
-    createAssistantSession,
     createTask,
     deleteProject,
     updateProject,
@@ -69,6 +68,7 @@ import {
 import { EditLabelsModal } from "../components/EditLabelsModal";
 import { LabelDisplay } from "../components/LabelDisplay";
 import { ExecutionLogModal } from "../components/ExecutionLogModal";
+import { CreateSessionModal } from "../components/assistant/CreateSessionModal";
 import { ConfirmDeleteModal } from "../components/ConfirmDeleteModal";
 
 const STATUS_COLORS: Record<string, "blue" | "green" | "orange" | "grey" | "red"> = {
@@ -99,6 +99,7 @@ export function ProjectDetailPage() {
 
     // Trigger Action state
     const [isActionModalOpen, setIsActionModalOpen] = useState(false);
+    const [isAssistantModalOpen, setIsAssistantModalOpen] = useState(false);
     const [actionTypes, setActionTypes] = useState<ActionType[]>([]);
     const [selectedActionType, setSelectedActionType] = useState("");
     const [actionInput, setActionInput] = useState("");
@@ -224,13 +225,7 @@ export function ProjectDetailPage() {
                     <Button
                         variant="secondary"
                         icon={<ChatIcon />}
-                        onClick={() => {
-                            createAssistantSession("project-assistant", project.name, project.id)
-                                .then(session => {
-                                    window.open(`/assistant/${session.id}?breakout=true`, "_blank");
-                                })
-                                .catch(err => console.error("Failed to create project assistant session", err));
-                        }}
+                        onClick={() => setIsAssistantModalOpen(true)}
                         style={{ marginRight: "8px" }}
                     >
                         Assistant
@@ -418,6 +413,17 @@ export function ProjectDetailPage() {
                     </Button>
                 </ModalFooter>
             </Modal>
+
+            <CreateSessionModal
+                isOpen={isAssistantModalOpen}
+                onClose={() => setIsAssistantModalOpen(false)}
+                onSessionCreated={(session) => {
+                    setIsAssistantModalOpen(false);
+                    window.open(`/assistant/${session.id}?breakout=true`, "_blank");
+                }}
+                projectId={project.id}
+                defaultName={project.name}
+            />
 
             <ConfirmDeleteModal isOpen={isDeleteOpen} title="Delete Project"
                 onConfirm={() => {


### PR DESCRIPTION
## Summary

- Extract the template picker and session name modals from `AssistantPage` into a shared
  `CreateSessionModal` component
- Replace the hardcoded `project-assistant` template on the project detail page with the
  template picker, allowing users to choose any configured template for project sessions
- The backend already injects project context (workspace, system prompt, env vars, MCP tools)
  regardless of which template is used, so no backend changes are needed

## Test plan

- [ ] On the Assistant page, click "New Session" — verify the template picker and name modal
      work as before
- [ ] On a project detail page, click "Assistant" — verify the template picker appears with all
      templates, select one, name the session, and verify it opens in a breakout window
- [ ] Create a project session with the "General Assistant" template — verify project context
      is still injected (system prompt, workspace directory)
- [ ] Cancel the template picker — verify no session is created