### PR TITLE
Document init script security trust boundary (#74)

### DIFF
--- a/docs/developer-guide/stack-and-architecture.md
+++ b/docs/developer-guide/stack-and-architecture.md
@@ -185,6 +185,32 @@ JAX-RS SSE endpoint (per-session)
 Sessions are in-memory — they do not survive server restarts. Cost and token usage
 are accumulated per-session and persisted to `AiUsageEntity` on session destruction.
 
+#### Init Script Security
+
+Session templates support optional init scripts (bash or Node.js) that run once when a
+session is created. The `runInitScript` method in `AssistantSessionManager` executes
+these scripts via `ProcessBuilder` with **no sandboxing** — the script runs as the same
+OS user as the Axiom server process, with full filesystem and network access. The only
+safeguard is a 60-second timeout.
+
+**Trust model:** The init script content comes from session templates stored in the
+database (user-defined) or in built-in JSON files under
+`resources/templates/assistant-templates/`. There are currently no authentication or
+role-based access controls on the template CRUD endpoints
+(`POST/PUT /assistant/templates`). Any user with network access to Axiom can create a
+template containing an arbitrary init script, which will execute with server privileges
+when a session is created from that template. Template authors are therefore implicitly
+trusted with server-level code execution.
+
+**Future hardening options** (not currently implemented):
+
+- Add role-based access control to the template CRUD endpoints so only administrators
+  can create or modify templates with init scripts
+- Run init scripts in a container or as a restricted OS user to limit their blast
+  radius
+- Validate or restrict init script content (e.g., command allowlists or static
+  analysis)
+
 ### Real-Time Updates (SSE)
 
 ```

--- a/docs/user-guide/ai-assistant.md
+++ b/docs/user-guide/ai-assistant.md
@@ -85,9 +85,11 @@ within 60 seconds, it is killed and the session continues without it. Keep scrip
 focused on quick setup tasks — long-running operations should be handled by the
 assistant itself during the conversation.
 
-**Environment:** Init scripts inherit the environment variables defined on the template
-(including resolved `${secret:NAME}` references), so they can use credentials for git
-clones, API calls, or authenticated downloads.
+**Environment:** Init scripts do **not** inherit the template's environment variables.
+Template environment variables (including resolved `${secret:NAME}` references) are
+injected into the Claude Code process, which starts after the init script finishes. If
+your init script needs credentials (e.g., for `git clone` or API calls), they must be
+available through the server's own environment or set up by other means.
 
 **Common use cases:**
 
@@ -120,6 +122,21 @@ const resp = await fetch("https://api.github.com/repos/my-org/my-repo/issues/42"
 const issue = await resp.json();
 fs.writeFileSync("context.json", JSON.stringify(issue, null, 2));
 ```
+
+!!! warning "Security: Init scripts run unsandboxed"
+    Init scripts execute as the **same OS user** that runs the Axiom server process.
+    There is no sandboxing, filesystem restriction, or network isolation — the only
+    guard is the 60-second timeout. This means anyone who can create or edit a session
+    template can run arbitrary code on the server with the server's full privileges.
+
+    **Recommendations:**
+
+    - Restrict template creation to **trusted administrators**. Treat the ability to
+      create or edit session templates as equivalent to shell access on the server.
+    - If Axiom is deployed in a multi-tenant or untrusted environment, consider running
+      the server under a **restricted service account** with minimal filesystem and
+      network permissions, or use **container-level isolation** to limit the blast
+      radius of init scripts.
 
 ---
 


### PR DESCRIPTION
## Summary

- Fix inaccurate user guide text that claimed init scripts inherit template environment
  variables — they actually run *before* `resolveEnvironment` in `AssistantSessionManager`,
  so template env vars are not available to init scripts
- Add a security warning admonition to the user guide explaining that init scripts run
  unsandboxed with server privileges
- Add an "Init Script Security" subsection to the developer guide documenting the trust
  model, lack of auth on template CRUD endpoints, and future hardening options

Closes #74