### PR TITLE
Fix getAssistantItem to use standard untyped JSON response pattern

### DIFF
--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -3280,11 +3280,7 @@
           "200": {
             "description": "Item content",
             "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/FileContent"
-                }
-              }
+              "application/json": {}
             }
           }
         }
@@ -7009,11 +7005,6 @@
             "type": "string"
           }
         }
-      },
-      "FileContent": {
-        "format": "binary",
-        "type": "string",
-        "x-codegen-inline": true
       }
     },
     "responses": {


### PR DESCRIPTION
## Summary

- Replace the `*/*` + `FileContent` (binary string) schema on the `getAssistantItem` response
  with the established `"application/json": {}` pattern already used by `evaluateEvent`,
  `exportPack`, and `listActionTypeTools`
- Remove the now-unused `FileContent` schema definition from `components/schemas`
- No Java code changes needed — the implementation already returns `Response.ok(content).build()`

Fixes #72