### PR TITLE
Add user-visible error feedback for failed AI assistant operations

### DIFF
--- a/ui/src/components/assistant/AssistantChatPanel.tsx
+++ b/ui/src/components/assistant/AssistantChatPanel.tsx
@@ -302,6 +302,7 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
             await sendAssistantMessage(sessionId, message);
         } catch (err) {
             console.error("Failed to send message:", err);
+            addMessage({ type: "system", content: "Failed to send message. Please try again." });
             setIsProcessing(false);
         }
     }, [sessionId, addMessage]);
@@ -321,9 +322,10 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
             await respondToAssistantPermission(sessionId, permissionId, allow, toolInput);
         } catch (err) {
             console.error("Failed to respond to permission:", err);
+            addMessage({ type: "system", content: "Failed to submit permission response. Please try again." });
             setIsProcessing(false);
         }
-    }, [sessionId]);
+    }, [sessionId, addMessage]);
 
     const handleCreateAutoApproval = useCallback(async (
         toolName: string, fieldName: string | undefined,

--- a/ui/src/components/assistant/AssistantChatPanel.tsx
+++ b/ui/src/components/assistant/AssistantChatPanel.tsx
@@ -346,8 +346,9 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
             onAutoApprovalCountChange?.();
         } catch (err) {
             console.error("Failed to create auto-approval:", err);
+            addMessage({ type: "system", content: "Failed to create auto-approval rule. Please try again." });
         }
-    }, [sessionId, onAutoApprovalCountChange]);
+    }, [sessionId, onAutoApprovalCountChange, addMessage]);
 
     return (
         <div style={{

--- a/ui/src/pages/AssistantSessionPage.css
+++ b/ui/src/pages/AssistantSessionPage.css
@@ -96,6 +96,12 @@
     font-size: 12px;
 }
 
+/* End session error */
+.axiom-session-page__end-session-error {
+    margin: 8px 16px;
+    flex-shrink: 0;
+}
+
 /* Split panels */
 .axiom-session-page__split-panels {
     display: flex;

--- a/ui/src/pages/AssistantSessionPage.css
+++ b/ui/src/pages/AssistantSessionPage.css
@@ -102,6 +102,12 @@
     flex-shrink: 0;
 }
 
+/* Rename error */
+.axiom-session-page__rename-error {
+    margin: 8px 16px;
+    flex-shrink: 0;
+}
+
 /* Split panels */
 .axiom-session-page__split-panels {
     display: flex;

--- a/ui/src/pages/AssistantSessionPage.css
+++ b/ui/src/pages/AssistantSessionPage.css
@@ -130,6 +130,11 @@
     min-height: 0;
 }
 
+/* Auto-approval error */
+.axiom-session-page__auto-approval-error {
+    margin-bottom: 12px;
+}
+
 /* Auto-approval modal */
 .axiom-session-page__auto-approval-empty {
     color: var(--pf-t--global--text--color--subtle, #6a6e73);

--- a/ui/src/pages/AssistantSessionPage.tsx
+++ b/ui/src/pages/AssistantSessionPage.tsx
@@ -51,6 +51,8 @@ export function AssistantSessionPage() {
     const [applyResult, setApplyResult] = useState<AssistantApplyResult | null>(null);
     const [applyError, setApplyError] = useState<string | null>(null);
     const [endSessionError, setEndSessionError] = useState<string | null>(null);
+    const [renameError, setRenameError] = useState<string | null>(null);
+    const [autoApprovalError, setAutoApprovalError] = useState<string | null>(null);
     const [sessionMode, setSessionMode] = useState<SessionMode>("normal");
     const [itemCount, setItemCount] = useState(0);
     const [isEditingName, setIsEditingName] = useState(false);
@@ -88,6 +90,7 @@ export function AssistantSessionPage() {
             setIsEditingName(false);
             return;
         }
+        setRenameError(null);
         try {
             const updated = await renameAssistantSession(sessionId, editName.trim());
             setSession(updated);
@@ -96,6 +99,7 @@ export function AssistantSessionPage() {
             }
         } catch (err) {
             console.error("Failed to rename session:", err);
+            setRenameError((err as Error).message || "Failed to rename session");
         }
         setIsEditingName(false);
     };
@@ -117,6 +121,7 @@ export function AssistantSessionPage() {
 
     const openAutoApprovalModal = () => {
         if (!sessionId) return;
+        setAutoApprovalError(null);
         fetchAutoApprovals(sessionId)
             .then((rules) => {
                 setAutoApprovalRules(rules);
@@ -128,6 +133,7 @@ export function AssistantSessionPage() {
 
     const handleDeleteAutoApproval = async (ruleId: string) => {
         if (!sessionId) return;
+        setAutoApprovalError(null);
         try {
             await deleteAutoApproval(sessionId, ruleId);
             const updated = autoApprovalRules.filter((r) => r.id !== ruleId);
@@ -135,6 +141,7 @@ export function AssistantSessionPage() {
             setAutoApprovalCount(updated.length);
         } catch (err) {
             console.error("Failed to delete auto-approval:", err);
+            setAutoApprovalError((err as Error).message || "Failed to delete auto-approval rule");
         }
     };
 
@@ -335,6 +342,18 @@ export function AssistantSessionPage() {
                 </Alert>
             )}
 
+            {renameError && (
+                <Alert
+                    variant="danger"
+                    isInline
+                    title="Failed to rename session"
+                    actionClose={<AlertActionCloseButton onClose={() => setRenameError(null)} />}
+                    className="axiom-session-page__end-session-error"
+                >
+                    {renameError}
+                </Alert>
+            )}
+
             {/* Split panels — fills remaining height */}
             <div className="axiom-session-page__split-panels">
                 <div className={`axiom-session-page__chat-panel${isConfigAssistant ? " axiom-session-page__chat-panel--with-sidebar" : ""}`}>
@@ -437,6 +456,17 @@ export function AssistantSessionPage() {
             >
                 <ModalHeader title="Auto-Approval Rules" />
                 <ModalBody>
+                    {autoApprovalError && (
+                        <Alert
+                            variant="danger"
+                            isInline
+                            title="Failed to delete auto-approval rule"
+                            actionClose={<AlertActionCloseButton onClose={() => setAutoApprovalError(null)} />}
+                            className="axiom-session-page__auto-approval-error"
+                        >
+                            {autoApprovalError}
+                        </Alert>
+                    )}
                     {autoApprovalRules.length === 0 ? (
                         <div className="axiom-session-page__auto-approval-empty">
                             No auto-approval rules active.

--- a/ui/src/pages/AssistantSessionPage.tsx
+++ b/ui/src/pages/AssistantSessionPage.tsx
@@ -15,6 +15,7 @@ import {
     ModalFooter,
     ModalHeader,
     Alert,
+    AlertActionCloseButton,
 } from "@patternfly/react-core";
 import { Table, Thead, Tr, Th, Tbody, Td } from "@patternfly/react-table";
 import ArrowLeftIcon from "@patternfly/react-icons/dist/esm/icons/arrow-left-icon";
@@ -49,6 +50,7 @@ export function AssistantSessionPage() {
     const [applying, setApplying] = useState(false);
     const [applyResult, setApplyResult] = useState<AssistantApplyResult | null>(null);
     const [applyError, setApplyError] = useState<string | null>(null);
+    const [endSessionError, setEndSessionError] = useState<string | null>(null);
     const [sessionMode, setSessionMode] = useState<SessionMode>("normal");
     const [itemCount, setItemCount] = useState(0);
     const [isEditingName, setIsEditingName] = useState(false);
@@ -138,6 +140,7 @@ export function AssistantSessionPage() {
 
     const handleEndSession = async () => {
         if (!sessionId) return;
+        setEndSessionError(null);
         try {
             await deleteAssistantSession(sessionId);
             if (isBreakout) {
@@ -147,6 +150,8 @@ export function AssistantSessionPage() {
             }
         } catch (err) {
             console.error("Failed to end session:", err);
+            setEndSessionError((err as Error).message || "Failed to end session");
+            setIsEndConfirmOpen(false);
         }
     };
 
@@ -315,6 +320,18 @@ export function AssistantSessionPage() {
                     className="axiom-session-page__apply-error"
                 >
                     <pre className="axiom-session-page__apply-error-pre">{applyError}</pre>
+                </Alert>
+            )}
+
+            {endSessionError && (
+                <Alert
+                    variant="danger"
+                    isInline
+                    title="Failed to end session"
+                    actionClose={<AlertActionCloseButton onClose={() => setEndSessionError(null)} />}
+                    className="axiom-session-page__end-session-error"
+                >
+                    {endSessionError}
                 </Alert>
             )}
 

--- a/ui/src/pages/AssistantSessionPage.tsx
+++ b/ui/src/pages/AssistantSessionPage.tsx
@@ -348,7 +348,7 @@ export function AssistantSessionPage() {
                     isInline
                     title="Failed to rename session"
                     actionClose={<AlertActionCloseButton onClose={() => setRenameError(null)} />}
-                    className="axiom-session-page__end-session-error"
+                    className="axiom-session-page__rename-error"
                 >
                     {renameError}
                 </Alert>


### PR DESCRIPTION
## Summary

Adds user-visible error feedback for failed operations in the AI Assistant frontend. Previously, most `catch` blocks only called `console.error`, leaving users unaware when actions failed.

## Changes

### `AssistantSessionPage.tsx`
- Added `endSessionError` state and a dismissible inline `Alert` banner (using PatternFly `AlertActionCloseButton`) that appears when ending a session fails. This follows the existing `applyError` pattern already used for the "Apply All" action.

### `AssistantChatPanel.tsx`
- Added system messages (via the existing `addMessage({ type: "system", ... })` pattern) when:
  - **Sending a message** fails — displays "Failed to send message. Please try again."
  - **Responding to a permission request** fails — displays "Failed to submit permission response. Please try again."
- This reuses the same `type: "system"` message pattern already used for `session_error` SSE events.

## Approach

The fix uses two existing patterns already established in the codebase:
1. **Inline Alert banners** (for page-level actions like ending a session) — matches the `applyError` pattern
2. **System chat messages** (for chat-level actions like sending messages) — matches the `session_error` event handler pattern

Fixes #77