### PR TITLE
Add missing response to SSE events endpoint (#73)

### DIFF
--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -3020,10 +3020,7 @@
         "operationId": "streamAssistantEvents",
         "responses": {
           "200": {
-            "description": "SSE event stream for the assistant session",
-            "content": {
-              "text/event-stream": {}
-            }
+            "description": "SSE event stream for the assistant session"
           }
         }
       },

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -3017,7 +3017,15 @@
           "Assistant"
         ],
         "summary": "SSE event stream for an assistant session",
-        "operationId": "streamAssistantEvents"
+        "operationId": "streamAssistantEvents",
+        "responses": {
+          "200": {
+            "description": "SSE event stream for the assistant session",
+            "content": {
+              "text/event-stream": {}
+            }
+          }
+        }
       },
       "parameters": [
         {


### PR DESCRIPTION
## Summary

- Add a `200` response with `text/event-stream` content type to the
  `GET /assistant/sessions/{sessionId}/events` operation in the OpenAPI spec.
- Resolves OP-007 validation error caused by the operation having no responses defined.

## Related Issue

Fixes #73

## Test Plan

- [ ] Run OpenAPI validation and confirm no OP-007 error on the `/assistant/sessions/{sessionId}/events` endpoint
- [ ] Run `mvn install` to regenerate JAX-RS interfaces and verify the build succeeds
- [ ] Verify the SSE endpoint continues to function correctly at runtime