### PR TITLE
Fix CodeEditor dark theme support across all instances

### DIFF
--- a/ui/src/components/ActionTypeAiModal.tsx
+++ b/ui/src/components/ActionTypeAiModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useEffectiveTheme } from "../hooks/useTheme";
 import {
     Flex,
     FlexItem,
@@ -28,6 +29,7 @@ export function ActionTypeAiModal({
     isOpen, promptTemplate, allowedTools, actionTypeName, actionTypeDescription,
     onApply, onClose,
 }: ActionTypeAiModalProps) {
+    const effectiveTheme = useEffectiveTheme();
     const [localPrompt, setLocalPrompt] = useState(promptTemplate);
     const [localTools, setLocalTools] = useState(allowedTools);
 
@@ -119,6 +121,7 @@ export function ActionTypeAiModal({
                     code={localPrompt || ""}
                     language={Language.markdown}
                     isFullHeight
+                    isDarkTheme={effectiveTheme === "dark"}
                     isReadOnly={false}
                     isLineNumbersVisible
                 />

--- a/ui/src/components/EventDetailModal.tsx
+++ b/ui/src/components/EventDetailModal.tsx
@@ -11,6 +11,7 @@ import {
     Title,
 } from "@patternfly/react-core";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
+import { useEffectiveTheme } from "../hooks/useTheme";
 import { type AxiomEvent } from "../config/api";
 
 interface EventDetailModalProps {
@@ -23,6 +24,7 @@ interface EventDetailModalProps {
  * metadata and the raw JSON payload in a read-only code editor.
  */
 export function EventDetailModal({ event, onClose }: EventDetailModalProps) {
+    const effectiveTheme = useEffectiveTheme();
     const formatPayload = (payload?: string): string => {
         if (!payload) return "";
         try {
@@ -94,6 +96,7 @@ export function EventDetailModal({ event, onClose }: EventDetailModalProps) {
                         <CodeEditor
                             code={formatPayload(event.payload)}
                             language={Language.json}
+                            isDarkTheme={effectiveTheme === "dark"}
                             height="400px"
                             isReadOnly
                             isLineNumbersVisible

--- a/ui/src/components/ExecutionLogModal.tsx
+++ b/ui/src/components/ExecutionLogModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { useEffectiveTheme } from "../hooks/useTheme";
 import {
     Button,
     EmptyState,
@@ -32,6 +33,7 @@ interface ExecutionLogModalProps {
  */
 export function ExecutionLogModal({ isOpen, projectId, taskId, activityId, reportId,
                                      onClose }: ExecutionLogModalProps) {
+    const effectiveTheme = useEffectiveTheme();
     const [content, setContent] = useState("");
     const [loading, setLoading] = useState(false);
 
@@ -83,6 +85,7 @@ export function ExecutionLogModal({ isOpen, projectId, taskId, activityId, repor
                     <CodeEditor
                         code={content}
                         language={Language.markdown}
+                        isDarkTheme={effectiveTheme === "dark"}
                         height="600px"
                         isReadOnly
                         isLineNumbersVisible

--- a/ui/src/components/ReportAiModal.tsx
+++ b/ui/src/components/ReportAiModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useEffectiveTheme } from "../hooks/useTheme";
 import {
     Flex,
     FlexItem,
@@ -28,6 +29,7 @@ export function ReportAiModal({
     isOpen, promptTemplate, allowedTools, reportName, reportDescription,
     onApply, onClose,
 }: ReportAiModalProps) {
+    const effectiveTheme = useEffectiveTheme();
     const [localPrompt, setLocalPrompt] = useState(promptTemplate);
     const [localTools, setLocalTools] = useState(allowedTools);
 
@@ -121,6 +123,7 @@ export function ReportAiModal({
                     code={localPrompt || ""}
                     language={Language.markdown}
                     isFullHeight
+                    isDarkTheme={effectiveTheme === "dark"}
                     isReadOnly={false}
                     isLineNumbersVisible
                 />

--- a/ui/src/components/ScriptAiModal.tsx
+++ b/ui/src/components/ScriptAiModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useEffectiveTheme } from "../hooks/useTheme";
 import {
     StackItem,
     Title,
@@ -24,6 +25,7 @@ interface ScriptAiModalProps {
 export function ScriptAiModal({
     isOpen, script, actionTypeName, actionTypeDescription, onApply, onClose,
 }: ScriptAiModalProps) {
+    const effectiveTheme = useEffectiveTheme();
     const [localScript, setLocalScript] = useState(script);
 
     useEffect(() => {
@@ -76,6 +78,7 @@ export function ScriptAiModal({
                     code={localScript || ""}
                     language={Language.shell}
                     isFullHeight
+                    isDarkTheme={effectiveTheme === "dark"}
                     isReadOnly={false}
                     isLineNumbersVisible
                 />

--- a/ui/src/components/ToolAiModal.tsx
+++ b/ui/src/components/ToolAiModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useEffectiveTheme } from "../hooks/useTheme";
 import {
     StackItem,
     Title,
@@ -22,6 +23,7 @@ interface ToolAiModalProps {
  * by AI). Right side is a chat interface for giving instructions.
  */
 export function ToolAiModal({ isOpen, form, params, onApply, onClose }: ToolAiModalProps) {
+    const effectiveTheme = useEffectiveTheme();
     const [localForm, setLocalForm] = useState(form);
     const [localParams, setLocalParams] = useState(params);
 
@@ -112,6 +114,7 @@ export function ToolAiModal({ isOpen, form, params, onApply, onClose }: ToolAiMo
                     code={localForm.scriptTemplate || ""}
                     language={Language.shell}
                     isFullHeight
+                    isDarkTheme={effectiveTheme === "dark"}
                     isReadOnly={false}
                     isLineNumbersVisible
                 />

--- a/ui/src/components/TraceNodeDetailModal.tsx
+++ b/ui/src/components/TraceNodeDetailModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useEffectiveTheme } from "../hooks/useTheme";
 import { Link } from "react-router-dom";
 import {
     DescriptionList,
@@ -121,24 +122,32 @@ function renderDetail(nodeType: string, entityType: string | undefined,
         case "event":
             return <EventDetail detail={detail} />;
         default:
-            return (
-                <CodeEditor
-                    code={JSON.stringify(detail, null, 2)}
-                    language={Language.json}
-                    isReadOnly
-                    height="400px"
-                />
-            );
+            return <RawJsonDetail detail={detail} />;
     }
 }
 
+function RawJsonDetail({ detail }: { detail: Record<string, unknown> }) {
+    const effectiveTheme = useEffectiveTheme();
+    return (
+        <CodeEditor
+            code={JSON.stringify(detail, null, 2)}
+            language={Language.json}
+            isDarkTheme={effectiveTheme === "dark"}
+            isReadOnly
+            height="400px"
+        />
+    );
+}
+
 function ReasoningDetail({ detail }: { detail: Record<string, unknown> }) {
+    const effectiveTheme = useEffectiveTheme();
     return (
         <>
             <h4 style={{ marginBottom: "4px", fontWeight: "bold" }}>Reasoning</h4>
             <CodeEditor
                 code={String(detail.summary || "")}
                 language={Language.plaintext}
+                isDarkTheme={effectiveTheme === "dark"}
                 isReadOnly
                 height="200px"
                 options={{ wordWrap: "on" }}
@@ -163,12 +172,14 @@ function ReportLinkDetail({ detail }: { detail: Record<string, unknown> }) {
 }
 
 function ReportExecutionLogDetail({ detail }: { detail: Record<string, unknown> }) {
+    const effectiveTheme = useEffectiveTheme();
     return (
         <>
             <h4 style={{ marginBottom: "4px", fontWeight: "bold" }}>Execution Log</h4>
             <CodeEditor
                 code={String(detail.executionLog || "")}
                 language={Language.markdown}
+                isDarkTheme={effectiveTheme === "dark"}
                 isReadOnly
                 height="400px"
             />
@@ -177,6 +188,7 @@ function ReportExecutionLogDetail({ detail }: { detail: Record<string, unknown> 
 }
 
 function DecisionDetail({ detail }: { detail: Record<string, unknown> }) {
+    const effectiveTheme = useEffectiveTheme();
     return (
         <>
             {detail.summary && (
@@ -191,6 +203,7 @@ function DecisionDetail({ detail }: { detail: Record<string, unknown> }) {
                     <CodeEditor
                         code={String(detail.details)}
                         language={Language.markdown}
+                        isDarkTheme={effectiveTheme === "dark"}
                         isReadOnly
                         height="300px"
                     />
@@ -201,6 +214,7 @@ function DecisionDetail({ detail }: { detail: Record<string, unknown> }) {
 }
 
 function ToolExecutionDetail({ detail }: { detail: Record<string, unknown> }) {
+    const effectiveTheme = useEffectiveTheme();
     const [toolId, setToolId] = useState<number | null>(null);
     const [activeTab, setActiveTab] = useState(0);
     const toolName = String(detail.toolName || "");
@@ -234,6 +248,7 @@ function ToolExecutionDetail({ detail }: { detail: Record<string, unknown> }) {
                         <CodeEditor
                             code={formatJson(String(detail.toolInput || "{}"))}
                             language={Language.json}
+                            isDarkTheme={effectiveTheme === "dark"}
                             isReadOnly
                             height="300px"
                             options={{ wordWrap: "on" }}
@@ -245,6 +260,7 @@ function ToolExecutionDetail({ detail }: { detail: Record<string, unknown> }) {
                         <CodeEditor
                             code={formatJson(String(detail.toolOutput || ""))}
                             language={Language.json}
+                            isDarkTheme={effectiveTheme === "dark"}
                             isReadOnly
                             height="300px"
                             options={{ wordWrap: "on" }}
@@ -257,6 +273,7 @@ function ToolExecutionDetail({ detail }: { detail: Record<string, unknown> }) {
 }
 
 function TaskDetail({ detail }: { detail: Record<string, unknown> }) {
+    const effectiveTheme = useEffectiveTheme();
     const [activeTab, setActiveTab] = useState(0);
 
     return (
@@ -267,6 +284,7 @@ function TaskDetail({ detail }: { detail: Record<string, unknown> }) {
                     <CodeEditor
                         code={String(detail.input || "")}
                         language={Language.markdown}
+                        isDarkTheme={effectiveTheme === "dark"}
                         isReadOnly
                         height="300px"
                         options={{ wordWrap: "on" }}
@@ -278,6 +296,7 @@ function TaskDetail({ detail }: { detail: Record<string, unknown> }) {
                     <CodeEditor
                         code={String(detail.output || "")}
                         language={Language.markdown}
+                        isDarkTheme={effectiveTheme === "dark"}
                         isReadOnly
                         height="300px"
                         options={{ wordWrap: "on" }}
@@ -289,6 +308,7 @@ function TaskDetail({ detail }: { detail: Record<string, unknown> }) {
                     <CodeEditor
                         code={String(detail.executionLog || "")}
                         language={Language.markdown}
+                        isDarkTheme={effectiveTheme === "dark"}
                         isReadOnly
                         height="400px"
                     />
@@ -299,6 +319,7 @@ function TaskDetail({ detail }: { detail: Record<string, unknown> }) {
 }
 
 function ActivityLogDetail({ detail }: { detail: Record<string, unknown> }) {
+    const effectiveTheme = useEffectiveTheme();
     return (
         <>
             {detail.summary && (
@@ -315,6 +336,7 @@ function ActivityLogDetail({ detail }: { detail: Record<string, unknown> }) {
                     <CodeEditor
                         code={String(detail.details)}
                         language={Language.markdown}
+                        isDarkTheme={effectiveTheme === "dark"}
                         isReadOnly
                         height="400px"
                     />
@@ -360,6 +382,7 @@ function AiUsageDetail({ detail }: { detail: Record<string, unknown> }) {
 }
 
 function EventDetail({ detail }: { detail: Record<string, unknown> }) {
+    const effectiveTheme = useEffectiveTheme();
     return (
         <>
             <DescriptionList isHorizontal isCompact style={{ marginBottom: "12px" }}>
@@ -388,6 +411,7 @@ function EventDetail({ detail }: { detail: Record<string, unknown> }) {
                     <CodeEditor
                         code={formatJson(String(detail.payload))}
                         language={Language.json}
+                        isDarkTheme={effectiveTheme === "dark"}
                         isReadOnly
                         height="400px"
                     />

--- a/ui/src/components/assistant/ActionTypeDetailModal.tsx
+++ b/ui/src/components/assistant/ActionTypeDetailModal.tsx
@@ -13,6 +13,7 @@ import {
 } from "@patternfly/react-core";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import { useState } from "react";
+import { useEffectiveTheme } from "../../hooks/useTheme";
 import ExclamationCircleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon";
 import { ValidationProblemsTab } from "./ValidationProblemsTab";
 import "./ActionTypeDetailModal.css";
@@ -26,6 +27,7 @@ interface ActionTypeDetailModalProps {
 }
 
 export function ActionTypeDetailModal({ isOpen, onClose, name, content, errors }: ActionTypeDetailModalProps) {
+    const effectiveTheme = useEffectiveTheme();
     const [activeTab, setActiveTab] = useState(0);
 
     const description = (content.description as string) || "";
@@ -126,6 +128,7 @@ export function ActionTypeDetailModal({ isOpen, onClose, name, content, errors }
                                 <CodeEditor
                                     code={templateContent}
                                     language={templateLanguage}
+                                    isDarkTheme={effectiveTheme === "dark"}
                                     height="100%"
                                     isReadOnly
                                     isLineNumbersVisible

--- a/ui/src/components/assistant/ReportDefinitionDetailModal.tsx
+++ b/ui/src/components/assistant/ReportDefinitionDetailModal.tsx
@@ -13,6 +13,7 @@ import {
 } from "@patternfly/react-core";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import { useState } from "react";
+import { useEffectiveTheme } from "../../hooks/useTheme";
 import ExclamationCircleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon";
 import { ValidationProblemsTab } from "./ValidationProblemsTab";
 import "./ActionTypeDetailModal.css";
@@ -32,6 +33,7 @@ export function ReportDefinitionDetailModal({
     content,
     errors,
 }: ReportDefinitionDetailModalProps) {
+    const effectiveTheme = useEffectiveTheme();
     const [activeTab, setActiveTab] = useState(0);
 
     const description = (content.description as string) || "";
@@ -121,6 +123,7 @@ export function ReportDefinitionDetailModal({
                                 <CodeEditor
                                     code={promptTemplate}
                                     language={Language.markdown}
+                                    isDarkTheme={effectiveTheme === "dark"}
                                     height="100%"
                                     isReadOnly
                                     isLineNumbersVisible

--- a/ui/src/components/assistant/SessionTemplateDetailModal.tsx
+++ b/ui/src/components/assistant/SessionTemplateDetailModal.tsx
@@ -13,6 +13,7 @@ import {
 } from "@patternfly/react-core";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import { useState } from "react";
+import { useEffectiveTheme } from "../../hooks/useTheme";
 import ExclamationCircleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon";
 
 import { ValidationProblemsTab } from "./ValidationProblemsTab";
@@ -27,6 +28,7 @@ interface SessionTemplateDetailModalProps {
 }
 
 export function SessionTemplateDetailModal({ isOpen, onClose, name, content, errors }: SessionTemplateDetailModalProps) {
+    const effectiveTheme = useEffectiveTheme();
     const [activeTab, setActiveTab] = useState(0);
 
     const templateId = (content.templateId as string) || "";
@@ -109,6 +111,7 @@ export function SessionTemplateDetailModal({ isOpen, onClose, name, content, err
                             <CodeEditor
                                 code={JSON.stringify(content, null, 2)}
                                 language={Language.json}
+                                isDarkTheme={effectiveTheme === "dark"}
                                 height="100%"
                                 isReadOnly
                                 isLineNumbersVisible

--- a/ui/src/components/assistant/ToolDetailModal.tsx
+++ b/ui/src/components/assistant/ToolDetailModal.tsx
@@ -13,6 +13,7 @@ import {
 } from "@patternfly/react-core";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import { useState } from "react";
+import { useEffectiveTheme } from "../../hooks/useTheme";
 import ExclamationCircleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon";
 
 import { ValidationProblemsTab } from "./ValidationProblemsTab";
@@ -34,6 +35,7 @@ interface ToolDetailModalProps {
 }
 
 export function ToolDetailModal({ isOpen, onClose, name, content, errors }: ToolDetailModalProps) {
+    const effectiveTheme = useEffectiveTheme();
     const [activeTab, setActiveTab] = useState(0);
 
     const description = (content.description as string) || "";
@@ -116,6 +118,7 @@ export function ToolDetailModal({ isOpen, onClose, name, content, errors }: Tool
                                 <CodeEditor
                                     code={scriptTemplate}
                                     language={Language.shell}
+                                    isDarkTheme={effectiveTheme === "dark"}
                                     height="100%"
                                     isReadOnly
                                     isLineNumbersVisible

--- a/ui/src/components/assistant/ToolsetDetailModal.tsx
+++ b/ui/src/components/assistant/ToolsetDetailModal.tsx
@@ -13,6 +13,7 @@ import {
 } from "@patternfly/react-core";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import { useState } from "react";
+import { useEffectiveTheme } from "../../hooks/useTheme";
 import ExclamationCircleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon";
 
 import { ValidationProblemsTab } from "./ValidationProblemsTab";
@@ -27,6 +28,7 @@ interface ToolsetDetailModalProps {
 }
 
 export function ToolsetDetailModal({ isOpen, onClose, name, content, errors }: ToolsetDetailModalProps) {
+    const effectiveTheme = useEffectiveTheme();
     const [activeTab, setActiveTab] = useState(0);
 
     const description = (content.description as string) || "";
@@ -77,6 +79,7 @@ export function ToolsetDetailModal({ isOpen, onClose, name, content, errors }: T
                             <CodeEditor
                                 code={JSON.stringify(content, null, 2)}
                                 language={Language.json}
+                                isDarkTheme={effectiveTheme === "dark"}
                                 height="100%"
                                 isReadOnly
                                 isLineNumbersVisible

--- a/ui/src/pages/ActionTypeDetailPage.tsx
+++ b/ui/src/pages/ActionTypeDetailPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
+import { useEffectiveTheme } from "../hooks/useTheme";
 import { useParams, Link } from "react-router-dom";
 import {
     Breadcrumb,
@@ -464,6 +465,7 @@ function PromptTemplateTab({ value, onChange }: {
     value: string;
     onChange: (v: string) => void;
 }) {
+    const effectiveTheme = useEffectiveTheme();
     return (
         <div>
             <p className="axiom-text-subtle" style={{ marginBottom: "16px" }}>
@@ -479,6 +481,7 @@ function PromptTemplateTab({ value, onChange }: {
                 onCodeChange={(v) => onChange(v)}
                 language={Language.markdown}
                 height="500px"
+                isDarkTheme={effectiveTheme === "dark"}
                 isLineNumbersVisible
                 onEditorDidMount={(editor, monaco) => {
                     registerPlaceholderCompletions(editor, monaco, "markdown", ACTION_TYPE_PLACEHOLDERS);
@@ -492,6 +495,7 @@ function ScriptTab({ value, onChange }: {
     value: string;
     onChange: (v: string) => void;
 }) {
+    const effectiveTheme = useEffectiveTheme();
     return (
         <div>
             <p className="axiom-text-subtle" style={{ marginBottom: "16px" }}>
@@ -511,6 +515,7 @@ function ScriptTab({ value, onChange }: {
                 onCodeChange={(v) => onChange(v)}
                 language={Language.shell}
                 height="500px"
+                isDarkTheme={effectiveTheme === "dark"}
                 isLineNumbersVisible
             />
         </div>

--- a/ui/src/pages/ManagerConfigPage.tsx
+++ b/ui/src/pages/ManagerConfigPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
+import { useEffectiveTheme } from "../hooks/useTheme";
 import {
     Button,
     EmptyState,
@@ -22,6 +23,7 @@ import {
 } from "../config/api";
 
 export function ManagerConfigPage() {
+    const effectiveTheme = useEffectiveTheme();
     const [config, setConfig] = useState<ManagerConfig>({});
     const [loading, setLoading] = useState(true);
     const [saving, setSaving] = useState(false);
@@ -89,6 +91,7 @@ export function ManagerConfigPage() {
                             onCodeChange={(v) => { setConfig({ ...config, systemPrompt: v }); setDirty(true); }}
                             language={Language.markdown}
                             height="500px"
+                            isDarkTheme={effectiveTheme === "dark"}
                             isLineNumbersVisible
                         />
                     </TabContent>
@@ -113,6 +116,7 @@ export function ManagerConfigPage() {
                             onCodeChange={(v) => { setConfig({ ...config, promptTemplate: v }); setDirty(true); }}
                             language={Language.markdown}
                             height="500px"
+                            isDarkTheme={effectiveTheme === "dark"}
                             isLineNumbersVisible
                             onEditorDidMount={(editor, monaco) => {
                                 registerPlaceholderCompletions(editor, monaco, "markdown", MANAGER_PLACEHOLDERS);

--- a/ui/src/pages/ReportDefinitionDetailPage.tsx
+++ b/ui/src/pages/ReportDefinitionDetailPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
+import { useEffectiveTheme } from "../hooks/useTheme";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import {
     Breadcrumb,
@@ -423,6 +424,7 @@ function PromptTemplateTab({ value, onChange }: {
     value: string;
     onChange: (v: string) => void;
 }) {
+    const effectiveTheme = useEffectiveTheme();
     return (
         <div>
             <p className="axiom-text-subtle" style={{ marginBottom: "16px" }}>
@@ -438,6 +440,7 @@ function PromptTemplateTab({ value, onChange }: {
                 onCodeChange={(v) => onChange(v)}
                 language={Language.markdown}
                 height="400px"
+                isDarkTheme={effectiveTheme === "dark"}
                 isLineNumbersVisible
                 onEditorDidMount={(editor, monaco) => {
                     registerPlaceholderCompletions(editor, monaco, "markdown", REPORT_PLACEHOLDERS);

--- a/ui/src/pages/SessionTemplateDetailPage.tsx
+++ b/ui/src/pages/SessionTemplateDetailPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
+import { useEffectiveTheme } from "../hooks/useTheme";
 import { useParams, Link } from "react-router-dom";
 import {
     Alert,
@@ -39,6 +40,7 @@ import {
 
 export function SessionTemplateDetailPage() {
     const { templateId } = useParams<{ templateId: string }>();
+    const effectiveTheme = useEffectiveTheme();
     const [template, setTemplate] = useState<SessionTemplate | null>(null);
     const [form, setForm] = useState<NewSessionTemplate>({
         name: "", description: "", systemPrompt: "",
@@ -289,6 +291,7 @@ export function SessionTemplateDetailPage() {
                             onChange={(v) => updateForm({ systemPrompt: v })}
                             language={Language.markdown}
                             height="500px"
+                            isDarkTheme={effectiveTheme === "dark"}
                             isReadOnly={isReadOnly}
                             isLineNumbersVisible
                             options={{
@@ -430,6 +433,7 @@ export function SessionTemplateDetailPage() {
                             language={(form.initScriptType || "bash") === "bash"
                                 ? Language.shell : Language.javascript}
                             height="400px"
+                            isDarkTheme={effectiveTheme === "dark"}
                             isReadOnly={isReadOnly}
                             isLineNumbersVisible
                             options={{

--- a/ui/src/pages/ToolDetailPage.tsx
+++ b/ui/src/pages/ToolDetailPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
+import { useEffectiveTheme } from "../hooks/useTheme";
 import { useParams, Link } from "react-router-dom";
 import {
     Breadcrumb,
@@ -375,6 +376,7 @@ function ScriptTemplateTab({ value, onChange }: {
     value: string;
     onChange: (v: string) => void;
 }) {
+    const effectiveTheme = useEffectiveTheme();
     return (
         <div>
             <p className="axiom-text-subtle" style={{ marginBottom: "16px" }}>
@@ -389,6 +391,7 @@ function ScriptTemplateTab({ value, onChange }: {
                 onCodeChange={(v) => onChange(v)}
                 language={Language.shell}
                 height="400px"
+                isDarkTheme={effectiveTheme === "dark"}
                 isLineNumbersVisible
             />
         </div>
@@ -419,6 +422,7 @@ function TestTab({ toolId, params, scriptTemplate }: {
     params: ToolParameter[];
     scriptTemplate?: string;
 }) {
+    const effectiveTheme = useEffectiveTheme();
     const [paramValues, setParamValues] = useState<Record<string, string>>({});
     const [running, setRunning] = useState(false);
     const [result, setResult] = useState<ToolTestResponse | null>(null);
@@ -522,6 +526,7 @@ function TestTab({ toolId, params, scriptTemplate }: {
                                     code={result.resolvedScript}
                                     language={Language.shell}
                                     height="150px"
+                                    isDarkTheme={effectiveTheme === "dark"}
                                     isReadOnly
                                     isLineNumbersVisible
                                 />
@@ -536,6 +541,7 @@ function TestTab({ toolId, params, scriptTemplate }: {
                                 code={formatJson(result.output)}
                                 language={Language.json}
                                 height="400px"
+                                isDarkTheme={effectiveTheme === "dark"}
                                 isReadOnly
                                 isLineNumbersVisible
                             />


### PR DESCRIPTION
## Summary

- Pass `isDarkTheme={effectiveTheme === "dark"}` to all 32 `<CodeEditor>` instances so they
  render with the dark Monaco theme when the application is in Dark Mode
- Covers 17 files: 5 pages, 4 AI modals, `TraceNodeDetailModal` (11 instances across 7 helper
  components), `ExecutionLogModal`, `EventDetailModal`, and 5 assistant detail modals

## Test plan

- [ ] Enable Dark Mode in the application settings
- [ ] Verify code editors on config pages (Manager Config, Action Type, Report Definition,
  Tool, Session Template) use the dark theme
- [ ] Verify AI modals (Action Type, Report, Script, Tool) use the dark theme
- [ ] Verify read-only modals (Trace Node Detail, Execution Log, Event Detail) use the dark
  theme
- [ ] Verify assistant detail modals (Tool, Action Type, Session Template, Report Definition,
  Toolset) use the dark theme
- [ ] Verify light mode still works correctly when Dark Mode is disabled

Fixes #107