### PR TITLE
Fix session template allowed tools not available at runtime

### DIFF
--- a/actors/claude-code/src/main/java/io/apitomy/axiom/actors/claudecode/ClaudeCodeCommandBuilder.java
+++ b/actors/claude-code/src/main/java/io/apitomy/axiom/actors/claudecode/ClaudeCodeCommandBuilder.java
@@ -132,13 +132,7 @@ public class ClaudeCodeCommandBuilder {
         //    than prompt.
         if (allowedTools != null && !allowedTools.isEmpty()) {
             // Derive base tool names for --tools (hard availability restriction)
-            String baseTools = allowedTools.stream()
-                    .map(tool -> {
-                        int parenIdx = tool.indexOf('(');
-                        return parenIdx > 0 ? tool.substring(0, parenIdx) : tool;
-                    })
-                    .distinct()
-                    .collect(java.util.stream.Collectors.joining(","));
+            String baseTools = deriveBaseToolNames(allowedTools);
             cmd.add("--tools");
             cmd.add(baseTools);
 
@@ -188,5 +182,24 @@ public class ClaudeCodeCommandBuilder {
         }
 
         return cmd;
+    }
+
+    /**
+     * Derives comma-separated base tool names from a list of allowed tool
+     * patterns. Strips parenthesized pattern suffixes
+     * (e.g. {@code "Bash(git log *)"} becomes {@code "Bash"}) and
+     * deduplicates the result.
+     *
+     * @param allowedTools the list of tool patterns
+     * @return comma-separated base tool names
+     */
+    public static String deriveBaseToolNames(List<String> allowedTools) {
+        return allowedTools.stream()
+                .map(tool -> {
+                    int parenIdx = tool.indexOf('(');
+                    return parenIdx > 0 ? tool.substring(0, parenIdx) : tool;
+                })
+                .distinct()
+                .collect(Collectors.joining(","));
     }
 }

--- a/actors/claude-code/src/test/java/io/apitomy/axiom/actors/claudecode/ClaudeCodeCommandBuilderTest.java
+++ b/actors/claude-code/src/test/java/io/apitomy/axiom/actors/claudecode/ClaudeCodeCommandBuilderTest.java
@@ -230,6 +230,29 @@ class ClaudeCodeCommandBuilderTest {
     }
 
     @Test
+    void testDeriveBaseToolNamesWithPatterns() {
+        String result = ClaudeCodeCommandBuilder.deriveBaseToolNames(List.of(
+                "Read", "Bash(git log *)", "Bash(git diff *)",
+                "mcp__axiom__axiom_project_get_details"
+        ));
+        assertEquals("Read,Bash,mcp__axiom__axiom_project_get_details", result);
+    }
+
+    @Test
+    void testDeriveBaseToolNamesEmptyList() {
+        String result = ClaudeCodeCommandBuilder.deriveBaseToolNames(List.of());
+        assertEquals("", result);
+    }
+
+    @Test
+    void testDeriveBaseToolNamesNoPatterns() {
+        String result = ClaudeCodeCommandBuilder.deriveBaseToolNames(List.of(
+                "Read", "Write", "Edit"
+        ));
+        assertEquals("Read,Write,Edit", result);
+    }
+
+    @Test
     void testAllowedToolsEmptyListFallsBackToAcceptEdits() {
         ActorContext context = ActorContext.builder()
                 .allowedTools(List.of())

--- a/app/src/main/java/io/apitomy/axiom/app/McpConfigGenerator.java
+++ b/app/src/main/java/io/apitomy/axiom/app/McpConfigGenerator.java
@@ -253,12 +253,13 @@ public class McpConfigGenerator {
      * Ensures the Axiom MCP server Node.js project is installed and dependencies
      * are resolved. On first call, copies the template project from classpath
      * resources to {@code ~/.axiom/mcp-server/} and runs {@code npm install}.
-     * Subsequent calls return the cached path.
+     * Subsequent calls return the cached path. Used by both the task execution
+     * path and the assistant session path.
      *
      * @return path to the installed MCP server project directory
      * @throws IOException if the project cannot be installed
      */
-    private Path ensureMcpServerInstalled() throws IOException {
+    public Path ensureMcpServerInstalled() throws IOException {
         if (mcpServerDir != null && Files.exists(mcpServerDir.resolve("node_modules"))
                 && Files.exists(mcpServerDir.resolve("sdk-server.js"))) {
             return mcpServerDir;
@@ -330,12 +331,13 @@ public class McpConfigGenerator {
     }
 
     /**
-     * Builds the JSON array of tool definitions for the MCP server.
+     * Builds the JSON array of tool definitions for the MCP server. Used by
+     * both the task execution path and the assistant session path.
      *
      * @param tools the tool definition entities to serialize
      * @return JSON string representing the tool definitions array
      */
-    private String buildToolsJson(List<ToolDefinitionEntity> tools) {
+    public String buildToolsJson(List<ToolDefinitionEntity> tools) {
         try {
             List<Map<String, Object>> toolsList = new ArrayList<>();
             for (ToolDefinitionEntity tool : tools) {

--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantContextBuilder.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantContextBuilder.java
@@ -125,12 +125,17 @@ public class AssistantContextBuilder {
         for (var entry : resolvedServers.entrySet()) {
             ObjectNode serverNode = servers.putObject(entry.getKey());
             McpServerConfig config = entry.getValue();
-            serverNode.put("command", config.command());
-            ArrayNode argsNode = serverNode.putArray("args");
-            config.args().forEach(argsNode::add);
-            if (!config.env().isEmpty()) {
-                ObjectNode envNode = serverNode.putObject("env");
-                config.env().forEach(envNode::put);
+            if (config.isHttpTransport()) {
+                serverNode.put("type", config.type());
+                serverNode.put("url", config.url());
+            } else {
+                serverNode.put("command", config.command());
+                ArrayNode argsNode = serverNode.putArray("args");
+                config.args().forEach(argsNode::add);
+                if (!config.env().isEmpty()) {
+                    ObjectNode envNode = serverNode.putObject("env");
+                    config.env().forEach(envNode::put);
+                }
             }
         }
         return root.toPrettyString();
@@ -138,8 +143,32 @@ public class AssistantContextBuilder {
 
     /**
      * Resolved MCP server configuration ready for the mcp-config.json file.
+     * Supports both stdio transport (command + args) and HTTP transport (url).
      */
     public record McpServerConfig(String command, List<String> args,
-                                    Map<String, String> env) {
+                                    Map<String, String> env,
+                                    String type, String url) {
+
+        /**
+         * Creates a stdio-transport MCP server configuration.
+         */
+        public static McpServerConfig stdio(String command, List<String> args,
+                                             Map<String, String> env) {
+            return new McpServerConfig(command, args, env, null, null);
+        }
+
+        /**
+         * Creates an HTTP-transport MCP server configuration.
+         */
+        public static McpServerConfig http(String url) {
+            return new McpServerConfig(null, List.of(), Map.of(), "http", url);
+        }
+
+        /**
+         * Returns whether this config uses HTTP transport.
+         */
+        public boolean isHttpTransport() {
+            return url != null && !url.isBlank();
+        }
     }
 }

--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantContextBuilder.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantContextBuilder.java
@@ -168,7 +168,7 @@ public class AssistantContextBuilder {
          * Returns whether this config uses HTTP transport.
          */
         public boolean isHttpTransport() {
-            return url != null && !url.isBlank();
+            return "http".equals(type);
         }
     }
 }

--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSessionManager.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSessionManager.java
@@ -5,10 +5,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.apitomy.axiom.app.ImportExportService;
+import io.apitomy.axiom.app.McpConfigGenerator;
 import io.apitomy.axiom.app.assistant.AssistantEventParser.SseEvent;
 import io.apitomy.axiom.core.entities.AiUsageEntity;
 import io.apitomy.axiom.core.entities.McpServerEntity;
 import io.apitomy.axiom.core.entities.ProjectEntity;
+import io.apitomy.axiom.core.entities.ToolDefinitionEntity;
 import io.apitomy.axiom.core.entities.ToolsetEntity;
 import io.apitomy.axiom.core.services.EnvironmentResolver;
 import io.apitomy.axiom.core.services.WorkspaceService;
@@ -83,6 +85,9 @@ public class AssistantSessionManager {
     WorkspaceService workspaceService;
 
     @Inject
+    McpConfigGenerator mcpConfigGenerator;
+
+    @Inject
     Event<io.apitomy.axiom.core.events.SseEvent> sseEventEmitter;
 
     private final Map<String, AssistantSession> sessions = new ConcurrentHashMap<>();
@@ -131,19 +136,23 @@ public class AssistantSessionManager {
                 }
             }
 
+            // Create session directory first — MCP server resolution may need
+            // to write files there (e.g. tools.json for @axiom-tools).
+            String sessionId = UUID.randomUUID().toString();
+            Path sessionDir = contextBuilder.createSessionDirectory(sessionId, null);
+
             // Resolve MCP servers from template
             Map<String, AssistantContextBuilder.McpServerConfig> mcpConfigs =
-                    resolveMcpServers(template, project);
+                    resolveMcpServers(template, project, sessionDir);
 
             // Resolve allowed tools from template
             List<String> resolvedAllowedTools = resolveAllowedTools(template);
 
-            // Build MCP config JSON
+            // Build and write MCP config JSON to session directory
             String mcpConfig = contextBuilder.buildMcpConfig(mcpConfigs);
-
-            // Create session directory (always under ~/.axiom/assistant/sessions/)
-            String sessionId = UUID.randomUUID().toString();
-            Path sessionDir = contextBuilder.createSessionDirectory(sessionId, mcpConfig);
+            if (mcpConfig != null) {
+                Files.writeString(sessionDir.resolve("mcp-config.json"), mcpConfig);
+            }
 
             // Determine working directory
             Path workDir;
@@ -683,48 +692,93 @@ public class AssistantSessionManager {
 
     private Map<String, AssistantContextBuilder.McpServerConfig> resolveMcpServers(
             SessionTemplateService.SessionTemplate template,
-            ProjectEntity project) throws IOException {
+            ProjectEntity project, Path sessionDir) throws IOException {
         Map<String, AssistantContextBuilder.McpServerConfig> configs = new LinkedHashMap<>();
+
+        String apiUrl = "http://localhost:" + httpPort + "/api/v1";
 
         for (String serverName : template.mcpServers()) {
             if ("@axiom-assistant".equals(serverName)) {
-                // Special built-in MCP server for the assistant
+                // Built-in MCP server for project-scoped assistant tools
                 Path mcpServerDir = ensureAssistantMcpServerInstalled();
                 String serverJsPath = mcpServerDir.resolve("server.js")
                         .toAbsolutePath().toString();
-                String apiUrl = "http://localhost:" + httpPort + "/api/v1";
                 Map<String, String> env = new LinkedHashMap<>();
                 env.put("AXIOM_API_URL", apiUrl);
                 if (project != null) {
                     env.put("AXIOM_PROJECT_ID", String.valueOf(project.id));
                 }
-                configs.put("axiom", new AssistantContextBuilder.McpServerConfig(
-                        "node",
-                        List.of(serverJsPath),
-                        env));
+                configs.put("axiom", AssistantContextBuilder.McpServerConfig.stdio(
+                        "node", List.of(serverJsPath), env));
+
+            } else if ("@axiom-tools".equals(serverName)) {
+                // Built-in MCP server for user-defined script tools.
+                // Same server project as the task execution path — loads
+                // tool definitions from a generated tools.json file.
+                List<ToolDefinitionEntity> scriptTools =
+                        ToolDefinitionEntity.listAll();
+                if (!scriptTools.isEmpty()) {
+                    Path serverDir = mcpConfigGenerator.ensureMcpServerInstalled();
+                    String toolsJson = mcpConfigGenerator.buildToolsJson(scriptTools);
+                    Path toolsFile = sessionDir.resolve("tools.json");
+                    Files.writeString(toolsFile, toolsJson);
+                    Map<String, String> env = new LinkedHashMap<>();
+                    env.put("AXIOM_API_URL", apiUrl);
+                    configs.put("axiom-tools",
+                            AssistantContextBuilder.McpServerConfig.stdio("node",
+                                    List.of(serverDir.resolve("tools-server.js")
+                                                    .toAbsolutePath().toString(),
+                                            toolsFile.toAbsolutePath().toString()),
+                                    env));
+                } else {
+                    LOG.infof("No script tools defined — skipping @axiom-tools server");
+                }
+
+            } else if ("@axiom-sdk".equals(serverName)) {
+                // Built-in MCP server for Axiom SDK tools (project/task management)
+                Path serverDir = mcpConfigGenerator.ensureMcpServerInstalled();
+                Map<String, String> env = new LinkedHashMap<>();
+                env.put("AXIOM_API_URL", apiUrl);
+                configs.put("axiom-sdk",
+                        AssistantContextBuilder.McpServerConfig.stdio("node",
+                                List.of(serverDir.resolve("sdk-server.js")
+                                        .toAbsolutePath().toString()),
+                                env));
+
             } else {
                 // Resolve from database
                 McpServerEntity entity = McpServerEntity.find("name", serverName).firstResult();
-                if (entity != null && entity.serverCommand != null) {
-                    List<String> args = new ArrayList<>();
-                    if (entity.serverArgs != null && !entity.serverArgs.isBlank()) {
-                        JsonNode argsNode = objectMapper.readTree(entity.serverArgs);
-                        if (argsNode.isArray()) {
-                            for (JsonNode arg : argsNode) {
-                                args.add(arg.asText());
+                if (entity != null) {
+                    if (entity.serverUrl != null && !entity.serverUrl.isBlank()) {
+                        // HTTP transport
+                        configs.put(serverName,
+                                AssistantContextBuilder.McpServerConfig.http(entity.serverUrl));
+                    } else if (entity.serverCommand != null) {
+                        // Stdio transport
+                        List<String> args = new ArrayList<>();
+                        if (entity.serverArgs != null && !entity.serverArgs.isBlank()) {
+                            JsonNode argsNode = objectMapper.readTree(entity.serverArgs);
+                            if (argsNode.isArray()) {
+                                for (JsonNode arg : argsNode) {
+                                    args.add(arg.asText());
+                                }
                             }
                         }
+                        Map<String, String> env = new LinkedHashMap<>();
+                        if (entity.serverEnv != null && !entity.serverEnv.isBlank()) {
+                            JsonNode envNode = objectMapper.readTree(entity.serverEnv);
+                            envNode.fields().forEachRemaining(
+                                    field -> env.put(field.getKey(),
+                                            field.getValue().asText()));
+                        }
+                        configs.put(serverName,
+                                AssistantContextBuilder.McpServerConfig.stdio(
+                                        entity.serverCommand, args, env));
+                    } else {
+                        LOG.warnf("MCP server has neither URL nor command: %s", serverName);
                     }
-                    Map<String, String> env = new LinkedHashMap<>();
-                    if (entity.serverEnv != null && !entity.serverEnv.isBlank()) {
-                        JsonNode envNode = objectMapper.readTree(entity.serverEnv);
-                        envNode.fields().forEachRemaining(
-                                field -> env.put(field.getKey(), field.getValue().asText()));
-                    }
-                    configs.put(serverName, new AssistantContextBuilder.McpServerConfig(
-                            entity.serverCommand, args, env));
                 } else {
-                    LOG.warnf("MCP server not found or has no command: %s", serverName);
+                    LOG.warnf("MCP server not found: %s", serverName);
                 }
             }
         }

--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSessionManager.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSessionManager.java
@@ -136,14 +136,30 @@ public class AssistantSessionManager {
                 }
             }
 
+            // Resolve environment variables early — MCP server resolution needs
+            // them (e.g. @axiom-tools passes env to the tools MCP server).
+            Map<String, String> resolvedEnv = new LinkedHashMap<>();
+            if (environmentResolver.hasCustomEnvironment(template.environment())) {
+                resolvedEnv.putAll(environmentResolver.resolve(template.environment()));
+            }
+
+            // Inject project environment variables
+            if (project != null) {
+                resolvedEnv.put("AXIOM_PROJECT_ID", String.valueOf(project.id));
+                resolvedEnv.put("AXIOM_PROJECT_NAME", project.name);
+                resolvedEnv.put("AXIOM_ISSUE_REF", project.issueRef);
+                resolvedEnv.put("AXIOM_REPOSITORY", project.repository);
+            }
+
             // Create session directory first — MCP server resolution may need
             // to write files there (e.g. tools.json for @axiom-tools).
             String sessionId = UUID.randomUUID().toString();
             Path sessionDir = contextBuilder.createSessionDirectory(sessionId, null);
 
+            try {
             // Resolve MCP servers from template
             Map<String, AssistantContextBuilder.McpServerConfig> mcpConfigs =
-                    resolveMcpServers(template, project, sessionDir);
+                    resolveMcpServers(template, project, sessionDir, resolvedEnv);
 
             // Resolve allowed tools from template
             List<String> resolvedAllowedTools = resolveAllowedTools(template);
@@ -177,20 +193,6 @@ public class AssistantSessionManager {
             if (template.initScript() != null && !template.initScript().isBlank()) {
                 runInitScript(workDir, sessionDir, template.initScript(),
                         template.initScriptType());
-            }
-
-            // Resolve environment variables (with secret substitution)
-            Map<String, String> resolvedEnv = new LinkedHashMap<>();
-            if (environmentResolver.hasCustomEnvironment(template.environment())) {
-                resolvedEnv.putAll(environmentResolver.resolve(template.environment()));
-            }
-
-            // Inject project environment variables
-            if (project != null) {
-                resolvedEnv.put("AXIOM_PROJECT_ID", String.valueOf(project.id));
-                resolvedEnv.put("AXIOM_PROJECT_NAME", project.name);
-                resolvedEnv.put("AXIOM_ISSUE_REF", project.issueRef);
-                resolvedEnv.put("AXIOM_REPOSITORY", project.repository);
             }
 
             // Build system prompt, augmenting with project context if applicable
@@ -250,6 +252,11 @@ public class AssistantSessionManager {
             }
 
             return session;
+            } catch (Exception e) {
+                // Clean up the session directory if setup fails after creation
+                contextBuilder.deleteSessionDirectory(sessionDir);
+                throw e;
+            }
         } catch (Exception e) {
             sessionCount.decrementAndGet();
             throw e;
@@ -692,7 +699,8 @@ public class AssistantSessionManager {
 
     private Map<String, AssistantContextBuilder.McpServerConfig> resolveMcpServers(
             SessionTemplateService.SessionTemplate template,
-            ProjectEntity project, Path sessionDir) throws IOException {
+            ProjectEntity project, Path sessionDir,
+            Map<String, String> sessionEnv) throws IOException {
         Map<String, AssistantContextBuilder.McpServerConfig> configs = new LinkedHashMap<>();
 
         String apiUrl = "http://localhost:" + httpPort + "/api/v1";
@@ -722,8 +730,8 @@ public class AssistantSessionManager {
                     String toolsJson = mcpConfigGenerator.buildToolsJson(scriptTools);
                     Path toolsFile = sessionDir.resolve("tools.json");
                     Files.writeString(toolsFile, toolsJson);
-                    Map<String, String> env = new LinkedHashMap<>();
-                    env.put("AXIOM_API_URL", apiUrl);
+                    Map<String, String> env = new LinkedHashMap<>(sessionEnv);
+                    env.putIfAbsent("AXIOM_API_URL", apiUrl);
                     configs.put("axiom-tools",
                             AssistantContextBuilder.McpServerConfig.stdio("node",
                                     List.of(serverDir.resolve("tools-server.js")


### PR DESCRIPTION
## Summary

Fixes #108 — MCP tools configured in a session template's "Allowed Tools" section were not callable
at runtime, failing with `No such tool available`.

- **Root cause**: The `axiom-tools` and `axiom-sdk` MCP servers are built-in servers constructed
  programmatically by `McpConfigGenerator` only in the task execution path. The assistant session
  path's `resolveMcpServers()` only knew about `@axiom-assistant` and database-defined
  `McpServerEntity` records — it looked up `axiom-tools` in the database, got null, and silently
  dropped the server. The MCP server was never started, so its tools were never discovered.
- Added `@axiom-tools` and `@axiom-sdk` as recognized built-in server names in `resolveMcpServers()`,
  reusing `McpConfigGenerator.ensureMcpServerInstalled()` and `buildToolsJson()` to construct them
  identically to the task execution path.
- Fixed HTTP-transport MCP servers being silently dropped for database-defined servers.
- Extracted `deriveBaseToolNames()` in `ClaudeCodeCommandBuilder` as a minor refactor.

## Test plan

- [x] `build.sh` passes (compilation + all unit tests)
- [ ] Create a session template with `@axiom-tools` in `mcpServers` and `mcp__axiom-tools__*` tools
  in `allowedTools` — verify tools are callable at runtime
- [ ] Create a session template with `@axiom-sdk` in `mcpServers` — verify SDK tools are available
- [ ] Verify existing `@axiom-assistant` sessions (project-assistant, config-assistant) still work
- [ ] If an HTTP-transport MCP server exists, verify it is included in the session's MCP config