### PR TITLE
Add Dark Mode support

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from "react";
-import { useTheme } from "./hooks/useTheme";
+import { useTheme, EffectiveThemeContext } from "./hooks/useTheme";
 import { Routes, Route, useLocation } from "react-router-dom";
 import { Page } from "@patternfly/react-core";
 
@@ -47,7 +47,7 @@ import { sseClient } from "./config/sse";
 
 export function App() {
     const location = useLocation();
-    const { mode: themeMode, setMode: setThemeMode } = useTheme();
+    const { mode: themeMode, effectiveTheme, setMode: setThemeMode } = useTheme();
     const [startupChecks, setStartupChecks] = useState<StartupCheck[] | null>(null);
     const [engineName, setEngineName] = useState<string | undefined>(undefined);
     const [appVersion, setAppVersion] = useState<string>("");
@@ -84,58 +84,60 @@ export function App() {
     const isBreakout = new URLSearchParams(location.search).get("breakout") === "true";
 
     return (
-        <Page
-            masthead={isBreakout ? undefined : <AppMasthead engineName={engineName} appVersion={appVersion} {...themeProps} />}
-            sidebar={hasCheckErrors || isAssistantPage || isBreakout ? undefined : <AppSidebar />}
-            isContentFilled
-            style={isBreakout ? {
-                paddingTop: 8,
-                "--pf-v6-c-page__sidebar--Width": "0px",
-                "--pf-v6-c-page__sidebar--xl--Width": "0px",
-            } as React.CSSProperties : undefined}
-        >
-            {hasCheckErrors ? (
-                <ConfigurationWarning checks={startupChecks!} />
-            ) : (
-                <Routes>
-                    <Route path="/" element={<DashboardPage />} />
-                    <Route path="/inbox" element={<InboxPage />} />
-                    <Route path="/projects" element={<ProjectsPage />} />
-                    <Route path="/projects/:projectId" element={<ProjectDetailPage />} />
-                    <Route path="/engine" element={<EngineSettingsPage />} />
-                    <Route path="/actors" element={<ActorsPage />} />
-                    <Route path="/actors/:actorId" element={<ActorDetailPage />} />
-                    <Route path="/manager" element={<ManagerConfigPage />} />
-                    <Route path="/action-types" element={<ActionTypesPage />} />
-                    <Route path="/action-types/:actionTypeId" element={<ActionTypeDetailPage />} />
-                    <Route path="/tools" element={<ToolsPage />} />
-                    <Route path="/tools/:toolId" element={<ToolDetailPage />} />
-                    <Route path="/toolsets" element={<ToolsetsPage />} />
-                    <Route path="/toolsets/:toolsetId" element={<ToolsetDetailPage />} />
-                    <Route path="/mcp-servers" element={<McpServersPage />} />
-                    <Route path="/mcp-servers/:mcpServerId" element={<McpServerDetailPage />} />
-                    <Route path="/logs/activity" element={<ActivityLogPage />} />
-                    <Route path="/logs/events" element={<EventsPage />} />
-                    <Route path="/logs/manager" element={<ManagerDecisionsPage />} />
-                    <Route path="/logs/tasks" element={<TasksPage />} />
-                    <Route path="/logs/traces" element={<TracesPage />} />
-                    <Route path="/logs/traces/:traceId" element={<TraceDetailPage />} />
-                    <Route path="/reports" element={<ReportsPage />} />
-                    <Route path="/reports/:reportId" element={<ReportDetailPage />} />
-                    <Route path="/report-definitions" element={<ReportDefinitionsPage />} />
-                    <Route path="/report-definitions/:definitionId" element={<ReportDefinitionDetailPage />} />
-                    <Route path="/metrics/ai-usage" element={<AiUsagePage />} />
-                    <Route path="/metrics/disk-usage" element={<DiskUsagePage />} />
-                    <Route path="/event-sources" element={<EventSourcesPage />} />
-                    <Route path="/event-sources/:eventSourceId" element={<EventSourceDetailPage />} />
-                    <Route path="/secrets" element={<SecretsPage />} />
-                    <Route path="/configuration-packs" element={<ConfigurationPacksPage />} />
-                    <Route path="/session-templates" element={<SessionTemplatesPage />} />
-                    <Route path="/session-templates/:templateId" element={<SessionTemplateDetailPage />} />
-                    <Route path="/assistant" element={<AssistantPage />} />
-                    <Route path="/assistant/:sessionId" element={<AssistantSessionPage />} />
-                </Routes>
-            )}
-        </Page>
+        <EffectiveThemeContext.Provider value={effectiveTheme}>
+            <Page
+                masthead={isBreakout ? undefined : <AppMasthead engineName={engineName} appVersion={appVersion} {...themeProps} />}
+                sidebar={hasCheckErrors || isAssistantPage || isBreakout ? undefined : <AppSidebar />}
+                isContentFilled
+                style={isBreakout ? {
+                    paddingTop: 8,
+                    "--pf-v6-c-page__sidebar--Width": "0px",
+                    "--pf-v6-c-page__sidebar--xl--Width": "0px",
+                } as React.CSSProperties : undefined}
+            >
+                {hasCheckErrors ? (
+                    <ConfigurationWarning checks={startupChecks!} />
+                ) : (
+                    <Routes>
+                        <Route path="/" element={<DashboardPage />} />
+                        <Route path="/inbox" element={<InboxPage />} />
+                        <Route path="/projects" element={<ProjectsPage />} />
+                        <Route path="/projects/:projectId" element={<ProjectDetailPage />} />
+                        <Route path="/engine" element={<EngineSettingsPage />} />
+                        <Route path="/actors" element={<ActorsPage />} />
+                        <Route path="/actors/:actorId" element={<ActorDetailPage />} />
+                        <Route path="/manager" element={<ManagerConfigPage />} />
+                        <Route path="/action-types" element={<ActionTypesPage />} />
+                        <Route path="/action-types/:actionTypeId" element={<ActionTypeDetailPage />} />
+                        <Route path="/tools" element={<ToolsPage />} />
+                        <Route path="/tools/:toolId" element={<ToolDetailPage />} />
+                        <Route path="/toolsets" element={<ToolsetsPage />} />
+                        <Route path="/toolsets/:toolsetId" element={<ToolsetDetailPage />} />
+                        <Route path="/mcp-servers" element={<McpServersPage />} />
+                        <Route path="/mcp-servers/:mcpServerId" element={<McpServerDetailPage />} />
+                        <Route path="/logs/activity" element={<ActivityLogPage />} />
+                        <Route path="/logs/events" element={<EventsPage />} />
+                        <Route path="/logs/manager" element={<ManagerDecisionsPage />} />
+                        <Route path="/logs/tasks" element={<TasksPage />} />
+                        <Route path="/logs/traces" element={<TracesPage />} />
+                        <Route path="/logs/traces/:traceId" element={<TraceDetailPage />} />
+                        <Route path="/reports" element={<ReportsPage />} />
+                        <Route path="/reports/:reportId" element={<ReportDetailPage />} />
+                        <Route path="/report-definitions" element={<ReportDefinitionsPage />} />
+                        <Route path="/report-definitions/:definitionId" element={<ReportDefinitionDetailPage />} />
+                        <Route path="/metrics/ai-usage" element={<AiUsagePage />} />
+                        <Route path="/metrics/disk-usage" element={<DiskUsagePage />} />
+                        <Route path="/event-sources" element={<EventSourcesPage />} />
+                        <Route path="/event-sources/:eventSourceId" element={<EventSourceDetailPage />} />
+                        <Route path="/secrets" element={<SecretsPage />} />
+                        <Route path="/configuration-packs" element={<ConfigurationPacksPage />} />
+                        <Route path="/session-templates" element={<SessionTemplatesPage />} />
+                        <Route path="/session-templates/:templateId" element={<SessionTemplateDetailPage />} />
+                        <Route path="/assistant" element={<AssistantPage />} />
+                        <Route path="/assistant/:sessionId" element={<AssistantSessionPage />} />
+                    </Routes>
+                )}
+            </Page>
+        </EffectiveThemeContext.Provider>
     );
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
+import { useTheme } from "./hooks/useTheme";
 import { Routes, Route, useLocation } from "react-router-dom";
 import { Page } from "@patternfly/react-core";
 
@@ -46,9 +47,11 @@ import { sseClient } from "./config/sse";
 
 export function App() {
     const location = useLocation();
+    const { mode: themeMode, setMode: setThemeMode } = useTheme();
     const [startupChecks, setStartupChecks] = useState<StartupCheck[] | null>(null);
     const [engineName, setEngineName] = useState<string | undefined>(undefined);
     const [appVersion, setAppVersion] = useState<string>("");
+    const themeProps = useMemo(() => ({ themeMode, setThemeMode }), [themeMode, setThemeMode]);
 
     useEffect(() => {
         fetchSystemHealth()
@@ -82,7 +85,7 @@ export function App() {
 
     return (
         <Page
-            masthead={isBreakout ? undefined : <AppMasthead engineName={engineName} appVersion={appVersion} />}
+            masthead={isBreakout ? undefined : <AppMasthead engineName={engineName} appVersion={appVersion} {...themeProps} />}
             sidebar={hasCheckErrors || isAssistantPage || isBreakout ? undefined : <AppSidebar />}
             isContentFilled
             style={isBreakout ? {

--- a/ui/src/axiom-theme.css
+++ b/ui/src/axiom-theme.css
@@ -1,0 +1,70 @@
+/* ============================================================
+   Axiom Theme — custom properties and utility classes
+   ============================================================ */
+
+/* --- Semantic custom properties (light defaults) --- */
+:root {
+    --axiom--color--warning--bg: #fdf7e7;
+    --axiom--color--warning--border: #f0d67b;
+    --axiom--color--warning--text: #795600;
+    --axiom--color--success--bg: #f3faf3;
+    --axiom--color--success--border: #c6e3c6;
+    --axiom--color--danger--bg: #fef3f2;
+    --axiom--color--orange--bg: #fffaf0;
+    --axiom--color--info--bg: #f0f8ff;
+
+    --axiom--color--brand: #0b2545;
+    --axiom--color--brand--accent: #2082a3;
+    --axiom--color--brand--gradient: linear-gradient(90deg, #0b2545, #1b6b93, #4fc0d0);
+}
+
+/* --- Dark-mode overrides --- */
+:root:where(.pf-v6-theme-dark) {
+    --axiom--color--warning--bg: #332800;
+    --axiom--color--warning--border: #6b5200;
+    --axiom--color--warning--text: #f0d67b;
+    --axiom--color--success--bg: #1a3a1a;
+    --axiom--color--success--border: #2d5f2d;
+    --axiom--color--danger--bg: #3d0f0f;
+    --axiom--color--orange--bg: #332200;
+    --axiom--color--info--bg: #0d1f30;
+
+    --axiom--color--brand: #8ecae6;
+    --axiom--color--brand--accent: #4fc0d0;
+    --axiom--color--brand--gradient: linear-gradient(90deg, #4fc0d0, #1b6b93, #8ecae6);
+}
+
+/* --- Utility classes --- */
+
+.axiom-text-subtle {
+    color: var(--pf-t--global--text--color--subtle, #6a6e73);
+}
+
+.axiom-text-default {
+    color: var(--pf-t--global--text--color--regular, #151515);
+}
+
+.axiom-icon-danger {
+    color: var(--pf-t--global--color--status--danger--default, #c9190b);
+}
+
+.axiom-icon-warning {
+    color: var(--pf-t--global--color--status--warning--default, #f0ab00);
+}
+
+.axiom-icon-success {
+    color: var(--pf-t--global--color--status--success--default, #3e8635);
+}
+
+.axiom-icon-disabled {
+    color: var(--pf-t--global--color--status--disabled--default, #8a8d90);
+}
+
+.axiom-generated-item-card {
+    background-color: var(--pf-t--global--background--color--secondary--default, #fafafa);
+    border: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
+}
+
+.axiom-generated-item-card:hover {
+    background-color: var(--pf-t--global--background--color--tertiary--default, #f0f0f0);
+}

--- a/ui/src/components/ActionTypeAiModal.tsx
+++ b/ui/src/components/ActionTypeAiModal.tsx
@@ -97,7 +97,7 @@ export function ActionTypeAiModal({
                         ))}
                     </div>
                 ) : (
-                    <div style={{ color: "#6a6e73", fontSize: "13px" }}>
+                    <div className="axiom-text-subtle" style={{ fontSize: "13px" }}>
                         No tools configured. Ask the AI to recommend tools.
                     </div>
                 )}
@@ -106,7 +106,7 @@ export function ActionTypeAiModal({
                 <Title headingLevel="h4" size="md">
                     Prompt Template
                 </Title>
-                <div style={{ color: "#6a6e73", fontSize: "13px", marginTop: "2px" }}>
+                <div className="axiom-text-subtle" style={{ fontSize: "13px", marginTop: "2px" }}>
                     Placeholders:{" "}
                     <code>{"{{managerInput}}"}</code>,{" "}
                     <code>{"{{issueRef}}"}</code>,{" "}

--- a/ui/src/components/AiEditModal.tsx
+++ b/ui/src/components/AiEditModal.tsx
@@ -103,8 +103,8 @@ export function AiEditModal({
                                 gap: "12px",
                             }}>
                                 {messages.length === 0 && (
-                                    <div style={{
-                                        color: "#6a6e73", fontSize: "13px", textAlign: "center",
+                                    <div className="axiom-text-subtle" style={{
+                                        fontSize: "13px", textAlign: "center",
                                         marginTop: "32px",
                                     }}>
                                         {emptyHint}
@@ -119,7 +119,7 @@ export function AiEditModal({
                                         backgroundColor: msg.role === "user"
                                             ? "var(--pf-t--global--color--brand--default)"
                                             : "var(--pf-t--global--background--color--secondary--default)",
-                                        color: msg.role === "user" ? "white" : "inherit",
+                                        color: msg.role === "user" ? "var(--pf-t--global--background--color--primary--default, #fff)" : "inherit",
                                         fontSize: "13px",
                                     }}>
                                         {msg.role === "assistant" ? (
@@ -130,13 +130,12 @@ export function AiEditModal({
                                     </div>
                                 ))}
                                 {loading && (
-                                    <div style={{
+                                    <div className="axiom-text-subtle" style={{
                                         alignSelf: "flex-start",
                                         padding: "8px 12px",
                                         borderRadius: "8px",
                                         backgroundColor: "var(--pf-t--global--background--color--secondary--default)",
                                         fontSize: "13px",
-                                        color: "#6a6e73",
                                     }}>
                                         <Spinner size="sm" style={{ marginRight: "5px" }} />
                                         Thinking...

--- a/ui/src/components/AppMasthead.css
+++ b/ui/src/components/AppMasthead.css
@@ -34,7 +34,7 @@
     }
     50% {
         transform: scale(2);
-        color: #cc6600;
+        color: var(--pf-t--global--color--nonstatus--orange--default, #cc6600);
     }
 }
 

--- a/ui/src/components/AppMasthead.css
+++ b/ui/src/components/AppMasthead.css
@@ -1,7 +1,36 @@
+.axiom-masthead {
+    position: relative;
+    border-bottom: none;
+    box-shadow: none;
+    background: var(--pf-t--global--background--color--primary--default, #fff);
+    margin-bottom: 6px;
+}
+
+.axiom-masthead__brand-text {
+    font-size: 20px;
+    font-weight: 600;
+    color: var(--axiom--color--brand, #0b2545);
+    cursor: pointer;
+    letter-spacing: -0.5px;
+}
+
+.axiom-masthead__icon {
+    color: var(--axiom--color--brand--accent, #2082a3);
+}
+
+.axiom-masthead__gradient-bar {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: var(--axiom--color--brand--gradient);
+}
+
 @keyframes axiom-throb {
     0%, 100% {
         transform: scale(1);
-        color: #2082a3;
+        color: var(--axiom--color--brand--accent, #2082a3);
     }
     50% {
         transform: scale(2);
@@ -16,5 +45,5 @@
 .axiom-assistant-throb:hover svg {
     animation: none;
     transform: scale(1.3);
-    color: #0066cc;
+    color: var(--pf-t--global--color--link--default, #0066cc);
 }

--- a/ui/src/components/AppMasthead.tsx
+++ b/ui/src/components/AppMasthead.tsx
@@ -16,29 +16,52 @@ import {
 } from "@patternfly/react-core";
 import QuestionCircleIcon from "@patternfly/react-icons/dist/esm/icons/question-circle-icon";
 import RobotIcon from "@patternfly/react-icons/dist/esm/icons/robot-icon";
+import SunIcon from "@patternfly/react-icons/dist/esm/icons/sun-icon";
+import MoonIcon from "@patternfly/react-icons/dist/esm/icons/moon-icon";
+import DesktopIcon from "@patternfly/react-icons/dist/esm/icons/desktop-icon";
+import { type ThemeMode } from "../hooks/useTheme";
 
 interface AppMastheadProps {
     engineName?: string;
     appVersion: string;
+    themeMode: ThemeMode;
+    setThemeMode: (mode: ThemeMode) => void;
 }
 
-export function AppMasthead({ engineName, appVersion }: AppMastheadProps) {
+const THEME_CYCLE: ThemeMode[] = ["light", "dark", "system"];
+
+/**
+ * Returns the icon and tooltip label for the current theme mode.
+ */
+function themeDisplay(mode: ThemeMode) {
+    switch (mode) {
+        case "light":
+            return { icon: <SunIcon />, label: "Theme: Light (click for Dark)" };
+        case "dark":
+            return { icon: <MoonIcon />, label: "Theme: Dark (click for System)" };
+        case "system":
+            return { icon: <DesktopIcon />, label: "Theme: System (click for Light)" };
+    }
+}
+
+export function AppMasthead({ engineName, appVersion, themeMode, setThemeMode }: AppMastheadProps) {
     const navigate = useNavigate();
     const [isAboutOpen, setIsAboutOpen] = useState(false);
+    const { icon: themeIcon, label: themeLabel } = themeDisplay(themeMode);
+
+    const cycleTheme = () => {
+        const currentIndex = THEME_CYCLE.indexOf(themeMode);
+        const nextIndex = (currentIndex + 1) % THEME_CYCLE.length;
+        setThemeMode(THEME_CYCLE[nextIndex]);
+    };
 
     return (
         <>
-            <Masthead style={{
-                position: "relative",
-                borderBottom: "none",
-                boxShadow: "none",
-                background: "white",
-                marginBottom: "6px",
-            }}>
+            <Masthead className="axiom-masthead">
                 <MastheadMain>
                     <MastheadBrand>
                         <span
-                            style={{ fontSize: "20px", fontWeight: 600, color: "#0b2545", cursor: "pointer", letterSpacing: "-0.5px" }}
+                            className="axiom-masthead__brand-text"
                             onClick={() => navigate("/")}>Apitomy Axiom</span>
                     </MastheadBrand>
                 </MastheadMain>
@@ -57,30 +80,31 @@ export function AppMasthead({ engineName, appVersion }: AppMastheadProps) {
                                                 localStorage.getItem("axiom.assistant.discovered")
                                                     ? undefined : "axiom-assistant-throb"
                                             }>
-                                            <RobotIcon style={{ color: "#2082a3", transform: "scale(1.25)" }} />
+                                            <RobotIcon className="axiom-masthead__icon" style={{ transform: "scale(1.25)" }} />
                                         </Button>
                                     </Tooltip>
                                 )}
                             </ToolbarItem>
                             <ToolbarItem>
+                                <Tooltip content={themeLabel}>
+                                    <Button variant="plain" aria-label="Toggle theme"
+                                        onClick={cycleTheme}>
+                                        <span className="axiom-masthead__icon">{themeIcon}</span>
+                                    </Button>
+                                </Tooltip>
+                            </ToolbarItem>
+                            <ToolbarItem>
                                 <Tooltip content="About Axiom">
                                     <Button variant="plain" aria-label="About"
                                         onClick={() => setIsAboutOpen(true)}>
-                                        <QuestionCircleIcon style={{ color: "#2082a3" }} />
+                                        <QuestionCircleIcon className="axiom-masthead__icon" />
                                     </Button>
                                 </Tooltip>
                             </ToolbarItem>
                         </ToolbarContent>
                     </Toolbar>
                 </MastheadContent>
-                <div style={{
-                    position: "absolute",
-                    bottom: 0,
-                    left: 0,
-                    right: 0,
-                    height: "3px",
-                    background: "linear-gradient(90deg, #0b2545, #1b6b93, #4fc0d0)",
-                }} />
+                <div className="axiom-masthead__gradient-bar" />
             </Masthead>
 
             <AboutModal

--- a/ui/src/components/BrowseToolsModal.tsx
+++ b/ui/src/components/BrowseToolsModal.tsx
@@ -113,7 +113,7 @@ export function BrowseToolsModal({ isOpen, onClose, onSave, existingTools }: Bro
         return (
             <div key={entry.value} style={{
                 padding: "6px 8px",
-                borderBottom: "1px solid #f0f0f0",
+                borderBottom: "1px solid var(--pf-t--global--border--color--default, #d2d2d2)",
             }}>
                 <Checkbox
                     id={`browse-${entry.value}`}
@@ -129,7 +129,7 @@ export function BrowseToolsModal({ isOpen, onClose, onSave, existingTools }: Bro
                                 {entry.label}
                             </span>
                             {entry.description && (
-                                <span style={{ color: "#6a6e73", fontSize: "12px", marginLeft: 8 }}>
+                                <span className="axiom-text-subtle" style={{ fontSize: "12px", marginLeft: 8 }}>
                                     — {entry.description}
                                 </span>
                             )}
@@ -193,7 +193,7 @@ export function BrowseToolsModal({ isOpen, onClose, onSave, existingTools }: Bro
                 )}
 
                 {filteredToolsets.length === 0 && filteredCustom.length === 0 && filteredSdk.length === 0 && (
-                    <div style={{ padding: 24, textAlign: "center", color: "#6a6e73" }}>
+                    <div className="axiom-text-subtle" style={{ padding: 24, textAlign: "center" }}>
                         No tools match the filter.
                     </div>
                 )}

--- a/ui/src/components/ConfigurationWarning.tsx
+++ b/ui/src/components/ConfigurationWarning.tsx
@@ -30,7 +30,7 @@ export function ConfigurationWarning({ checks }: ConfigurationWarningProps) {
                 <Title headingLevel="h1" size="xl" style={{ marginBottom: "8px" }}>
                     Application Configuration Required
                 </Title>
-                <p style={{ color: "#6a6e73", marginBottom: "24px" }}>
+                <p className="axiom-text-subtle" style={{ marginBottom: "24px" }}>
                     Apitomy Axiom detected configuration issues during startup.
                     Please resolve the items below and restart the application.
                 </p>
@@ -73,7 +73,7 @@ export function ConfigurationWarning({ checks }: ConfigurationWarningProps) {
                         <table style={{ width: "100%", borderCollapse: "collapse" }}>
                             <tbody>
                                 {checks.map((check) => (
-                                    <tr key={check.name} style={{ borderBottom: "1px solid #d2d2d2" }}>
+                                    <tr key={check.name} style={{ borderBottom: "1px solid var(--pf-t--global--border--color--default, #d2d2d2)" }}>
                                         <td style={{ padding: "12px 8px", width: "32px" }}>
                                             {check.status === "ok" ? (
                                                 <CheckCircleIcon color="var(--pf-t--global--color--status--success--default)" />
@@ -86,7 +86,7 @@ export function ConfigurationWarning({ checks }: ConfigurationWarningProps) {
                                         <td style={{ padding: "12px 8px", fontWeight: "bold" }}>
                                             {check.name}
                                         </td>
-                                        <td style={{ padding: "12px 8px", color: "#6a6e73" }}>
+                                        <td className="axiom-text-subtle" style={{ padding: "12px 8px" }}>
                                             {check.status === "ok" ? "Configured" : check.message}
                                         </td>
                                     </tr>

--- a/ui/src/components/EditLabelsModal.tsx
+++ b/ui/src/components/EditLabelsModal.tsx
@@ -50,7 +50,7 @@ export function EditLabelsModal({ isOpen, labels, onSave, onClose }: {
             aria-label="Edit Labels">
             <ModalHeader title="Edit Labels" />
             <ModalBody>
-                <p style={{ color: "#6a6e73", marginBottom: "16px" }}>
+                <p className="axiom-text-subtle" style={{ marginBottom: "16px" }}>
                     Type a label and press Enter to add it. Click the X on a label to remove it.
                 </p>
                 <LabelInput labels={draft} onChange={setDraft} />

--- a/ui/src/components/EnvironmentTab.tsx
+++ b/ui/src/components/EnvironmentTab.tsx
@@ -45,7 +45,7 @@ export function EnvironmentTab({ envVars, onChange }: {
 
     return (
         <div style={{ maxWidth: "700px" }}>
-            <p style={{ color: "#6a6e73", marginBottom: "16px" }}>
+            <p className="axiom-text-subtle" style={{ marginBottom: "16px" }}>
                 Custom environment variables injected into the subprocess. When configured,
                 these replace the default all-secrets injection. Reference an encrypted secret
                 using <code>{"${secret:SECRET_NAME}"}</code> syntax.

--- a/ui/src/components/LabelDisplay.tsx
+++ b/ui/src/components/LabelDisplay.tsx
@@ -19,7 +19,7 @@ export function LabelDisplay({ labels, onEdit }: {
                     ))}
                 </div>
             ) : (
-                <span style={{ color: "#6a6e73", fontStyle: "italic" }}>No labels</span>
+                <span className="axiom-text-subtle" style={{ fontStyle: "italic" }}>No labels</span>
             )}
             <Button variant="plain" size="sm" style={{ padding: 0 }}
                 onClick={onEdit} aria-label="Edit labels">

--- a/ui/src/components/RenderedReport.css
+++ b/ui/src/components/RenderedReport.css
@@ -41,7 +41,7 @@
     border-left: 4px solid var(--pf-t--global--border--color--default);
     margin: 12px 0;
     padding: 8px 16px;
-    color: #6a6e73;
+    color: var(--pf-t--global--text--color--subtle, #6a6e73);
 }
 
 .axiom-rendered-report h1 {

--- a/ui/src/components/ReportAiModal.tsx
+++ b/ui/src/components/ReportAiModal.tsx
@@ -99,7 +99,7 @@ export function ReportAiModal({
                         ))}
                     </div>
                 ) : (
-                    <div style={{ color: "#6a6e73", fontSize: "13px" }}>
+                    <div className="axiom-text-subtle" style={{ fontSize: "13px" }}>
                         No tools configured. Ask the AI to recommend tools.
                     </div>
                 )}
@@ -108,7 +108,7 @@ export function ReportAiModal({
                 <Title headingLevel="h4" size="md">
                     Prompt Template
                 </Title>
-                <div style={{ color: "#6a6e73", fontSize: "13px", marginTop: "2px" }}>
+                <div className="axiom-text-subtle" style={{ fontSize: "13px", marginTop: "2px" }}>
                     Placeholders:{" "}
                     <code>{"{{repositories}}"}</code>,{" "}
                     <code>{"{{timeRangeStart}}"}</code>,{" "}

--- a/ui/src/components/ScriptAiModal.tsx
+++ b/ui/src/components/ScriptAiModal.tsx
@@ -59,7 +59,7 @@ export function ScriptAiModal({
                 <Title headingLevel="h4" size="md">
                     Script Template
                 </Title>
-                <div style={{ color: "#6a6e73", fontSize: "13px", marginTop: "4px" }}>
+                <div className="axiom-text-subtle" style={{ fontSize: "13px", marginTop: "4px" }}>
                     Available placeholders:{" "}
                     <code>{"{{projectId}}"}</code>,{" "}
                     <code>{"{{eventId}}"}</code>,{" "}

--- a/ui/src/components/ToolAiModal.tsx
+++ b/ui/src/components/ToolAiModal.tsx
@@ -97,7 +97,7 @@ export function ToolAiModal({ isOpen, form, params, onApply, onClose }: ToolAiMo
                         </Table>
                     </div>
                 ) : (
-                    <div style={{ color: "#6a6e73", fontSize: "13px" }}>
+                    <div className="axiom-text-subtle" style={{ fontSize: "13px" }}>
                         No parameters defined yet. Ask the AI to create them.
                     </div>
                 )}

--- a/ui/src/components/ToolListEditor.tsx
+++ b/ui/src/components/ToolListEditor.tsx
@@ -23,7 +23,7 @@ export function ToolListEditor({ tools, onAdd, onRemove, onReplace, helpText, em
     return (
         <div style={{ maxWidth: "700px" }}>
             {helpText && (
-                <p style={{ color: "#6a6e73", marginBottom: "16px" }}>
+                <p className="axiom-text-subtle" style={{ marginBottom: "16px" }}>
                     {helpText}
                 </p>
             )}

--- a/ui/src/components/TraceGraph.tsx
+++ b/ui/src/components/TraceGraph.tsx
@@ -79,7 +79,9 @@ async function layoutTrace(traceNodes: TraceNode[]): Promise<{
             target: targetId,
             type: "smoothstep",
             style: {
-                stroke: targetNode?.status === "failed" ? "#c9190b" : "#8a8d90",
+                stroke: targetNode?.status === "failed"
+                    ? "var(--pf-t--global--color--status--danger--default, #c9190b)"
+                    : "var(--pf-t--global--color--status--disabled--default, #8a8d90)",
                 strokeWidth: 2,
             },
             animated: targetNode?.status === "in-progress",

--- a/ui/src/components/TraceGraph.tsx
+++ b/ui/src/components/TraceGraph.tsx
@@ -13,6 +13,7 @@ import {
 import "@xyflow/react/dist/style.css";
 import ELK from "elkjs/lib/elk.bundled.js";
 import { EmptyState, EmptyStateBody } from "@patternfly/react-core";
+import { useEffectiveTheme } from "../hooks/useTheme";
 import { fetchTraceDetail, type TraceDetail, type TraceNode } from "../config/api";
 import { nodeTypes } from "./TraceGraphNode";
 import { TraceNodeDetailModal } from "./TraceNodeDetailModal";
@@ -92,6 +93,7 @@ async function layoutTrace(traceNodes: TraceNode[]): Promise<{
 }
 
 function TraceGraphInner({ traceId, traceDetail, refreshKey }: TraceGraphProps) {
+    const effectiveTheme = useEffectiveTheme();
     const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
     const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
     const [loading, setLoading] = useState(true);
@@ -147,7 +149,7 @@ function TraceGraphInner({ traceId, traceDetail, refreshKey }: TraceGraphProps) 
                 fitView
                 nodesConnectable={false}
                 nodesDraggable={false}
-                colorMode="system"
+                colorMode={effectiveTheme}
             >
                 <Background />
                 <Controls />

--- a/ui/src/components/TraceGraphNode.css
+++ b/ui/src/components/TraceGraphNode.css
@@ -11,7 +11,7 @@
 }
 
 .axiom-trace-graph-node:hover {
-    box-shadow: 0 3px 12px rgba(0, 0, 0, 0.25);
+    box-shadow: 0 3px 12px var(--pf-t--global--box-shadow--color--200, rgba(0, 0, 0, 0.25));
 }
 
 .axiom-trace-graph-node[data-status="completed"] {
@@ -20,7 +20,7 @@
 .axiom-trace-graph-node[data-status="failed"],
 .axiom-trace-graph-node[data-status="failure"] {
     border-color: var(--pf-t--global--color--status--danger--default, #c9190b);
-    background: rgba(201, 25, 11, 0.07);
+    background: var(--axiom--color--danger--bg, #fef3f2);
 }
 .axiom-trace-graph-node[data-status="in-progress"] {
     border-color: var(--pf-t--global--color--status--info--default, #06c);

--- a/ui/src/components/ValidationProblemsPanel.tsx
+++ b/ui/src/components/ValidationProblemsPanel.tsx
@@ -21,17 +21,17 @@ export function ValidationProblemsPanel({ messages }: {
                     marginBottom: 4,
                     borderRadius: 4,
                     backgroundColor: msg.severity === "error"
-                        ? "#fef3f2" : "#fdf7e7",
+                        ? "var(--axiom--color--danger--bg)" : "var(--axiom--color--warning--bg)",
                     border: `1px solid ${msg.severity === "error"
-                        ? "#c9190b" : "#f0ab00"}`,
+                        ? "var(--pf-t--global--color--status--danger--default, #c9190b)" : "var(--pf-t--global--color--status--warning--default, #f0ab00)"}`,
                 }}>
                     {msg.severity === "error"
-                        ? <ExclamationCircleIcon style={{ color: "#c9190b", marginTop: 2 }} />
-                        : <ExclamationTriangleIcon style={{ color: "#f0ab00", marginTop: 2 }} />
+                        ? <ExclamationCircleIcon className="axiom-icon-danger" style={{ marginTop: 2 }} />
+                        : <ExclamationTriangleIcon className="axiom-icon-warning" style={{ marginTop: 2 }} />
                     }
                     <div>
                         <div style={{ fontSize: "13px" }}>{msg.message}</div>
-                        <div style={{ fontSize: "12px", color: "#6a6e73", marginTop: 2 }}>
+                        <div className="axiom-text-subtle" style={{ fontSize: "12px", marginTop: 2 }}>
                             Field: <code>{msg.field}</code>
                         </div>
                     </div>

--- a/ui/src/components/assistant/ActionTypeDetailModal.tsx
+++ b/ui/src/components/assistant/ActionTypeDetailModal.tsx
@@ -137,7 +137,7 @@ export function ActionTypeDetailModal({ isOpen, onClose, name, content, errors }
                     {(errors?.length ?? 0) > 0 && (
                         <Tab eventKey={2} title={
                             <TabTitleText>
-                                <ExclamationCircleIcon style={{ color: "#c9190b", marginRight: 6 }} />
+                                <ExclamationCircleIcon className="axiom-icon-danger" style={{ marginRight: 6 }} />
                                 Problems ({errors!.length})
                             </TabTitleText>
                         }>

--- a/ui/src/components/assistant/AssistantAskUserQuestion.tsx
+++ b/ui/src/components/assistant/AssistantAskUserQuestion.tsx
@@ -99,7 +99,7 @@ export function AssistantAskUserQuestion({
     return (
         <div style={{
             padding: "8px 12px",
-            backgroundColor: "#f0f8ff",
+            backgroundColor: "var(--axiom--color--info--bg)",
         }}>
             <ExpandableSection
                 toggleContent={
@@ -108,7 +108,7 @@ export function AssistantAskUserQuestion({
                             Question
                         </Label>
                         {resolved && summaryText && (
-                            <span style={{ fontSize: "13px", color: "#6a6e73" }}>
+                            <span className="axiom-text-subtle" style={{ fontSize: "13px" }}>
                                 {summaryText}
                             </span>
                         )}
@@ -126,11 +126,10 @@ export function AssistantAskUserQuestion({
                 {questions.map((q, qIdx) => (
                     <div key={qIdx} style={{ marginBottom: qIdx < questions.length - 1 ? 16 : 8 }}>
                         {q.header && (
-                            <div style={{
+                            <div className="axiom-text-subtle" style={{
                                 fontSize: "11px",
                                 fontWeight: 600,
                                 textTransform: "uppercase",
-                                color: "#6a6e73",
                                 marginBottom: 4,
                             }}>
                                 {q.header}
@@ -154,7 +153,7 @@ export function AssistantAskUserQuestion({
                                                     <span>
                                                         {opt.label}
                                                         {opt.description && (
-                                                            <span style={{ color: "#6a6e73", marginLeft: 6, fontSize: "13px" }}>
+                                                            <span className="axiom-text-subtle" style={{ marginLeft: 6, fontSize: "13px" }}>
                                                                 — {opt.description}
                                                             </span>
                                                         )}
@@ -186,7 +185,7 @@ export function AssistantAskUserQuestion({
                                                 <span>
                                                     {opt.label}
                                                     {opt.description && (
-                                                        <span style={{ color: "#6a6e73", marginLeft: 6, fontSize: "13px" }}>
+                                                        <span className="axiom-text-subtle" style={{ marginLeft: 6, fontSize: "13px" }}>
                                                             — {opt.description}
                                                         </span>
                                                     )}

--- a/ui/src/components/assistant/AssistantGeneratedItems.tsx
+++ b/ui/src/components/assistant/AssistantGeneratedItems.tsx
@@ -76,11 +76,10 @@ export function AssistantGeneratedItems({ sessionId, refreshTrigger, onItemCount
 
     return (
         <div style={{ padding: "16px", height: "100%", overflow: "auto" }}>
-            <div style={{
+            <div className="axiom-text-default" style={{
                 fontWeight: 600,
                 fontSize: "14px",
                 marginBottom: "12px",
-                color: "#151515",
             }}>
                 Generated Items ({items.length})
             </div>
@@ -108,6 +107,7 @@ export function AssistantGeneratedItems({ sessionId, refreshTrigger, onItemCount
                     <div
                         key={`${item.type}/${item.name}`}
                         onClick={() => handleItemClick(item)}
+                        className="axiom-generated-item-card"
                         style={{
                             display: "flex",
                             alignItems: "center",
@@ -116,14 +116,6 @@ export function AssistantGeneratedItems({ sessionId, refreshTrigger, onItemCount
                             marginBottom: "4px",
                             borderRadius: "6px",
                             cursor: "pointer",
-                            backgroundColor: "#fafafa",
-                            border: "1px solid #d2d2d2",
-                        }}
-                        onMouseEnter={(e) => {
-                            e.currentTarget.style.backgroundColor = "#f0f0f0";
-                        }}
-                        onMouseLeave={(e) => {
-                            e.currentTarget.style.backgroundColor = "#fafafa";
                         }}
                     >
                         <Label isCompact color={typeInfo.color}>
@@ -131,12 +123,12 @@ export function AssistantGeneratedItems({ sessionId, refreshTrigger, onItemCount
                         </Label>
                         <span style={{ flex: 1, fontSize: "13px" }}>{item.name}</span>
                         {item.valid ? (
-                            <CheckCircleIcon style={{ color: "#3e8635" }} />
+                            <CheckCircleIcon className="axiom-icon-success" />
                         ) : (
                             <Tooltip content={
                                 `${(item.validationErrors || []).length} validation error(s)`
                             }>
-                                <ExclamationCircleIcon style={{ color: "#c9190b" }} />
+                                <ExclamationCircleIcon className="axiom-icon-danger" />
                             </Tooltip>
                         )}
                     </div>

--- a/ui/src/components/assistant/AssistantMessageInput.css
+++ b/ui/src/components/assistant/AssistantMessageInput.css
@@ -20,7 +20,7 @@
     background-color: var(--pf-t--global--background--color--primary--default, #fff);
     border: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
     border-radius: 6px;
-    box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 -4px 12px var(--pf-t--global--box-shadow--color--100, rgba(0, 0, 0, 0.1));
     z-index: 100;
     margin-bottom: 4px;
 }

--- a/ui/src/components/assistant/AssistantToolUseBlock.css
+++ b/ui/src/components/assistant/AssistantToolUseBlock.css
@@ -1,13 +1,3 @@
-:root {
-    --axiom--color--warning--bg: #fdf7e7;
-    --axiom--color--warning--border: #f0d67b;
-    --axiom--color--warning--text: #795600;
-    --axiom--color--success--bg: #f3faf3;
-    --axiom--color--success--border: #c6e3c6;
-    --axiom--color--danger--bg: #fef3f2;
-    --axiom--color--orange--bg: #fffaf0;
-}
-
 /* Block wrapper */
 .axiom-tool-use {
     margin: 4px 0;

--- a/ui/src/components/assistant/AssistantToolUseBlock.tsx
+++ b/ui/src/components/assistant/AssistantToolUseBlock.tsx
@@ -18,6 +18,8 @@ import { Light as SyntaxHighlighter } from "react-syntax-highlighter";
 import json from "react-syntax-highlighter/dist/esm/languages/hljs/json";
 import bash from "react-syntax-highlighter/dist/esm/languages/hljs/bash";
 import { stackoverflowLight } from "react-syntax-highlighter/dist/esm/styles/hljs";
+import { stackoverflowDark } from "react-syntax-highlighter/dist/esm/styles/hljs";
+import { useEffectiveTheme } from "../../hooks/useTheme";
 import { AssistantAskUserQuestion } from "./AssistantAskUserQuestion";
 import "./AssistantToolUseBlock.css";
 
@@ -53,6 +55,8 @@ export function AssistantToolUseBlock({
     permissionId, permissionResolved, permissionAllowed, onPermissionRespond,
     onCreateAutoApproval,
 }: AssistantToolUseBlockProps) {
+    const effectiveTheme = useEffectiveTheme();
+    const syntaxStyle = effectiveTheme === "dark" ? stackoverflowDark : stackoverflowLight;
     const [isExpanded, setIsExpanded] = useState(false);
     const [showPatternUI, setShowPatternUI] = useState(false);
     const [customPattern, setCustomPattern] = useState("");
@@ -97,7 +101,7 @@ export function AssistantToolUseBlock({
                             <div className="axiom-tool-use__code">
                                 <SyntaxHighlighter
                                     language="json"
-                                    style={stackoverflowLight}
+                                    style={syntaxStyle}
                                     wrapLongLines
                                 >
                                     {JSON.stringify(input, null, 2)}
@@ -113,7 +117,7 @@ export function AssistantToolUseBlock({
                             <div className={`axiom-tool-use__code${isError ? " axiom-tool-use__code--error" : ""}`}>
                                 <SyntaxHighlighter
                                     language={isJson(result) ? "json" : "bash"}
-                                    style={stackoverflowLight}
+                                    style={syntaxStyle}
                                     wrapLongLines
                                 >
                                     {isJson(result) ? formatJson(result) : result}

--- a/ui/src/components/assistant/ReportDefinitionDetailModal.tsx
+++ b/ui/src/components/assistant/ReportDefinitionDetailModal.tsx
@@ -132,7 +132,7 @@ export function ReportDefinitionDetailModal({
                     {(errors?.length ?? 0) > 0 && (
                         <Tab eventKey={2} title={
                             <TabTitleText>
-                                <ExclamationCircleIcon style={{ color: "#c9190b", marginRight: 6 }} />
+                                <ExclamationCircleIcon className="axiom-icon-danger" style={{ marginRight: 6 }} />
                                 Problems ({errors!.length})
                             </TabTitleText>
                         }>

--- a/ui/src/components/assistant/SessionTemplateDetailModal.tsx
+++ b/ui/src/components/assistant/SessionTemplateDetailModal.tsx
@@ -118,7 +118,7 @@ export function SessionTemplateDetailModal({ isOpen, onClose, name, content, err
                     {(errors?.length ?? 0) > 0 && (
                         <Tab eventKey={2} title={
                             <TabTitleText>
-                                <ExclamationCircleIcon style={{ color: "#c9190b", marginRight: 6 }} />
+                                <ExclamationCircleIcon className="axiom-icon-danger" style={{ marginRight: 6 }} />
                                 Problems ({errors!.length})
                             </TabTitleText>
                         }>

--- a/ui/src/components/assistant/ToolDetailModal.tsx
+++ b/ui/src/components/assistant/ToolDetailModal.tsx
@@ -88,7 +88,7 @@ export function ToolDetailModal({ isOpen, onClose, name, content, errors }: Tool
                                     </DescriptionList>
                                     <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "13px" }}>
                                         <thead>
-                                            <tr style={{ borderBottom: "2px solid #d2d2d2" }}>
+                                            <tr style={{ borderBottom: "2px solid var(--pf-t--global--border--color--default, #d2d2d2)" }}>
                                                 <th style={{ textAlign: "left", padding: "6px 8px" }}>Name</th>
                                                 <th style={{ textAlign: "left", padding: "6px 8px" }}>Type</th>
                                                 <th style={{ textAlign: "left", padding: "6px 8px" }}>Description</th>
@@ -97,7 +97,7 @@ export function ToolDetailModal({ isOpen, onClose, name, content, errors }: Tool
                                         </thead>
                                         <tbody>
                                             {parameters.map((p) => (
-                                                <tr key={p.name} style={{ borderBottom: "1px solid #d2d2d2" }}>
+                                                <tr key={p.name} style={{ borderBottom: "1px solid var(--pf-t--global--border--color--default, #d2d2d2)" }}>
                                                     <td style={{ padding: "6px 8px", fontFamily: "monospace" }}>{p.name}</td>
                                                     <td style={{ padding: "6px 8px" }}>{p.type || "string"}</td>
                                                     <td style={{ padding: "6px 8px" }}>{p.description || "—"}</td>
@@ -126,7 +126,7 @@ export function ToolDetailModal({ isOpen, onClose, name, content, errors }: Tool
                     {(errors?.length ?? 0) > 0 && (
                         <Tab eventKey={2} title={
                             <TabTitleText>
-                                <ExclamationCircleIcon style={{ color: "#c9190b", marginRight: 6 }} />
+                                <ExclamationCircleIcon className="axiom-icon-danger" style={{ marginRight: 6 }} />
                                 Problems ({errors!.length})
                             </TabTitleText>
                         }>

--- a/ui/src/components/assistant/ToolsetDetailModal.tsx
+++ b/ui/src/components/assistant/ToolsetDetailModal.tsx
@@ -86,7 +86,7 @@ export function ToolsetDetailModal({ isOpen, onClose, name, content, errors }: T
                     {(errors?.length ?? 0) > 0 && (
                         <Tab eventKey={2} title={
                             <TabTitleText>
-                                <ExclamationCircleIcon style={{ color: "#c9190b", marginRight: 6 }} />
+                                <ExclamationCircleIcon className="axiom-icon-danger" style={{ marginRight: 6 }} />
                                 Problems ({errors!.length})
                             </TabTitleText>
                         }>

--- a/ui/src/components/assistant/ValidationProblemsTab.tsx
+++ b/ui/src/components/assistant/ValidationProblemsTab.tsx
@@ -17,10 +17,10 @@ export function ValidationProblemsTab({ errors = [], warnings = [] }: Validation
                     padding: "10px 12px",
                     marginBottom: 4,
                     borderRadius: 4,
-                    backgroundColor: "#fef3f2",
-                    border: "1px solid #c9190b",
+                    backgroundColor: "var(--axiom--color--danger--bg)",
+                    border: "1px solid var(--pf-t--global--color--status--danger--default, #c9190b)",
                 }}>
-                    <ExclamationCircleIcon style={{ color: "#c9190b", marginTop: 2, flexShrink: 0 }} />
+                    <ExclamationCircleIcon className="axiom-icon-danger" style={{ marginTop: 2, flexShrink: 0 }} />
                     <div style={{ fontSize: "13px" }}>{msg}</div>
                 </div>
             ))}
@@ -32,10 +32,10 @@ export function ValidationProblemsTab({ errors = [], warnings = [] }: Validation
                     padding: "10px 12px",
                     marginBottom: 4,
                     borderRadius: 4,
-                    backgroundColor: "#fdf7e7",
-                    border: "1px solid #f0ab00",
+                    backgroundColor: "var(--axiom--color--warning--bg)",
+                    border: "1px solid var(--pf-t--global--color--status--warning--default, #f0ab00)",
                 }}>
-                    <ExclamationTriangleIcon style={{ color: "#f0ab00", marginTop: 2, flexShrink: 0 }} />
+                    <ExclamationTriangleIcon className="axiom-icon-warning" style={{ marginTop: 2, flexShrink: 0 }} />
                     <div style={{ fontSize: "13px" }}>{msg}</div>
                 </div>
             ))}

--- a/ui/src/hooks/useTheme.ts
+++ b/ui/src/hooks/useTheme.ts
@@ -1,10 +1,21 @@
-import { useState, useEffect, useCallback } from "react";
+import { createContext, useContext, useState, useEffect, useCallback } from "react";
 
 export type ThemeMode = "light" | "dark" | "system";
 export type EffectiveTheme = "light" | "dark";
 
 const STORAGE_KEY = "axiom.theme";
 const DARK_CLASS = "pf-v6-theme-dark";
+
+/**
+ * Context providing the resolved (effective) theme to deeply nested components
+ * that need to adapt their rendering to the current color scheme.
+ */
+export const EffectiveThemeContext = createContext<EffectiveTheme>("light");
+
+/** Returns the current effective theme from context. */
+export function useEffectiveTheme(): EffectiveTheme {
+    return useContext(EffectiveThemeContext);
+}
 
 function getSystemPreference(): EffectiveTheme {
     return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
@@ -24,9 +35,13 @@ function applyTheme(effective: EffectiveTheme): void {
 }
 
 function loadStoredMode(): ThemeMode {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored === "light" || stored === "dark" || stored === "system") {
-        return stored;
+    try {
+        const stored = localStorage.getItem(STORAGE_KEY);
+        if (stored === "light" || stored === "dark" || stored === "system") {
+            return stored;
+        }
+    } catch {
+        // localStorage unavailable (e.g. private browsing in older Safari)
     }
     return "system";
 }
@@ -37,11 +52,16 @@ function loadStoredMode(): ThemeMode {
  * dark-mode class on the document element.
  */
 export function useTheme() {
-    const [mode, setModeState] = useState<ThemeMode>(loadStoredMode);
-    const [effectiveTheme, setEffectiveTheme] = useState<EffectiveTheme>(() => resolveTheme(loadStoredMode()));
+    const initialMode = loadStoredMode();
+    const [mode, setModeState] = useState<ThemeMode>(initialMode);
+    const [effectiveTheme, setEffectiveTheme] = useState<EffectiveTheme>(resolveTheme(initialMode));
 
     const setMode = useCallback((newMode: ThemeMode) => {
-        localStorage.setItem(STORAGE_KEY, newMode);
+        try {
+            localStorage.setItem(STORAGE_KEY, newMode);
+        } catch {
+            // localStorage unavailable
+        }
         setModeState(newMode);
         const effective = resolveTheme(newMode);
         setEffectiveTheme(effective);

--- a/ui/src/hooks/useTheme.ts
+++ b/ui/src/hooks/useTheme.ts
@@ -1,0 +1,67 @@
+import { useState, useEffect, useCallback } from "react";
+
+export type ThemeMode = "light" | "dark" | "system";
+export type EffectiveTheme = "light" | "dark";
+
+const STORAGE_KEY = "axiom.theme";
+const DARK_CLASS = "pf-v6-theme-dark";
+
+function getSystemPreference(): EffectiveTheme {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function resolveTheme(mode: ThemeMode): EffectiveTheme {
+    return mode === "system" ? getSystemPreference() : mode;
+}
+
+function applyTheme(effective: EffectiveTheme): void {
+    const root = document.documentElement;
+    if (effective === "dark") {
+        root.classList.add(DARK_CLASS);
+    } else {
+        root.classList.remove(DARK_CLASS);
+    }
+}
+
+function loadStoredMode(): ThemeMode {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === "light" || stored === "dark" || stored === "system") {
+        return stored;
+    }
+    return "system";
+}
+
+/**
+ * Manages the application color theme (light, dark, or system-following).
+ * Persists the user's choice to localStorage and toggles PatternFly's
+ * dark-mode class on the document element.
+ */
+export function useTheme() {
+    const [mode, setModeState] = useState<ThemeMode>(loadStoredMode);
+    const [effectiveTheme, setEffectiveTheme] = useState<EffectiveTheme>(() => resolveTheme(loadStoredMode()));
+
+    const setMode = useCallback((newMode: ThemeMode) => {
+        localStorage.setItem(STORAGE_KEY, newMode);
+        setModeState(newMode);
+        const effective = resolveTheme(newMode);
+        setEffectiveTheme(effective);
+        applyTheme(effective);
+    }, []);
+
+    useEffect(() => {
+        applyTheme(resolveTheme(mode));
+
+        const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+        const handleChange = () => {
+            if (mode === "system") {
+                const effective = getSystemPreference();
+                setEffectiveTheme(effective);
+                applyTheme(effective);
+            }
+        };
+        mediaQuery.addEventListener("change", handleChange);
+        return () => mediaQuery.removeEventListener("change", handleChange);
+    }, [mode]);
+
+    return { mode, effectiveTheme, setMode };
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from "react-router-dom";
 import { App } from "./App";
 
 import "@patternfly/react-core/dist/styles/base.css";
+import "./axiom-theme.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
     <React.StrictMode>

--- a/ui/src/pages/ActionTypeDetailPage.tsx
+++ b/ui/src/pages/ActionTypeDetailPage.tsx
@@ -297,8 +297,8 @@ export function ActionTypeDetailPage() {
                     <Tab eventKey={5} title={
                         <TabTitleText>
                             {validationMessages.some((m) => m.severity === "error")
-                                ? <ExclamationCircleIcon style={{ color: "#c9190b", marginRight: 6 }} />
-                                : <ExclamationTriangleIcon style={{ color: "#f0ab00", marginRight: 6 }} />
+                                ? <ExclamationCircleIcon className="axiom-icon-danger" style={{ marginRight: 6 }} />
+                                : <ExclamationTriangleIcon className="axiom-icon-warning" style={{ marginRight: 6 }} />
                             }
                             Problems ({validationMessages.length})
                         </TabTitleText>
@@ -466,7 +466,7 @@ function PromptTemplateTab({ value, onChange }: {
 }) {
     return (
         <div>
-            <p style={{ color: "#6a6e73", marginBottom: "16px" }}>
+            <p className="axiom-text-subtle" style={{ marginBottom: "16px" }}>
                 The prompt sent to the AI agent when executing this action type.
                 Supports placeholders:{" "}
                 <code>{"{{managerInput}}"}</code>,{" "}
@@ -494,7 +494,7 @@ function ScriptTab({ value, onChange }: {
 }) {
     return (
         <div>
-            <p style={{ color: "#6a6e73", marginBottom: "16px" }}>
+            <p className="axiom-text-subtle" style={{ marginBottom: "16px" }}>
                 A bash script that runs when this action type is triggered.
                 Supports placeholders:{" "}
                 <code>{"{{projectId}}"}</code>,{" "}

--- a/ui/src/pages/AiUsagePage.tsx
+++ b/ui/src/pages/AiUsagePage.tsx
@@ -113,7 +113,7 @@ export function AiUsagePage() {
                             <div style={{ fontSize: "24px", fontWeight: "bold" }}>
                                 {totalCount}
                             </div>
-                            <div style={{ fontSize: "13px", color: "#6a6e73" }}>
+                            <div className="axiom-text-subtle" style={{ fontSize: "13px" }}>
                                 Invocations
                             </div>
                         </CardBody>
@@ -125,7 +125,7 @@ export function AiUsagePage() {
                             <div style={{ fontSize: "24px", fontWeight: "bold" }}>
                                 ${totalCost.toFixed(4)}
                             </div>
-                            <div style={{ fontSize: "13px", color: "#6a6e73" }}>
+                            <div className="axiom-text-subtle" style={{ fontSize: "13px" }}>
                                 Cost
                             </div>
                         </CardBody>
@@ -137,7 +137,7 @@ export function AiUsagePage() {
                             <div style={{ fontSize: "24px", fontWeight: "bold" }}>
                                 {totalInputTokens.toLocaleString()}
                             </div>
-                            <div style={{ fontSize: "13px", color: "#6a6e73" }}>
+                            <div className="axiom-text-subtle" style={{ fontSize: "13px" }}>
                                 Input Tokens
                             </div>
                         </CardBody>
@@ -149,7 +149,7 @@ export function AiUsagePage() {
                             <div style={{ fontSize: "24px", fontWeight: "bold" }}>
                                 {totalOutputTokens.toLocaleString()}
                             </div>
-                            <div style={{ fontSize: "13px", color: "#6a6e73" }}>
+                            <div className="axiom-text-subtle" style={{ fontSize: "13px" }}>
                                 Output Tokens
                             </div>
                         </CardBody>

--- a/ui/src/pages/ConfigurationPacksPage.tsx
+++ b/ui/src/pages/ConfigurationPacksPage.tsx
@@ -259,7 +259,7 @@ export function ConfigurationPacksPage() {
             <Title headingLevel="h1" size="lg">
                 Configuration Packs
             </Title>
-            <p style={{ color: "#6a6e73", marginTop: "8px", marginBottom: "16px" }}>
+            <p className="axiom-text-subtle" style={{ marginTop: "8px", marginBottom: "16px" }}>
                 Configuration packs bundle related items — action types, tools, toolsets,
                 MCP servers, and report definitions — into a portable JSON file. Create a pack
                 to share your setup with others, or import one to quickly add pre-configured
@@ -304,7 +304,7 @@ export function ConfigurationPacksPage() {
                                                         {at?.executionMode || "—"}
                                                     </Label>
                                                 </FlexItem>
-                                                <FlexItem style={{ fontSize: "12px", color: "#6a6e73" }}>
+                                                <FlexItem className="axiom-text-subtle" style={{ fontSize: "12px" }}>
                                                     {at?.executionMode === "actor" ? `${at?.allowedTools?.length || 0} tools` : ""}
                                                 </FlexItem>
                                             </Flex>
@@ -323,7 +323,7 @@ export function ConfigurationPacksPage() {
                                         return (
                                             <Flex alignItems={{ default: "alignItemsCenter" }} style={{ gap: "8px" }}>
                                                 <FlexItem><span style={{ fontWeight: 600 }}>{item.name}</span></FlexItem>
-                                                <FlexItem style={{ fontSize: "12px", color: "#6a6e73" }}>
+                                                <FlexItem className="axiom-text-subtle" style={{ fontSize: "12px" }}>
                                                     {t?.parameters?.length ? `${t.parameters.length} param(s)` : ""}
                                                 </FlexItem>
                                             </Flex>
@@ -344,7 +344,7 @@ export function ConfigurationPacksPage() {
                                         return (
                                             <Flex alignItems={{ default: "alignItemsCenter" }} style={{ gap: "8px" }}>
                                                 <FlexItem><span style={{ fontWeight: 600 }}>{item.name}</span></FlexItem>
-                                                <FlexItem style={{ fontSize: "12px", color: "#6a6e73" }}>
+                                                <FlexItem className="axiom-text-subtle" style={{ fontSize: "12px" }}>
                                                     {ts?.tools?.length ? `${ts.tools.length} tool(s)` : ""}
                                                 </FlexItem>
                                             </Flex>
@@ -398,7 +398,7 @@ export function ConfigurationPacksPage() {
                     <TabContent id="import-tab" eventKey={1} activeKey={activeTab}
                         style={{ marginTop: "24px" }}>
                         <div style={{ maxWidth: "600px" }}>
-                            <p style={{ color: "#6a6e73", marginBottom: "16px" }}>
+                            <p className="axiom-text-subtle" style={{ marginBottom: "16px" }}>
                                 Upload a configuration pack JSON file to import its contents.
                             </p>
 
@@ -595,7 +595,7 @@ function SelectedItemsSection({ title, allItems, selected, onAdd, onRemove, rend
             </Flex>
 
             {selectedItems.length === 0 ? (
-                <p style={{ color: "#6a6e73", fontSize: "13px", fontStyle: "italic" }}>
+                <p className="axiom-text-subtle" style={{ fontSize: "13px", fontStyle: "italic" }}>
                     No {title.toLowerCase()} selected.
                 </p>
             ) : (
@@ -608,7 +608,7 @@ function SelectedItemsSection({ title, allItems, selected, onAdd, onRemove, rend
                                         <>
                                             <span style={{ fontWeight: 600 }}>{item.name}</span>
                                             {item.description && (
-                                                <span style={{ fontSize: "12px", color: "#6a6e73", marginLeft: "8px" }}>
+                                                <span className="axiom-text-subtle" style={{ fontSize: "12px", marginLeft: "8px" }}>
                                                     {item.description}
                                                 </span>
                                             )}
@@ -648,7 +648,7 @@ function SelectedItemsSection({ title, allItems, selected, onAdd, onRemove, rend
                             style={{ marginBottom: "16px" }}
                         />
                         {filteredItems.length === 0 ? (
-                            <p style={{ color: "#6a6e73", fontStyle: "italic" }}>
+                            <p className="axiom-text-subtle" style={{ fontStyle: "italic" }}>
                                 {availableItems.length === 0
                                     ? `All ${title.toLowerCase()} are already selected.`
                                     : "No items match the filter."}
@@ -725,7 +725,7 @@ function ActionTypePickerModal({ isOpen, onClose, availableItems, modalSelected,
                     style={{ marginBottom: "16px" }}
                 />
                 {filtered.length === 0 ? (
-                    <p style={{ color: "#6a6e73", fontStyle: "italic" }}>
+                    <p className="axiom-text-subtle" style={{ fontStyle: "italic" }}>
                         {availableItems.length === 0
                             ? "All action types are already selected."
                             : "No action types match the filter."}
@@ -818,7 +818,7 @@ function ToolPickerModal({ isOpen, onClose, availableItems, modalSelected, toggl
                     onChange={(_e, v) => setFilter(v)} aria-label="Filter tools"
                     style={{ marginBottom: "16px" }} />
                 {filtered.length === 0 ? (
-                    <p style={{ color: "#6a6e73", fontStyle: "italic" }}>
+                    <p className="axiom-text-subtle" style={{ fontStyle: "italic" }}>
                         {available.length === 0 ? "All tools are already selected." : "No tools match the filter."}
                     </p>
                 ) : (
@@ -838,7 +838,7 @@ function ToolPickerModal({ isOpen, onClose, availableItems, modalSelected, toggl
                                     <Td><Checkbox id={`tool-pick-${t.id}`} isChecked={modalSelected.has(t.id)}
                                         onChange={() => toggleItem(t.id)} aria-label={`Select ${t.name}`} /></Td>
                                     <Td>{t.name}</Td>
-                                    <Td style={{ color: "#6a6e73", fontSize: "13px" }}>
+                                    <Td className="axiom-text-subtle" style={{ fontSize: "13px" }}>
                                         {t.description ? (t.description.length > 60 ? t.description.substring(0, 57) + "..." : t.description) : "—"}
                                     </Td>
                                     <Td>{t.parameters?.length || 0}</Td>
@@ -894,7 +894,7 @@ function ToolsetPickerModal({ isOpen, onClose, availableItems, modalSelected, to
                     onChange={(_e, v) => setFilter(v)} aria-label="Filter toolsets"
                     style={{ marginBottom: "16px" }} />
                 {filtered.length === 0 ? (
-                    <p style={{ color: "#6a6e73", fontStyle: "italic" }}>
+                    <p className="axiom-text-subtle" style={{ fontStyle: "italic" }}>
                         {available.length === 0 ? "All toolsets are already selected." : "No toolsets match the filter."}
                     </p>
                 ) : (
@@ -914,7 +914,7 @@ function ToolsetPickerModal({ isOpen, onClose, availableItems, modalSelected, to
                                     <Td><Checkbox id={`ts-pick-${ts.id}`} isChecked={modalSelected.has(ts.id)}
                                         onChange={() => toggleItem(ts.id)} aria-label={`Select ${ts.name}`} /></Td>
                                     <Td>{ts.name}</Td>
-                                    <Td style={{ color: "#6a6e73", fontSize: "13px" }}>
+                                    <Td className="axiom-text-subtle" style={{ fontSize: "13px" }}>
                                         {ts.description || "—"}
                                     </Td>
                                     <Td>{ts.tools?.length || 0}</Td>
@@ -970,7 +970,7 @@ function ReportDefinitionPickerModal({ isOpen, onClose, availableItems, modalSel
                     onChange={(_e, v) => setFilter(v)} aria-label="Filter report definitions"
                     style={{ marginBottom: "16px" }} />
                 {filtered.length === 0 ? (
-                    <p style={{ color: "#6a6e73", fontStyle: "italic" }}>
+                    <p className="axiom-text-subtle" style={{ fontStyle: "italic" }}>
                         {available.length === 0 ? "All report definitions are already selected." : "No report definitions match the filter."}
                     </p>
                 ) : (

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -171,7 +171,7 @@ export function DashboardPage() {
                     <table style={{ width: "100%", borderCollapse: "collapse" }}>
                         <tbody>
                             {requirements.map((req) => (
-                                <tr key={req.name} style={{ borderBottom: "1px solid #d2d2d2" }}>
+                                <tr key={req.name} style={{ borderBottom: "1px solid var(--pf-t--global--border--color--default, #d2d2d2)" }}>
                                     <td style={{ padding: "8px", width: "24px" }}>
                                         {req.met ? (
                                             <CheckCircleIcon color="var(--pf-t--global--color--status--success--default)" />
@@ -404,11 +404,11 @@ export function DashboardPage() {
                                                        color={ENTRY_TYPE_COLORS[entry.entryType] || "grey"}>
                                                     {entry.entryType}
                                                 </Label>
-                                                <span style={{ fontSize: "12px", color: "#6a6e73" }}>
+                                                <span className="axiom-text-subtle" style={{ fontSize: "12px" }}>
                                                     {new Date(entry.createdOn).toLocaleTimeString()}
                                                 </span>
                                             </div>
-                                            <div style={{ fontSize: "13px", color: "#151515" }}>
+                                            <div className="axiom-text-default" style={{ fontSize: "13px" }}>
                                                 {entry.summary.length > 120
                                                     ? entry.summary.substring(0, 117) + "..."
                                                     : entry.summary}
@@ -447,7 +447,7 @@ function StatusCard({ label, count, color }: {
                 }}>
                     {count}
                 </div>
-                <div style={{ fontSize: "13px", color: "#6a6e73", marginTop: "4px" }}>
+                <div className="axiom-text-subtle" style={{ fontSize: "13px", marginTop: "4px" }}>
                     {label}
                 </div>
             </CardBody>

--- a/ui/src/pages/DiskUsagePage.tsx
+++ b/ui/src/pages/DiskUsagePage.tsx
@@ -91,7 +91,7 @@ export function DiskUsagePage() {
                             <div style={{ fontSize: "24px", fontWeight: "bold" }}>
                                 {formatBytes(totalDiskUsageBytes)}
                             </div>
-                            <div style={{ fontSize: "13px", color: "#6a6e73" }}>
+                            <div className="axiom-text-subtle" style={{ fontSize: "13px" }}>
                                 Total Disk Usage
                             </div>
                         </CardBody>
@@ -103,7 +103,7 @@ export function DiskUsagePage() {
                             <div style={{ fontSize: "24px", fontWeight: "bold" }}>
                                 {projectCount}
                             </div>
-                            <div style={{ fontSize: "13px", color: "#6a6e73" }}>
+                            <div className="axiom-text-subtle" style={{ fontSize: "13px" }}>
                                 Projects
                             </div>
                         </CardBody>

--- a/ui/src/pages/EngineSettingsPage.tsx
+++ b/ui/src/pages/EngineSettingsPage.tsx
@@ -175,7 +175,7 @@ export function EngineSettingsPage() {
                                 </div>
                             ))}
                             {models.length === 0 && (
-                                <p style={{ color: "#6a6e73" }}>No models configured.</p>
+                                <p className="axiom-text-subtle">No models configured.</p>
                             )}
                         </CardBody>
                     </Card>

--- a/ui/src/pages/EventSourceDetailPage.tsx
+++ b/ui/src/pages/EventSourceDetailPage.tsx
@@ -252,7 +252,7 @@ function LogsTab({ logs, totalCount, page, perPage, onPageChange, onPerPageChang
                 alignItems={{ default: "alignItemsCenter" }}
                 style={{ marginBottom: "16px" }}>
                 <FlexItem>
-                    <p style={{ color: "#6a6e73" }}>
+                    <p className="axiom-text-subtle">
                         Poll activity for this event source. Click a row to view details.
                     </p>
                 </FlexItem>
@@ -343,7 +343,7 @@ function LogsTab({ logs, totalCount, page, perPage, onPageChange, onPerPageChang
                                     <CodeBlockCode>{selectedLog.detail}</CodeBlockCode>
                                 </CodeBlock>
                             ) : (
-                                <p style={{ color: "#6a6e73", fontStyle: "italic" }}>
+                                <p className="axiom-text-subtle" style={{ fontStyle: "italic" }}>
                                     No detailed log available for this poll cycle.
                                 </p>
                             )}

--- a/ui/src/pages/ManagerConfigPage.tsx
+++ b/ui/src/pages/ManagerConfigPage.tsx
@@ -80,7 +80,7 @@ export function ManagerConfigPage() {
                 <Tab eventKey={0} title={<TabTitleText>System Prompt</TabTitleText>}>
                     <TabContent id="system-prompt-tab" eventKey={0} activeKey={activeTab}
                         style={{ marginTop: "16px" }}>
-                        <p style={{ color: "#6a6e73", marginBottom: "16px" }}>
+                        <p className="axiom-text-subtle" style={{ marginBottom: "16px" }}>
                             The system prompt defines the Manager's role, behavior, and decision
                             format. It is sent as the system context for every Manager evaluation.
                         </p>
@@ -96,7 +96,7 @@ export function ManagerConfigPage() {
                 <Tab eventKey={1} title={<TabTitleText>Prompt Template</TabTitleText>}>
                     <TabContent id="prompt-template-tab" eventKey={1} activeKey={activeTab}
                         style={{ marginTop: "16px" }}>
-                        <p style={{ color: "#6a6e73", marginBottom: "16px" }}>
+                        <p className="axiom-text-subtle" style={{ marginBottom: "16px" }}>
                             The prompt template is sent as the user message for each event evaluation.
                             Placeholders are substituted at runtime:{" "}
                             <code>{"{{actionTypes}}"}</code> (list of configured action types),{" "}

--- a/ui/src/pages/McpServerDetailPage.tsx
+++ b/ui/src/pages/McpServerDetailPage.tsx
@@ -127,7 +127,7 @@ export function McpServerDetailPage() {
                     <TabContent id="connection-tab" eventKey={1} activeKey={activeTab}
                         style={{ marginTop: "24px" }}>
                         <Form style={{ maxWidth: "600px" }}>
-                            <p style={{ color: "#6a6e73", marginBottom: "16px" }}>
+                            <p className="axiom-text-subtle" style={{ marginBottom: "16px" }}>
                                 Configure the MCP server connection. Use either an HTTP URL
                                 (for HTTP/SSE transport) or a command (for stdio transport).
                             </p>

--- a/ui/src/pages/ProjectDetailPage.tsx
+++ b/ui/src/pages/ProjectDetailPage.tsx
@@ -380,7 +380,7 @@ export function ProjectDetailPage() {
                                 </FormSelect>
                             </FormGroup>
                             {selectedActionDesc && (
-                                <p style={{ color: "#6a6e73", fontSize: "14px", marginTop: "-8px" }}>
+                                <p className="axiom-text-subtle" style={{ fontSize: "14px", marginTop: "-8px" }}>
                                     {selectedActionDesc}
                                 </p>
                             )}
@@ -645,7 +645,7 @@ function ThreadTab({ entries }: { entries: ThreadEntry[] }) {
                                 </Label>
                             </FlexItem>
                             <FlexItem>
-                                <span style={{ fontSize: "12px", color: "#6a6e73" }}>
+                                <span className="axiom-text-subtle" style={{ fontSize: "12px" }}>
                                     {new Date(entry.createdOn).toLocaleString()}
                                 </span>
                             </FlexItem>
@@ -738,7 +738,7 @@ function MetricsTab({ metrics }: { metrics: ProjectMetrics | null }) {
                         <div style={{ fontSize: "24px", fontWeight: "bold" }}>
                             {formatBytes(metrics.diskUsageBytes)}
                         </div>
-                        <div style={{ fontSize: "13px", color: "#6a6e73" }}>Disk Usage</div>
+                        <div className="axiom-text-subtle" style={{ fontSize: "13px" }}>Disk Usage</div>
                     </CardBody>
                 </Card>
             </GalleryItem>
@@ -748,7 +748,7 @@ function MetricsTab({ metrics }: { metrics: ProjectMetrics | null }) {
                         <div style={{ fontSize: "24px", fontWeight: "bold" }}>
                             ${metrics.totalCostUsd.toFixed(4)}
                         </div>
-                        <div style={{ fontSize: "13px", color: "#6a6e73" }}>AI Cost</div>
+                        <div className="axiom-text-subtle" style={{ fontSize: "13px" }}>AI Cost</div>
                     </CardBody>
                 </Card>
             </GalleryItem>
@@ -758,7 +758,7 @@ function MetricsTab({ metrics }: { metrics: ProjectMetrics | null }) {
                         <div style={{ fontSize: "24px", fontWeight: "bold" }}>
                             {metrics.invocationCount}
                         </div>
-                        <div style={{ fontSize: "13px", color: "#6a6e73" }}>AI Invocations</div>
+                        <div className="axiom-text-subtle" style={{ fontSize: "13px" }}>AI Invocations</div>
                     </CardBody>
                 </Card>
             </GalleryItem>
@@ -768,7 +768,7 @@ function MetricsTab({ metrics }: { metrics: ProjectMetrics | null }) {
                         <div style={{ fontSize: "24px", fontWeight: "bold" }}>
                             {metrics.totalInputTokens.toLocaleString()}
                         </div>
-                        <div style={{ fontSize: "13px", color: "#6a6e73" }}>Input Tokens</div>
+                        <div className="axiom-text-subtle" style={{ fontSize: "13px" }}>Input Tokens</div>
                     </CardBody>
                 </Card>
             </GalleryItem>
@@ -778,7 +778,7 @@ function MetricsTab({ metrics }: { metrics: ProjectMetrics | null }) {
                         <div style={{ fontSize: "24px", fontWeight: "bold" }}>
                             {metrics.totalOutputTokens.toLocaleString()}
                         </div>
-                        <div style={{ fontSize: "13px", color: "#6a6e73" }}>Output Tokens</div>
+                        <div className="axiom-text-subtle" style={{ fontSize: "13px" }}>Output Tokens</div>
                     </CardBody>
                 </Card>
             </GalleryItem>

--- a/ui/src/pages/ReportDefinitionDetailPage.tsx
+++ b/ui/src/pages/ReportDefinitionDetailPage.tsx
@@ -306,8 +306,8 @@ export function ReportDefinitionDetailPage() {
                     <Tab eventKey={4} title={
                         <TabTitleText>
                             {validationMessages.some((m) => m.severity === "error")
-                                ? <ExclamationCircleIcon style={{ color: "#c9190b", marginRight: 6 }} />
-                                : <ExclamationTriangleIcon style={{ color: "#f0ab00", marginRight: 6 }} />
+                                ? <ExclamationCircleIcon className="axiom-icon-danger" style={{ marginRight: 6 }} />
+                                : <ExclamationTriangleIcon className="axiom-icon-warning" style={{ marginRight: 6 }} />
                             }
                             Problems ({validationMessages.length})
                         </TabTitleText>
@@ -344,7 +344,7 @@ function InfoTab({ form, updateForm, initialLabels, onLabelsChange }: {
                 <TextInput id="titleTemplate" value={form.titleTemplate || ""}
                     onChange={(_e, v) => updateForm({ titleTemplate: v || undefined })}
                     placeholder="e.g. {{name}} — {{date}}" />
-                <p style={{ color: "#6a6e73", fontSize: "0.85em", marginTop: "4px" }}>
+                <p className="axiom-text-subtle" style={{ fontSize: "0.85em", marginTop: "4px" }}>
                     Optional. If set, the report title uses this template instead of
                     extracting from markdown. Placeholders:{" "}
                     <code>{"{{name}}"}</code>, <code>{"{{date}}"}</code>,{" "}
@@ -425,7 +425,7 @@ function PromptTemplateTab({ value, onChange }: {
 }) {
     return (
         <div>
-            <p style={{ color: "#6a6e73", marginBottom: "16px" }}>
+            <p className="axiom-text-subtle" style={{ marginBottom: "16px" }}>
                 Instructions for the AI agent when generating this report.
                 Supports placeholders:{" "}
                 <code>{"{{repositories}}"}</code>,{" "}

--- a/ui/src/pages/ReportDefinitionsPage.tsx
+++ b/ui/src/pages/ReportDefinitionsPage.tsx
@@ -118,7 +118,7 @@ export function ReportDefinitionsPage() {
                                     <Td>
                                         <Label isCompact>{def.schedule}</Label>
                                         {def.scheduleTime && (
-                                            <span style={{ marginLeft: "4px", fontSize: "12px", color: "#6a6e73" }}>
+                                            <span className="axiom-text-subtle" style={{ marginLeft: "4px", fontSize: "12px" }}>
                                                 at {def.scheduleTime}
                                             </span>
                                         )}

--- a/ui/src/pages/SecretsPage.tsx
+++ b/ui/src/pages/SecretsPage.tsx
@@ -99,7 +99,7 @@ export function SecretsPage() {
                 </FlexItem>
             </Flex>
 
-            <p style={{ color: "#6a6e73", marginTop: "8px", marginBottom: "16px" }}>
+            <p className="axiom-text-subtle" style={{ marginTop: "8px", marginBottom: "16px" }}>
                 Secrets are injected as environment variables into AI agent and script
                 subprocesses. Use them for CLI authentication tokens (e.g. GH_TOKEN,
                 JIRA_API_TOKEN). Values are encrypted at rest and never returned by the API.
@@ -127,7 +127,7 @@ export function SecretsPage() {
                                 <Tr key={s.id}>
                                     <Td><code>{s.name}</code></Td>
                                     <Td>{s.description || "—"}</Td>
-                                    <Td style={{ color: "#6a6e73" }}>••••••••</Td>
+                                    <Td className="axiom-text-subtle">••••••••</Td>
                                     <Td>
                                         <Button variant="plain" size="sm" style={{ padding: 0 }}
                                             onClick={() => openEdit(s)} aria-label="Edit">

--- a/ui/src/pages/SessionTemplateDetailPage.tsx
+++ b/ui/src/pages/SessionTemplateDetailPage.tsx
@@ -343,15 +343,14 @@ export function SessionTemplateDetailPage() {
                                 </HelperText>
                             </FormHelperText>
                             <div style={{
-                                border: "1px solid #d2d2d2",
+                                border: "1px solid var(--pf-t--global--border--color--default, #d2d2d2)",
                                 borderRadius: "3px",
                                 padding: "8px",
                                 maxHeight: "200px",
                                 overflowY: "auto",
                             }}>
                                 {mcpServers.length === 0 ? (
-                                    <div style={{
-                                        color: "#6a6e73",
+                                    <div className="axiom-text-subtle" style={{
                                         fontStyle: "italic",
                                     }}>
                                         No MCP servers configured
@@ -378,9 +377,8 @@ export function SessionTemplateDetailPage() {
                                                 />
                                                 <span>{server.name}</span>
                                                 {server.description && (
-                                                    <span style={{
+                                                    <span className="axiom-text-subtle" style={{
                                                         marginLeft: "8px",
-                                                        color: "#6a6e73",
                                                         fontSize: "0.9em",
                                                     }}>
                                                         — {server.description}
@@ -447,7 +445,7 @@ export function SessionTemplateDetailPage() {
                 <Tab eventKey={4} title={<TabTitleText>Environment</TabTitleText>}>
                     <div style={{ marginTop: 24 }}>
                         {isReadOnly ? (
-                            <p style={{ color: "#6a6e73", fontStyle: "italic" }}>
+                            <p className="axiom-text-subtle" style={{ fontStyle: "italic" }}>
                                 Environment variables cannot be modified on built-in templates.
                             </p>
                         ) : (

--- a/ui/src/pages/ToolDetailPage.tsx
+++ b/ui/src/pages/ToolDetailPage.tsx
@@ -235,8 +235,8 @@ export function ToolDetailPage() {
                     <Tab eventKey={4} title={
                         <TabTitleText>
                             {validationMessages.some((m) => m.severity === "error")
-                                ? <ExclamationCircleIcon style={{ color: "#c9190b", marginRight: 6 }} />
-                                : <ExclamationTriangleIcon style={{ color: "#f0ab00", marginRight: 6 }} />
+                                ? <ExclamationCircleIcon className="axiom-icon-danger" style={{ marginRight: 6 }} />
+                                : <ExclamationTriangleIcon className="axiom-icon-warning" style={{ marginRight: 6 }} />
                             }
                             Problems ({validationMessages.length})
                         </TabTitleText>
@@ -305,7 +305,7 @@ function ParametersTab({ params, addParam, updateParam, removeParam }: {
 }) {
     return (
         <div style={{ maxWidth: "800px" }}>
-            <p style={{ color: "#6a6e73", marginBottom: "16px" }}>
+            <p className="axiom-text-subtle" style={{ marginBottom: "16px" }}>
                 Define the parameters the AI agent will provide when calling this tool.
                 Use <code>{"{{param_name}}"}</code> in the script template to substitute values.
             </p>
@@ -377,7 +377,7 @@ function ScriptTemplateTab({ value, onChange }: {
 }) {
     return (
         <div>
-            <p style={{ color: "#6a6e73", marginBottom: "16px" }}>
+            <p className="axiom-text-subtle" style={{ marginBottom: "16px" }}>
                 Bash script to execute when the tool is called. Supports multi-line scripts
                 with variables, pipes, and control flow.
                 Use <code>{"{{param_name}}"}</code> for parameter substitution.
@@ -462,7 +462,7 @@ function TestTab({ toolId, params, scriptTemplate }: {
 
     return (
         <div style={{ maxWidth: "800px" }}>
-            <p style={{ color: "#6a6e73", marginBottom: "16px" }}>
+            <p className="axiom-text-subtle" style={{ marginBottom: "16px" }}>
                 Test this tool by providing parameter values and executing the script template.
                 Secrets are not injected during testing.
             </p>
@@ -505,7 +505,7 @@ function TestTab({ toolId, params, scriptTemplate }: {
                                 </Label>
                             </FlexItem>
                             <FlexItem>
-                                <span style={{ color: "#6a6e73", fontSize: "13px" }}>
+                                <span className="axiom-text-subtle" style={{ fontSize: "13px" }}>
                                     {result.durationMs}ms
                                 </span>
                             </FlexItem>
@@ -530,7 +530,7 @@ function TestTab({ toolId, params, scriptTemplate }: {
 
                         <div style={{ marginBottom: "8px", fontWeight: 600, fontSize: "14px" }}>Output</div>
                         {!result.output || result.output.trim() === "" ? (
-                            <p style={{ color: "#6a6e73", fontStyle: "italic" }}>(no output)</p>
+                            <p className="axiom-text-subtle" style={{ fontStyle: "italic" }}>(no output)</p>
                         ) : outputIsJson ? (
                             <CodeEditor
                                 code={formatJson(result.output)}


### PR DESCRIPTION
## Summary

- Add light/dark/system theme toggle to the application masthead, persisted via `localStorage`
- Create `useTheme` hook that manages theme state and toggles PatternFly's `.pf-v6-theme-dark` CSS class on the document root
- Create `axiom-theme.css` with custom property definitions, dark-mode overrides, and utility CSS classes
- Replace ~90 hardcoded hex color values across 44 files with theme-aware CSS variables and utility classes
- Move masthead inline styles to CSS classes with brand color custom properties
- Fix CSS files (box shadows, background tints, blockquote colors) to use theme-aware tokens

Closes #96

## Test plan

- [ ] Verify theme toggle appears in the masthead between the AI Assistant and About buttons
- [ ] Click the toggle to cycle through light → dark → system modes
- [ ] Confirm PatternFly components render correctly in dark mode (sidebar, nav, tables, modals)
- [ ] Check custom components in both modes: trace graph, assistant chat, tool-use blocks, validation warnings
- [ ] Verify the masthead brand gradient and icon colors adapt to dark mode
- [ ] Refresh the page and confirm the selected theme persists via `localStorage`
- [ ] Set theme to "system" and verify it follows the OS color scheme preference
- [ ] Check the ConfigurationPacks, ProjectDetail, and Dashboard pages for subtle text readability in both modes