### PR TITLE
Fix infinite re-render loop in AssistantMessageInput

### DIFF
--- a/ui/src/components/assistant/AssistantMessageInput.tsx
+++ b/ui/src/components/assistant/AssistantMessageInput.tsx
@@ -155,7 +155,7 @@ export function AssistantMessageInput({ onSend, disabled, slashCommands = [] }: 
                     <TextArea
                         ref={textAreaRef}
                         value={value}
-                        onChange={(_e, val) => setValue(val)}
+                        onChange={(_e, val) => { if (val !== value) setValue(val); }}
                         onKeyDown={handleKeyDown}
                         placeholder="Type a message... (/ for commands)"
                         aria-label="Message input"


### PR DESCRIPTION
## Summary

- Guard the `onChange` handler in `AssistantMessageInput` to skip `setValue` when the value hasn't
  changed, breaking the cycle between PatternFly's `autoResize` and the controlled state update

## Test plan

- [ ] Open the AI Assistant page and create a new session
- [ ] Send messages and receive responses with browser DevTools console open
- [ ] Confirm `Maximum update depth exceeded` error no longer appears
- [ ] Confirm the TextArea still auto-resizes when typing multi-line content

Fixes #80