### PR TITLE
Fix End Session dialog text for non-Config Assistant sessions

### DIFF
--- a/ui/src/pages/AssistantSessionPage.tsx
+++ b/ui/src/pages/AssistantSessionPage.tsx
@@ -355,8 +355,9 @@ export function AssistantSessionPage() {
             >
                 <ModalHeader title="End Session?" />
                 <ModalBody>
-                    This will terminate the AI assistant and delete all generated items
-                    that have not been applied. This action cannot be undone.
+                    {isConfigAssistant
+                        ? "This will terminate the AI assistant and delete all generated items that have not been applied. This action cannot be undone."
+                        : "This will terminate the AI assistant and delete the session. This action cannot be undone."}
                 </ModalBody>
                 <ModalFooter>
                     <Button variant="danger" onClick={handleEndSession}>


### PR DESCRIPTION
## Summary

- Fixes the End Session confirmation dialog on the session chat page to show template-appropriate
  text instead of always showing Config Assistant-specific text about "generated items"
- Config Assistant sessions keep the existing text; all other sessions now show
  "delete the session" (matching the session list page)

Closes #81

## Test plan

- [ ] Create a General Assistant session, click "End Session", confirm dialog says
  "delete the session" (not "generated items")
- [ ] Create a Config Assistant session, click "End Session", confirm dialog still says
  "delete all generated items that have not been applied"
- [ ] Verify both dialogs still function correctly (End Session deletes, Cancel dismisses)