### PR TITLE
Make operational config properties runtime-configurable via database

### DIFF
--- a/actors/claude-code/src/main/java/io/apitomy/axiom/actors/claudecode/ClaudeCodeActor.java
+++ b/actors/claude-code/src/main/java/io/apitomy/axiom/actors/claudecode/ClaudeCodeActor.java
@@ -4,15 +4,15 @@ import io.apitomy.axiom.actors.spi.Actor;
 import io.apitomy.axiom.actors.spi.ActorContext;
 import io.apitomy.axiom.actors.spi.TaskResult;
 import io.apitomy.axiom.core.entities.TaskEntity;
+import io.apitomy.axiom.core.services.SystemSettingsService;
 import jakarta.enterprise.context.ApplicationScoped;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
+import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -26,17 +26,8 @@ public class ClaudeCodeActor implements Actor {
 
     private static final Logger LOG = Logger.getLogger(ClaudeCodeActor.class);
 
-    @ConfigProperty(name = "axiom.claude-code.model")
-    Optional<String> model;
-
-    @ConfigProperty(name = "axiom.claude-code.max-turns", defaultValue = "50")
-    int maxTurns;
-
-    @ConfigProperty(name = "axiom.claude-code.max-budget-usd", defaultValue = "5.0")
-    double maxBudgetUsd;
-
-    @ConfigProperty(name = "axiom.claude-code.timeout-seconds", defaultValue = "600")
-    int timeoutSeconds;
+    @Inject
+    SystemSettingsService settingsService;
 
     private final Map<Long, ClaudeCodeSubprocess> runningProcesses = new ConcurrentHashMap<>();
 
@@ -67,14 +58,17 @@ public class ClaudeCodeActor implements Actor {
 
         ClaudeCodeCommandBuilder cmdBuilder = ClaudeCodeCommandBuilder
                 .fromContext(prompt, context)
-                .maxTurns(maxTurns)
-                .maxBudgetUsd(maxBudgetUsd);
+                .maxTurns(settingsService.getClaudeCodeMaxTurns())
+                .maxBudgetUsd(settingsService.getClaudeCodeMaxBudgetUsd());
 
         // Per-action-type model takes priority over the global default
         if (context.getModel() != null && !context.getModel().isBlank()) {
             cmdBuilder.model(context.getModel());
         } else {
-            model.ifPresent(cmdBuilder::model);
+            String globalModel = settingsService.getClaudeCodeModel();
+            if (globalModel != null) {
+                cmdBuilder.model(globalModel);
+            }
         }
 
         if (context.getMcpConfigFile() != null) {
@@ -90,7 +84,7 @@ public class ClaudeCodeActor implements Actor {
                 command,
                 workDir,
                 context.getEnvironment() != null ? context.getEnvironment() : Map.of(),
-                Duration.ofSeconds(timeoutSeconds),
+                Duration.ofSeconds(settingsService.getClaudeCodeTimeoutSeconds()),
                 line -> LOG.tracef("Task %d stream: %s", task.id, line),
                 logBuilder
         );

--- a/app/src/main/java/io/apitomy/axiom/app/ActionTypeAiService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ActionTypeAiService.java
@@ -8,10 +8,10 @@ import io.apitomy.axiom.core.entities.AiUsageEntity;
 import io.apitomy.axiom.engine.spi.AiEngine;
 import io.apitomy.axiom.engine.spi.AiEngineConfig;
 import io.apitomy.axiom.engine.spi.AiEngineResult;
+import io.apitomy.axiom.core.services.SystemSettingsService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 import java.time.Instant;
@@ -33,8 +33,8 @@ public class ActionTypeAiService {
     @Inject
     AiEngine aiEngine;
 
-    @ConfigProperty(name = "axiom.ai-assistant.timeout-seconds", defaultValue = "300")
-    int assistantTimeoutSeconds;
+    @Inject
+    SystemSettingsService settingsService;
 
     private static final String SYSTEM_PROMPT = """
             You are an action type editor for Apicurio Axiom. Your job is to create \
@@ -126,7 +126,7 @@ public class ActionTypeAiService {
                 .systemPrompt(SYSTEM_PROMPT)
                 .allowedTools(List.of("StructuredOutput"))
                 .maxSteps(3)
-                .timeoutSeconds(assistantTimeoutSeconds)
+                .timeoutSeconds(settingsService.getAssistantTimeoutSeconds())
                 .build();
 
         try {

--- a/app/src/main/java/io/apitomy/axiom/app/EventSourceLogCleanup.java
+++ b/app/src/main/java/io/apitomy/axiom/app/EventSourceLogCleanup.java
@@ -1,10 +1,11 @@
 package io.apitomy.axiom.app;
 
 import io.apitomy.axiom.core.entities.EventSourceLogEntity;
+import io.apitomy.axiom.core.services.SystemSettingsService;
 import io.quarkus.scheduler.Scheduled;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 import java.time.Instant;
@@ -20,8 +21,8 @@ public class EventSourceLogCleanup {
 
     private static final Logger LOG = Logger.getLogger(EventSourceLogCleanup.class);
 
-    @ConfigProperty(name = "axiom.event-source-logs.retention-days", defaultValue = "7")
-    int retentionDays;
+    @Inject
+    SystemSettingsService settingsService;
 
     /**
      * Deletes event source log entries older than the retention period.
@@ -29,6 +30,7 @@ public class EventSourceLogCleanup {
     @Scheduled(every = "1h", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
     @Transactional
     void cleanup() {
+        int retentionDays = settingsService.getEventSourceLogRetentionDays();
         Instant cutoff = Instant.now().minus(retentionDays, ChronoUnit.DAYS);
         long deleted = EventSourceLogEntity.delete("createdOn < ?1", cutoff);
         if (deleted > 0) {

--- a/app/src/main/java/io/apitomy/axiom/app/ReportAiService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ReportAiService.java
@@ -10,10 +10,10 @@ import io.apitomy.axiom.actors.spi.ActorContext;
 import io.apitomy.axiom.api.beans.ReportAiEditRequest;
 import io.apitomy.axiom.api.beans.ReportAiEditResponse;
 import io.apitomy.axiom.core.entities.AiUsageEntity;
+import io.apitomy.axiom.core.services.SystemSettingsService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 import java.time.Duration;
@@ -21,7 +21,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * Service that invokes Claude Code to generate or update report definition
@@ -35,8 +34,8 @@ public class ReportAiService {
     @Inject
     ObjectMapper objectMapper;
 
-    @ConfigProperty(name = "axiom.manager.model")
-    Optional<String> model;
+    @Inject
+    SystemSettingsService settingsService;
 
     private static final String SYSTEM_PROMPT = """
             You are a report definition editor for Apicurio Axiom. Your job is to create \
@@ -136,7 +135,10 @@ public class ReportAiService {
                 .streamJson(true)
                 .maxTurns(3);
 
-        model.ifPresent(cmdBuilder::model);
+        String managerModel = settingsService.getManagerModel();
+        if (managerModel != null) {
+            cmdBuilder.model(managerModel);
+        }
 
         List<String> command = cmdBuilder.build();
         command.add("--json-schema");

--- a/app/src/main/java/io/apitomy/axiom/app/ReportExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ReportExecutionService.java
@@ -13,6 +13,7 @@ import io.apitomy.axiom.core.entities.ReportEntity;
 import io.apitomy.axiom.core.entities.SecretEntity;
 import io.apitomy.axiom.core.services.EncryptionService;
 import io.apitomy.axiom.core.services.EnvironmentResolver;
+import io.apitomy.axiom.core.services.SystemSettingsService;
 import io.apitomy.axiom.core.services.ToolsetResolver;
 import io.apitomy.axiom.engine.spi.AiEngine;
 import io.apitomy.axiom.engine.spi.AiEngineConfig;
@@ -21,7 +22,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Event;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 import java.nio.file.Path;
@@ -32,7 +32,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * Executes report generation by invoking the AI engine with a prompt template,
@@ -68,11 +67,8 @@ public class ReportExecutionService {
     @Inject
     TraceService traceService;
 
-    @ConfigProperty(name = "axiom.claude-code.model")
-    Optional<String> model;
-
-    @ConfigProperty(name = "axiom.claude-code.timeout-seconds", defaultValue = "600")
-    int timeoutSeconds;
+    @Inject
+    SystemSettingsService settingsService;
 
     private static final String SYSTEM_PROMPT = """
             You are a report generator for Apicurio Axiom. Your job is to gather \
@@ -148,13 +144,13 @@ public class ReportExecutionService {
 
         // Build engine-agnostic config
         int effectiveTimeout = definition.timeoutSeconds != null
-                ? definition.timeoutSeconds : timeoutSeconds;
+                ? definition.timeoutSeconds : settingsService.getClaudeCodeTimeoutSeconds();
         AiEngineConfig engineConfig = AiEngineConfig.builder()
                 .systemPrompt(SYSTEM_PROMPT)
                 .allowedTools(allowedTools)
                 .timeoutSeconds(effectiveTimeout)
                 .maxSteps(30)
-                .model(model.orElse(null))
+                .model(settingsService.getClaudeCodeModel())
                 .environment(env)
                 .mcpConfigFile(mcpConfig)
                 .build();

--- a/app/src/main/java/io/apitomy/axiom/app/ScriptAiService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ScriptAiService.java
@@ -8,15 +8,14 @@ import io.apitomy.axiom.core.entities.AiUsageEntity;
 import io.apitomy.axiom.engine.spi.AiEngine;
 import io.apitomy.axiom.engine.spi.AiEngineConfig;
 import io.apitomy.axiom.engine.spi.AiEngineResult;
+import io.apitomy.axiom.core.services.SystemSettingsService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 import java.time.Instant;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Service that invokes the AI engine to generate or update bash script
@@ -33,11 +32,8 @@ public class ScriptAiService {
     @Inject
     AiEngine aiEngine;
 
-    @ConfigProperty(name = "axiom.manager.model")
-    Optional<String> model;
-
-    @ConfigProperty(name = "axiom.ai-assistant.timeout-seconds", defaultValue = "300")
-    int assistantTimeoutSeconds;
+    @Inject
+    SystemSettingsService settingsService;
 
     private static final String SYSTEM_PROMPT = """
             You are a script editor for Apicurio Axiom. Your job is to create or update \
@@ -116,9 +112,9 @@ public class ScriptAiService {
         AiEngineConfig engineConfig = AiEngineConfig.builder()
                 .systemPrompt(SYSTEM_PROMPT)
                 .allowedTools(List.of("StructuredOutput"))
-                .timeoutSeconds(assistantTimeoutSeconds)
+                .timeoutSeconds(settingsService.getAssistantTimeoutSeconds())
                 .maxSteps(3)
-                .model(model.orElse(null))
+                .model(settingsService.getManagerModel())
                 .build();
 
         try {

--- a/app/src/main/java/io/apitomy/axiom/app/ScriptExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ScriptExecutionService.java
@@ -11,6 +11,7 @@ import io.apitomy.axiom.core.entities.ThreadEntryEntity;
 import io.apitomy.axiom.core.events.SseEvent;
 import io.apitomy.axiom.core.services.EncryptionService;
 import io.apitomy.axiom.core.services.EnvironmentResolver;
+import io.apitomy.axiom.core.services.SystemSettingsService;
 import io.quarkus.arc.Arc;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Event;
@@ -48,11 +49,11 @@ public class ScriptExecutionService {
     @Inject
     TraceService traceService;
 
+    @Inject
+    SystemSettingsService settingsService;
+
     @ConfigProperty(name = "quarkus.http.port", defaultValue = "9090")
     int httpPort;
-
-    @ConfigProperty(name = "axiom.script.timeout-seconds", defaultValue = "60")
-    int timeoutSeconds;
 
     /**
      * Executes the script for a task asynchronously.
@@ -113,7 +114,7 @@ public class ScriptExecutionService {
             scriptFile.toFile().setExecutable(true);
 
             LOG.infof("Executing script for task %d (%s), timeout %ds",
-                    task.id, task.actionType, timeoutSeconds);
+                    task.id, task.actionType, settingsService.getScriptTimeoutSeconds());
 
             ProcessBuilder pb = new ProcessBuilder("/bin/bash", scriptFile.toString())
                     .redirectErrorStream(true);
@@ -136,7 +137,7 @@ public class ScriptExecutionService {
 
             Process process = pb.start();
             String output = new String(process.getInputStream().readAllBytes());
-            boolean finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS);
+            boolean finished = process.waitFor(settingsService.getScriptTimeoutSeconds(), TimeUnit.SECONDS);
             Instant endTime = Instant.now();
             long durationMs = java.time.Duration.between(startTime, endTime).toMillis();
 
@@ -144,7 +145,7 @@ public class ScriptExecutionService {
             if (!finished) {
                 process.destroyForcibly();
                 exitCode = 1;
-                output = output + "\n[Script timed out after " + timeoutSeconds + "s]";
+                output = output + "\n[Script timed out after " + settingsService.getScriptTimeoutSeconds() + "s]";
             } else {
                 exitCode = process.exitValue();
             }

--- a/app/src/main/java/io/apitomy/axiom/app/ToolAiService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ToolAiService.java
@@ -10,16 +10,15 @@ import io.apitomy.axiom.core.entities.AiUsageEntity;
 import io.apitomy.axiom.engine.spi.AiEngine;
 import io.apitomy.axiom.engine.spi.AiEngineConfig;
 import io.apitomy.axiom.engine.spi.AiEngineResult;
+import io.apitomy.axiom.core.services.SystemSettingsService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Service that invokes the AI engine to generate or update tool definitions
@@ -36,11 +35,8 @@ public class ToolAiService {
     @Inject
     AiEngine aiEngine;
 
-    @ConfigProperty(name = "axiom.manager.model")
-    Optional<String> model;
-
-    @ConfigProperty(name = "axiom.ai-assistant.timeout-seconds", defaultValue = "300")
-    int assistantTimeoutSeconds;
+    @Inject
+    SystemSettingsService settingsService;
 
     private static final String SYSTEM_PROMPT = """
             You are a tool definition editor for Apicurio Axiom. Your job is to create \
@@ -121,9 +117,9 @@ public class ToolAiService {
         AiEngineConfig engineConfig = AiEngineConfig.builder()
                 .systemPrompt(SYSTEM_PROMPT)
                 .allowedTools(List.of("StructuredOutput"))
-                .timeoutSeconds(assistantTimeoutSeconds)
+                .timeoutSeconds(settingsService.getAssistantTimeoutSeconds())
                 .maxSteps(3)
-                .model(model.orElse(null))
+                .model(settingsService.getManagerModel())
                 .build();
 
         try {

--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSessionManager.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSessionManager.java
@@ -18,6 +18,7 @@ import io.quarkus.runtime.StartupEvent;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
+import io.apitomy.axiom.core.services.SystemSettingsService;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
@@ -49,11 +50,8 @@ public class AssistantSessionManager {
     private static final String ASSISTANT_MCP_DIR_NAME = "assistant-mcp-server";
     private static final String[] MCP_TEMPLATE_FILES = { "package.json", "server.js" };
 
-    @ConfigProperty(name = "axiom.assistant.max-sessions", defaultValue = "3")
-    int maxSessions;
-
-    @ConfigProperty(name = "axiom.ai-engine", defaultValue = "claude-code")
-    String aiEngine;
+    @Inject
+    SystemSettingsService settingsService;
 
     @ConfigProperty(name = "axiom.claude-code.executable", defaultValue = "claude")
     String claudeExecutable;
@@ -103,17 +101,17 @@ public class AssistantSessionManager {
      */
     public AssistantSession createSession(String name, String templateId,
                                           Long projectId) throws IOException {
-        if (!"claude-code".equals(aiEngine)) {
+        if (!"claude-code".equals(settingsService.getAiEngine())) {
             throw new IllegalStateException(
                     "The AI Assistant requires Claude Code as the active AI engine. "
-                            + "Current engine: " + aiEngine);
+                            + "Current engine: " + settingsService.getAiEngine());
         }
 
         // Atomically reserve a session slot before doing any setup work.
-        if (sessionCount.incrementAndGet() > maxSessions) {
+        if (sessionCount.incrementAndGet() > settingsService.getAssistantMaxSessions()) {
             sessionCount.decrementAndGet();
             throw new SessionLimitReachedException(
-                    "Maximum number of assistant sessions reached (" + maxSessions + ")");
+                    "Maximum number of assistant sessions reached (" + settingsService.getAssistantMaxSessions() + ")");
         }
 
         try {
@@ -447,7 +445,7 @@ public class AssistantSessionManager {
      * @return true if Claude Code is the active engine
      */
     public boolean isAvailable() {
-        return "claude-code".equals(aiEngine);
+        return "claude-code".equals(settingsService.getAiEngine());
     }
 
     /**

--- a/app/src/main/java/io/apitomy/axiom/app/rest/SystemResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/SystemResourceImpl.java
@@ -8,14 +8,19 @@ import io.apitomy.axiom.api.beans.PackExportRequest;
 import io.apitomy.axiom.api.beans.StartupCheck;
 import io.apitomy.axiom.api.beans.SystemConfig;
 import io.apitomy.axiom.api.beans.SystemHealth;
+import io.apitomy.axiom.api.beans.SystemSettings;
 import io.apitomy.axiom.api.SystemResource;
 import io.apitomy.axiom.app.ImportExportService;
 import io.apitomy.axiom.app.StartupCheckService;
+import io.apitomy.axiom.core.entities.SystemSettingsEntity;
+import io.apitomy.axiom.core.services.SystemSettingsService;
 import io.apitomy.axiom.engine.spi.AiEngine;
 import io.apitomy.axiom.engine.spi.AiEngineRegistry;
 import io.smallrye.common.annotation.RunOnVirtualThread;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 
 import java.io.InputStream;
@@ -24,7 +29,6 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Implementation of the System API endpoints.
@@ -36,13 +40,8 @@ public class SystemResourceImpl implements SystemResource {
     @ConfigProperty(name = "quarkus.application.version", defaultValue = "1.0.0-SNAPSHOT")
     String applicationVersion;
 
-    @ConfigProperty(name = "axiom.claude-code.available-models",
-            defaultValue = "claude-opus-4-7,claude-sonnet-4-6,claude-opus-4-6,claude-haiku-4-5-20251001,opus,sonnet,haiku")
-    String claudeAvailableModels;
-
-    @ConfigProperty(name = "axiom.opencode.available-models",
-            defaultValue = "anthropic/claude-sonnet-4-6,anthropic/claude-opus-4-6,anthropic/claude-haiku-4-5-20251001,openai/gpt-4o,openai/o3-mini")
-    String openCodeAvailableModels;
+    @Inject
+    SystemSettingsService settingsService;
 
     @Inject
     AiEngine aiEngine;
@@ -111,8 +110,8 @@ public class SystemResourceImpl implements SystemResource {
     public List<String> listModels(String engine) {
         String engineType = (engine != null && !engine.isBlank()) ? engine : aiEngine.getType();
         String models = "opencode".equals(engineType)
-                ? openCodeAvailableModels
-                : claudeAvailableModels;
+                ? settingsService.getOpencodeAvailableModels()
+                : settingsService.getClaudeCodeAvailableModels();
 
         return Arrays.stream(models.split(","))
                 .map(String::trim)
@@ -145,6 +144,150 @@ public class SystemResourceImpl implements SystemResource {
         } catch (Exception e) {
             throw new jakarta.ws.rs.WebApplicationException(
                     "Failed to parse pack JSON: " + e.getMessage(), 400);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SystemSettings getSystemSettings() {
+        return toBean(settingsService);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Transactional
+    public SystemSettings updateSystemSettings(SystemSettings data) {
+        validateSettings(data);
+
+        SystemSettingsEntity entity = SystemSettingsEntity.<SystemSettingsEntity>findAll()
+                .firstResult();
+        if (entity == null) {
+            entity = new SystemSettingsEntity();
+        }
+
+        if (data.getManagerMaxTurns() != null) {
+            entity.managerMaxTurns = data.getManagerMaxTurns().intValue();
+        }
+        if (data.getManagerConfidenceThreshold() != null) {
+            entity.managerConfidenceThreshold = data.getManagerConfidenceThreshold().doubleValue();
+        }
+        if (data.getManagerTimeoutSeconds() != null) {
+            entity.managerTimeoutSeconds = data.getManagerTimeoutSeconds().intValue();
+        }
+        if (data.getManagerModel() != null) {
+            entity.managerModel = data.getManagerModel().isBlank() ? null : data.getManagerModel();
+        }
+        if (data.getClaudeCodeMaxTurns() != null) {
+            entity.claudeCodeMaxTurns = data.getClaudeCodeMaxTurns().intValue();
+        }
+        if (data.getClaudeCodeMaxBudgetUsd() != null) {
+            entity.claudeCodeMaxBudgetUsd = data.getClaudeCodeMaxBudgetUsd().doubleValue();
+        }
+        if (data.getClaudeCodeTimeoutSeconds() != null) {
+            entity.claudeCodeTimeoutSeconds = data.getClaudeCodeTimeoutSeconds().intValue();
+        }
+        if (data.getClaudeCodeModel() != null) {
+            entity.claudeCodeModel = data.getClaudeCodeModel().isBlank() ? null : data.getClaudeCodeModel();
+        }
+        if (data.getClaudeCodeAvailableModels() != null) {
+            entity.claudeCodeAvailableModels = data.getClaudeCodeAvailableModels();
+        }
+        if (data.getOpencodeMaxSteps() != null) {
+            entity.opencodeMaxSteps = data.getOpencodeMaxSteps().intValue();
+        }
+        if (data.getOpencodeTimeoutSeconds() != null) {
+            entity.opencodeTimeoutSeconds = data.getOpencodeTimeoutSeconds().intValue();
+        }
+        if (data.getOpencodeModel() != null) {
+            entity.opencodeModel = data.getOpencodeModel().isBlank() ? null : data.getOpencodeModel();
+        }
+        if (data.getOpencodeAvailableModels() != null) {
+            entity.opencodeAvailableModels = data.getOpencodeAvailableModels();
+        }
+        if (data.getAssistantMaxSessions() != null) {
+            entity.assistantMaxSessions = data.getAssistantMaxSessions().intValue();
+        }
+        if (data.getAssistantTimeoutSeconds() != null) {
+            entity.assistantTimeoutSeconds = data.getAssistantTimeoutSeconds().intValue();
+        }
+        if (data.getAiEngine() != null) {
+            entity.aiEngine = data.getAiEngine();
+        }
+        if (data.getEventSourceLogRetentionDays() != null) {
+            entity.eventSourceLogRetentionDays = data.getEventSourceLogRetentionDays().intValue();
+        }
+        if (data.getScriptTimeoutSeconds() != null) {
+            entity.scriptTimeoutSeconds = data.getScriptTimeoutSeconds().intValue();
+        }
+
+        settingsService.update(entity);
+        return toBean(settingsService);
+    }
+
+    private SystemSettings toBean(SystemSettingsService svc) {
+        SystemSettings bean = new SystemSettings();
+        bean.setManagerMaxTurns(svc.getManagerMaxTurns());
+        bean.setManagerConfidenceThreshold(svc.getManagerConfidenceThreshold());
+        bean.setManagerTimeoutSeconds(svc.getManagerTimeoutSeconds());
+        bean.setManagerModel(svc.getManagerModel());
+        bean.setClaudeCodeMaxTurns(svc.getClaudeCodeMaxTurns());
+        bean.setClaudeCodeMaxBudgetUsd(svc.getClaudeCodeMaxBudgetUsd());
+        bean.setClaudeCodeTimeoutSeconds(svc.getClaudeCodeTimeoutSeconds());
+        bean.setClaudeCodeModel(svc.getClaudeCodeModel());
+        bean.setClaudeCodeAvailableModels(svc.getClaudeCodeAvailableModels());
+        bean.setOpencodeMaxSteps(svc.getOpencodeMaxSteps());
+        bean.setOpencodeTimeoutSeconds(svc.getOpencodeTimeoutSeconds());
+        bean.setOpencodeModel(svc.getOpencodeModel());
+        bean.setOpencodeAvailableModels(svc.getOpencodeAvailableModels());
+        bean.setAssistantMaxSessions(svc.getAssistantMaxSessions());
+        bean.setAssistantTimeoutSeconds(svc.getAssistantTimeoutSeconds());
+        bean.setAiEngine(svc.getAiEngine());
+        bean.setEventSourceLogRetentionDays(svc.getEventSourceLogRetentionDays());
+        bean.setScriptTimeoutSeconds(svc.getScriptTimeoutSeconds());
+        return bean;
+    }
+
+    private void validateSettings(SystemSettings data) {
+        if (data.getManagerMaxTurns() != null && data.getManagerMaxTurns() < 1) {
+            throw new WebApplicationException("managerMaxTurns must be >= 1", 400);
+        }
+        if (data.getManagerConfidenceThreshold() != null
+                && (data.getManagerConfidenceThreshold() < 0 || data.getManagerConfidenceThreshold() > 1)) {
+            throw new WebApplicationException("managerConfidenceThreshold must be between 0 and 1", 400);
+        }
+        if (data.getManagerTimeoutSeconds() != null && data.getManagerTimeoutSeconds() < 1) {
+            throw new WebApplicationException("managerTimeoutSeconds must be >= 1", 400);
+        }
+        if (data.getClaudeCodeMaxTurns() != null && data.getClaudeCodeMaxTurns() < 1) {
+            throw new WebApplicationException("claudeCodeMaxTurns must be >= 1", 400);
+        }
+        if (data.getClaudeCodeMaxBudgetUsd() != null && data.getClaudeCodeMaxBudgetUsd() < 0) {
+            throw new WebApplicationException("claudeCodeMaxBudgetUsd must be >= 0", 400);
+        }
+        if (data.getClaudeCodeTimeoutSeconds() != null && data.getClaudeCodeTimeoutSeconds() < 1) {
+            throw new WebApplicationException("claudeCodeTimeoutSeconds must be >= 1", 400);
+        }
+        if (data.getOpencodeMaxSteps() != null && data.getOpencodeMaxSteps() < 1) {
+            throw new WebApplicationException("opencodeMaxSteps must be >= 1", 400);
+        }
+        if (data.getOpencodeTimeoutSeconds() != null && data.getOpencodeTimeoutSeconds() < 1) {
+            throw new WebApplicationException("opencodeTimeoutSeconds must be >= 1", 400);
+        }
+        if (data.getAssistantMaxSessions() != null && data.getAssistantMaxSessions() < 1) {
+            throw new WebApplicationException("assistantMaxSessions must be >= 1", 400);
+        }
+        if (data.getAssistantTimeoutSeconds() != null && data.getAssistantTimeoutSeconds() < 1) {
+            throw new WebApplicationException("assistantTimeoutSeconds must be >= 1", 400);
+        }
+        if (data.getEventSourceLogRetentionDays() != null && data.getEventSourceLogRetentionDays() < 1) {
+            throw new WebApplicationException("eventSourceLogRetentionDays must be >= 1", 400);
+        }
+        if (data.getScriptTimeoutSeconds() != null && data.getScriptTimeoutSeconds() < 1) {
+            throw new WebApplicationException("scriptTimeoutSeconds must be >= 1", 400);
         }
     }
 }

--- a/app/src/main/resources/db/migration/V30__system_settings.sql
+++ b/app/src/main/resources/db/migration/V30__system_settings.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS system_settings (
+    id                             BIGINT AUTO_INCREMENT PRIMARY KEY,
+    manager_max_turns              INT NOT NULL DEFAULT 5,
+    manager_confidence_threshold   DOUBLE NOT NULL DEFAULT 0.7,
+    manager_timeout_seconds        INT NOT NULL DEFAULT 120,
+    manager_model                  VARCHAR(255),
+    claude_code_max_turns          INT NOT NULL DEFAULT 50,
+    claude_code_max_budget_usd     DOUBLE NOT NULL DEFAULT 5.0,
+    claude_code_timeout_seconds    INT NOT NULL DEFAULT 600,
+    claude_code_model              VARCHAR(255),
+    claude_code_available_models   TEXT NOT NULL,
+    opencode_max_steps             INT NOT NULL DEFAULT 50,
+    opencode_timeout_seconds       INT NOT NULL DEFAULT 600,
+    opencode_model                 VARCHAR(255),
+    opencode_available_models      TEXT NOT NULL,
+    assistant_max_sessions         INT NOT NULL DEFAULT 3,
+    assistant_timeout_seconds      INT NOT NULL DEFAULT 300,
+    ai_engine                      VARCHAR(255) NOT NULL DEFAULT 'claude-code',
+    event_source_log_retention_days INT NOT NULL DEFAULT 7,
+    script_timeout_seconds         INT NOT NULL DEFAULT 60
+);
+
+INSERT INTO system_settings (
+    claude_code_available_models,
+    opencode_available_models
+) VALUES (
+    'claude-opus-4-7,claude-sonnet-4-6,claude-opus-4-6,claude-haiku-4-5-20251001,opus,sonnet,haiku',
+    'anthropic/claude-sonnet-4-6,anthropic/claude-opus-4-6,anthropic/claude-haiku-4-5-20251001,openai/gpt-4o,openai/o3-mini'
+);

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -4132,6 +4132,55 @@
           }
         }
       }
+    },
+    "/system/settings": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Get runtime-configurable system settings",
+        "operationId": "getSystemSettings",
+        "responses": {
+          "200": {
+            "description": "Current system settings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SystemSettings"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Update runtime-configurable system settings",
+        "operationId": "updateSystemSettings",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SystemSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated system settings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SystemSettings"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -7003,6 +7052,97 @@
           "permissionId": {
             "description": "Optional pending permission ID to also approve immediately",
             "type": "string"
+          }
+        }
+      },
+      "SystemSettings": {
+        "description": "Runtime-configurable system settings. All properties are optional on update; omitted properties retain their current values.",
+        "type": "object",
+        "properties": {
+          "managerMaxTurns": {
+            "description": "Maximum number of turns for Manager AI evaluation.",
+            "minimum": 1,
+            "type": "integer"
+          },
+          "managerConfidenceThreshold": {
+            "description": "Confidence threshold for Manager decisions (0.0-1.0).",
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "managerTimeoutSeconds": {
+            "description": "Timeout in seconds for Manager AI evaluation.",
+            "minimum": 1,
+            "type": "integer"
+          },
+          "managerModel": {
+            "description": "Model override for the Manager. Null or empty uses the engine default.",
+            "type": "string"
+          },
+          "claudeCodeMaxTurns": {
+            "description": "Maximum number of turns for Claude Code task execution.",
+            "minimum": 1,
+            "type": "integer"
+          },
+          "claudeCodeMaxBudgetUsd": {
+            "description": "Maximum budget in USD for Claude Code task execution.",
+            "minimum": 0,
+            "type": "number"
+          },
+          "claudeCodeTimeoutSeconds": {
+            "description": "Timeout in seconds for Claude Code task execution.",
+            "minimum": 1,
+            "type": "integer"
+          },
+          "claudeCodeModel": {
+            "description": "Model override for Claude Code. Null or empty uses the engine default.",
+            "type": "string"
+          },
+          "claudeCodeAvailableModels": {
+            "description": "Comma-separated list of available Claude Code models.",
+            "type": "string"
+          },
+          "opencodeMaxSteps": {
+            "description": "Maximum number of steps for OpenCode task execution.",
+            "minimum": 1,
+            "type": "integer"
+          },
+          "opencodeTimeoutSeconds": {
+            "description": "Timeout in seconds for OpenCode task execution.",
+            "minimum": 1,
+            "type": "integer"
+          },
+          "opencodeModel": {
+            "description": "Model override for OpenCode. Null or empty uses the engine default.",
+            "type": "string"
+          },
+          "opencodeAvailableModels": {
+            "description": "Comma-separated list of available OpenCode models.",
+            "type": "string"
+          },
+          "assistantMaxSessions": {
+            "description": "Maximum number of concurrent AI assistant sessions.",
+            "minimum": 1,
+            "type": "integer"
+          },
+          "assistantTimeoutSeconds": {
+            "description": "Timeout in seconds for AI assistant operations.",
+            "minimum": 1,
+            "type": "integer"
+          },
+          "aiEngine": {
+            "description": "The active AI engine (e.g. claude-code, opencode).",
+            "type": "string"
+          },
+          "eventSourceLogRetentionDays": {
+            "description": "Number of days to retain event source poll logs.",
+            "minimum": 1,
+            "type": "integer"
+          },
+          "scriptTimeoutSeconds": {
+            "description": "Timeout in seconds for script execution.",
+            "minimum": 1,
+            "type": "integer"
           }
         }
       }

--- a/core/src/main/java/io/apitomy/axiom/core/entities/SystemSettingsEntity.java
+++ b/core/src/main/java/io/apitomy/axiom/core/entities/SystemSettingsEntity.java
@@ -1,0 +1,68 @@
+package io.apitomy.axiom.core.entities;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+/**
+ * Stores runtime-configurable system settings. This is a single-row table.
+ */
+@Entity
+@Table(name = "system_settings")
+public class SystemSettingsEntity extends PanacheEntity {
+
+    @Column(name = "manager_max_turns", nullable = false)
+    public int managerMaxTurns;
+
+    @Column(name = "manager_confidence_threshold", nullable = false)
+    public double managerConfidenceThreshold;
+
+    @Column(name = "manager_timeout_seconds", nullable = false)
+    public int managerTimeoutSeconds;
+
+    @Column(name = "manager_model")
+    public String managerModel;
+
+    @Column(name = "claude_code_max_turns", nullable = false)
+    public int claudeCodeMaxTurns;
+
+    @Column(name = "claude_code_max_budget_usd", nullable = false)
+    public double claudeCodeMaxBudgetUsd;
+
+    @Column(name = "claude_code_timeout_seconds", nullable = false)
+    public int claudeCodeTimeoutSeconds;
+
+    @Column(name = "claude_code_model")
+    public String claudeCodeModel;
+
+    @Column(name = "claude_code_available_models", columnDefinition = "TEXT", nullable = false)
+    public String claudeCodeAvailableModels;
+
+    @Column(name = "opencode_max_steps", nullable = false)
+    public int opencodeMaxSteps;
+
+    @Column(name = "opencode_timeout_seconds", nullable = false)
+    public int opencodeTimeoutSeconds;
+
+    @Column(name = "opencode_model")
+    public String opencodeModel;
+
+    @Column(name = "opencode_available_models", columnDefinition = "TEXT", nullable = false)
+    public String opencodeAvailableModels;
+
+    @Column(name = "assistant_max_sessions", nullable = false)
+    public int assistantMaxSessions;
+
+    @Column(name = "assistant_timeout_seconds", nullable = false)
+    public int assistantTimeoutSeconds;
+
+    @Column(name = "ai_engine", nullable = false)
+    public String aiEngine;
+
+    @Column(name = "event_source_log_retention_days", nullable = false)
+    public int eventSourceLogRetentionDays;
+
+    @Column(name = "script_timeout_seconds", nullable = false)
+    public int scriptTimeoutSeconds;
+}

--- a/core/src/main/java/io/apitomy/axiom/core/services/SystemSettingsService.java
+++ b/core/src/main/java/io/apitomy/axiom/core/services/SystemSettingsService.java
@@ -1,0 +1,302 @@
+package io.apitomy.axiom.core.services;
+
+import io.apitomy.axiom.core.entities.SystemSettingsEntity;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.transaction.Transactional;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import java.util.Optional;
+
+/**
+ * Provides access to runtime-configurable system settings stored in the database.
+ * Caches the single settings row in memory and invalidates on updates.
+ */
+@ApplicationScoped
+public class SystemSettingsService {
+
+    private static final Logger LOG = Logger.getLogger(SystemSettingsService.class);
+
+    private volatile SystemSettingsEntity cached;
+
+    // Fallback defaults from @ConfigProperty (used if DB row is missing)
+    @ConfigProperty(name = "axiom.manager.max-turns", defaultValue = "5")
+    int defaultManagerMaxTurns;
+
+    @ConfigProperty(name = "axiom.manager.confidence-threshold", defaultValue = "0.7")
+    double defaultManagerConfidenceThreshold;
+
+    @ConfigProperty(name = "axiom.manager.timeout-seconds", defaultValue = "120")
+    int defaultManagerTimeoutSeconds;
+
+    @ConfigProperty(name = "axiom.manager.model")
+    Optional<String> defaultManagerModel;
+
+    @ConfigProperty(name = "axiom.claude-code.max-turns", defaultValue = "50")
+    int defaultClaudeCodeMaxTurns;
+
+    @ConfigProperty(name = "axiom.claude-code.max-budget-usd", defaultValue = "5.0")
+    double defaultClaudeCodeMaxBudgetUsd;
+
+    @ConfigProperty(name = "axiom.claude-code.timeout-seconds", defaultValue = "600")
+    int defaultClaudeCodeTimeoutSeconds;
+
+    @ConfigProperty(name = "axiom.claude-code.model")
+    Optional<String> defaultClaudeCodeModel;
+
+    @ConfigProperty(name = "axiom.claude-code.available-models",
+            defaultValue = "claude-opus-4-7,claude-sonnet-4-6,claude-opus-4-6,claude-haiku-4-5-20251001,opus,sonnet,haiku")
+    String defaultClaudeCodeAvailableModels;
+
+    @ConfigProperty(name = "axiom.opencode.max-steps", defaultValue = "50")
+    int defaultOpencodeMaxSteps;
+
+    @ConfigProperty(name = "axiom.opencode.timeout-seconds", defaultValue = "600")
+    int defaultOpencodeTimeoutSeconds;
+
+    @ConfigProperty(name = "axiom.opencode.model")
+    Optional<String> defaultOpencodeModel;
+
+    @ConfigProperty(name = "axiom.opencode.available-models",
+            defaultValue = "anthropic/claude-sonnet-4-6,anthropic/claude-opus-4-6,anthropic/claude-haiku-4-5-20251001,openai/gpt-4o,openai/o3-mini")
+    String defaultOpencodeAvailableModels;
+
+    @ConfigProperty(name = "axiom.assistant.max-sessions", defaultValue = "3")
+    int defaultAssistantMaxSessions;
+
+    @ConfigProperty(name = "axiom.ai-assistant.timeout-seconds", defaultValue = "300")
+    int defaultAssistantTimeoutSeconds;
+
+    @ConfigProperty(name = "axiom.ai-engine", defaultValue = "claude-code")
+    String defaultAiEngine;
+
+    @ConfigProperty(name = "axiom.event-source-logs.retention-days", defaultValue = "7")
+    int defaultEventSourceLogRetentionDays;
+
+    @ConfigProperty(name = "axiom.script.timeout-seconds", defaultValue = "60")
+    int defaultScriptTimeoutSeconds;
+
+    /**
+     * Eagerly loads the settings cache at startup.
+     *
+     * @param event the startup event
+     */
+    void onStartup(@Observes StartupEvent event) {
+        load();
+    }
+
+    /**
+     * Loads the settings row from the database into the cache.
+     * Falls back to {@code @ConfigProperty} defaults if no row exists.
+     */
+    @Transactional
+    public void load() {
+        SystemSettingsEntity entity = SystemSettingsEntity.<SystemSettingsEntity>findAll()
+                .firstResult();
+        if (entity != null) {
+            cached = entity;
+            LOG.info("System settings loaded from database");
+        } else {
+            LOG.info("No system settings row found; using @ConfigProperty defaults");
+            cached = null;
+        }
+    }
+
+    /**
+     * Updates the settings row in the database and refreshes the cache.
+     *
+     * @param entity the entity to persist (must have fields set)
+     * @return the persisted entity
+     */
+    @Transactional
+    public SystemSettingsEntity update(SystemSettingsEntity entity) {
+        entity.persist();
+        cached = entity;
+        LOG.info("System settings updated");
+        return entity;
+    }
+
+    /**
+     * Returns the current settings entity, loading from DB if the cache is empty.
+     *
+     * @return the cached entity, or {@code null} if no DB row exists
+     */
+    public SystemSettingsEntity getCached() {
+        return cached;
+    }
+
+    // ── Typed getters with fallback ─────────────────────────────────
+
+    /**
+     * Returns the Manager max turns setting.
+     *
+     * @return max turns
+     */
+    public int getManagerMaxTurns() {
+        return cached != null ? cached.managerMaxTurns : defaultManagerMaxTurns;
+    }
+
+    /**
+     * Returns the Manager confidence threshold setting.
+     *
+     * @return confidence threshold (0.0-1.0)
+     */
+    public double getManagerConfidenceThreshold() {
+        return cached != null ? cached.managerConfidenceThreshold : defaultManagerConfidenceThreshold;
+    }
+
+    /**
+     * Returns the Manager timeout setting in seconds.
+     *
+     * @return timeout seconds
+     */
+    public int getManagerTimeoutSeconds() {
+        return cached != null ? cached.managerTimeoutSeconds : defaultManagerTimeoutSeconds;
+    }
+
+    /**
+     * Returns the Manager model override, or {@code null} if not set.
+     *
+     * @return model name or null
+     */
+    public String getManagerModel() {
+        if (cached != null) {
+            return cached.managerModel;
+        }
+        return defaultManagerModel.orElse(null);
+    }
+
+    /**
+     * Returns the Claude Code max turns setting.
+     *
+     * @return max turns
+     */
+    public int getClaudeCodeMaxTurns() {
+        return cached != null ? cached.claudeCodeMaxTurns : defaultClaudeCodeMaxTurns;
+    }
+
+    /**
+     * Returns the Claude Code max budget setting in USD.
+     *
+     * @return max budget
+     */
+    public double getClaudeCodeMaxBudgetUsd() {
+        return cached != null ? cached.claudeCodeMaxBudgetUsd : defaultClaudeCodeMaxBudgetUsd;
+    }
+
+    /**
+     * Returns the Claude Code timeout setting in seconds.
+     *
+     * @return timeout seconds
+     */
+    public int getClaudeCodeTimeoutSeconds() {
+        return cached != null ? cached.claudeCodeTimeoutSeconds : defaultClaudeCodeTimeoutSeconds;
+    }
+
+    /**
+     * Returns the Claude Code model override, or {@code null} if not set.
+     *
+     * @return model name or null
+     */
+    public String getClaudeCodeModel() {
+        if (cached != null) {
+            return cached.claudeCodeModel;
+        }
+        return defaultClaudeCodeModel.orElse(null);
+    }
+
+    /**
+     * Returns the comma-separated list of available Claude Code models.
+     *
+     * @return available models string
+     */
+    public String getClaudeCodeAvailableModels() {
+        return cached != null ? cached.claudeCodeAvailableModels : defaultClaudeCodeAvailableModels;
+    }
+
+    /**
+     * Returns the OpenCode max steps setting.
+     *
+     * @return max steps
+     */
+    public int getOpencodeMaxSteps() {
+        return cached != null ? cached.opencodeMaxSteps : defaultOpencodeMaxSteps;
+    }
+
+    /**
+     * Returns the OpenCode timeout setting in seconds.
+     *
+     * @return timeout seconds
+     */
+    public int getOpencodeTimeoutSeconds() {
+        return cached != null ? cached.opencodeTimeoutSeconds : defaultOpencodeTimeoutSeconds;
+    }
+
+    /**
+     * Returns the OpenCode model override, or {@code null} if not set.
+     *
+     * @return model name or null
+     */
+    public String getOpencodeModel() {
+        if (cached != null) {
+            return cached.opencodeModel;
+        }
+        return defaultOpencodeModel.orElse(null);
+    }
+
+    /**
+     * Returns the comma-separated list of available OpenCode models.
+     *
+     * @return available models string
+     */
+    public String getOpencodeAvailableModels() {
+        return cached != null ? cached.opencodeAvailableModels : defaultOpencodeAvailableModels;
+    }
+
+    /**
+     * Returns the maximum number of concurrent assistant sessions.
+     *
+     * @return max sessions
+     */
+    public int getAssistantMaxSessions() {
+        return cached != null ? cached.assistantMaxSessions : defaultAssistantMaxSessions;
+    }
+
+    /**
+     * Returns the assistant timeout setting in seconds.
+     *
+     * @return timeout seconds
+     */
+    public int getAssistantTimeoutSeconds() {
+        return cached != null ? cached.assistantTimeoutSeconds : defaultAssistantTimeoutSeconds;
+    }
+
+    /**
+     * Returns the active AI engine identifier.
+     *
+     * @return engine name (e.g. "claude-code", "opencode")
+     */
+    public String getAiEngine() {
+        return cached != null ? cached.aiEngine : defaultAiEngine;
+    }
+
+    /**
+     * Returns the event source log retention period in days.
+     *
+     * @return retention days
+     */
+    public int getEventSourceLogRetentionDays() {
+        return cached != null ? cached.eventSourceLogRetentionDays : defaultEventSourceLogRetentionDays;
+    }
+
+    /**
+     * Returns the script execution timeout in seconds.
+     *
+     * @return timeout seconds
+     */
+    public int getScriptTimeoutSeconds() {
+        return cached != null ? cached.scriptTimeoutSeconds : defaultScriptTimeoutSeconds;
+    }
+}

--- a/engine/opencode/src/main/java/io/apitomy/axiom/engine/opencode/OpenCodeActor.java
+++ b/engine/opencode/src/main/java/io/apitomy/axiom/engine/opencode/OpenCodeActor.java
@@ -6,15 +6,14 @@ import io.apitomy.axiom.actors.spi.TaskResult;
 import io.apitomy.axiom.core.entities.TaskEntity;
 import io.apitomy.axiom.engine.spi.AiEngineConfig;
 import io.apitomy.axiom.engine.spi.AiEngineResult;
+import io.apitomy.axiom.core.services.SystemSettingsService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 /**
  * Actor implementation that executes tasks via the OpenCode AI engine.
@@ -29,14 +28,8 @@ public class OpenCodeActor implements Actor {
     @Inject
     OpenCodeEngine engine;
 
-    @ConfigProperty(name = "axiom.opencode.model")
-    Optional<String> model;
-
-    @ConfigProperty(name = "axiom.opencode.max-steps", defaultValue = "50")
-    int maxSteps;
-
-    @ConfigProperty(name = "axiom.opencode.timeout-seconds", defaultValue = "600")
-    int timeoutSeconds;
+    @Inject
+    SystemSettingsService settingsService;
 
     /** Tracks running sessions for cancellation support. */
     private final Map<Long, String> runningSessions = new ConcurrentHashMap<>();
@@ -59,8 +52,8 @@ public class OpenCodeActor implements Actor {
                 .disallowedTools(context.getDisallowedTools())
                 .workingDirectory(context.getWorkingDirectory())
                 .environment(context.getEnvironment() != null ? context.getEnvironment() : Map.of())
-                .timeoutSeconds(timeoutSeconds)
-                .maxSteps(maxSteps)
+                .timeoutSeconds(settingsService.getOpencodeTimeoutSeconds())
+                .maxSteps(settingsService.getOpencodeMaxSteps())
                 .model(resolveModel(context))
                 .mcpConfigFile(context.getMcpConfigFile())
                 .build();
@@ -96,7 +89,7 @@ public class OpenCodeActor implements Actor {
         if (context.getModel() != null && !context.getModel().isBlank()) {
             return context.getModel();
         }
-        return model.orElse(null);
+        return settingsService.getOpencodeModel();
     }
 
     private String buildPrompt(TaskEntity task, ActorContext context) {

--- a/manager/src/main/java/io/apitomy/axiom/manager/ManagerService.java
+++ b/manager/src/main/java/io/apitomy/axiom/manager/ManagerService.java
@@ -15,17 +15,16 @@ import io.apitomy.axiom.core.entities.TaskEntity;
 import io.apitomy.axiom.engine.spi.AiEngine;
 import io.apitomy.axiom.engine.spi.AiEngineConfig;
 import io.apitomy.axiom.engine.spi.AiEngineResult;
+import io.apitomy.axiom.core.services.SystemSettingsService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import io.quarkus.narayana.jta.QuarkusTransaction;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Service that invokes the AI Manager to evaluate events and produce decisions.
@@ -46,17 +45,8 @@ public class ManagerService {
     @Inject
     TraceService traceService;
 
-    @ConfigProperty(name = "axiom.manager.confidence-threshold", defaultValue = "0.7")
-    double confidenceThreshold;
-
-    @ConfigProperty(name = "axiom.manager.timeout-seconds", defaultValue = "120")
-    int timeoutSeconds;
-
-    @ConfigProperty(name = "axiom.manager.max-turns", defaultValue = "5")
-    int maxTurns;
-
-    @ConfigProperty(name = "axiom.manager.model")
-    Optional<String> model;
+    @Inject
+    SystemSettingsService settingsService;
 
     /**
      * Evaluates an event and returns the Manager's decisions.
@@ -126,9 +116,9 @@ public class ManagerService {
         AiEngineConfig engineConfig = AiEngineConfig.builder()
                 .systemPrompt(systemPrompt)
                 .allowedTools(List.of("StructuredOutput"))
-                .timeoutSeconds(timeoutSeconds)
-                .maxSteps(maxTurns)
-                .model(model.orElse(null))
+                .timeoutSeconds(settingsService.getManagerTimeoutSeconds())
+                .maxSteps(settingsService.getManagerMaxTurns())
+                .model(settingsService.getManagerModel())
                 .build();
 
         try {
@@ -221,7 +211,7 @@ public class ManagerService {
      * @return true if the confidence is at or above the threshold
      */
     public boolean meetsConfidenceThreshold(ManagerDecision decision) {
-        return decision.confidence() >= confidenceThreshold;
+        return decision.confidence() >= settingsService.getManagerConfidenceThreshold();
     }
 
     /**

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -42,6 +42,7 @@ import { TraceDetailPage } from "./pages/TraceDetailPage";
 import { InboxPage } from "./pages/InboxPage";
 import { SessionTemplatesPage } from "./pages/SessionTemplatesPage";
 import { SessionTemplateDetailPage } from "./pages/SessionTemplateDetailPage";
+import { SystemSettingsPage } from "./pages/SystemSettingsPage";
 import { type StartupCheck, fetchSystemHealth, fetchSystemConfig } from "./config/api";
 import { sseClient } from "./config/sse";
 
@@ -103,6 +104,7 @@ export function App() {
                         <Route path="/inbox" element={<InboxPage />} />
                         <Route path="/projects" element={<ProjectsPage />} />
                         <Route path="/projects/:projectId" element={<ProjectDetailPage />} />
+                        <Route path="/settings" element={<SystemSettingsPage />} />
                         <Route path="/engine" element={<EngineSettingsPage />} />
                         <Route path="/actors" element={<ActorsPage />} />
                         <Route path="/actors/:actorId" element={<ActorDetailPage />} />

--- a/ui/src/components/AppSidebar.tsx
+++ b/ui/src/components/AppSidebar.tsx
@@ -12,7 +12,7 @@ import {
 import { fetchInboxCount } from "../config/api";
 import { sseClient, type AxiomSseEvent } from "../config/sse";
 
-const CONFIG_PATHS = ["/actors", "/manager", "/action-types", "/tools", "/toolsets", "/mcp-servers", "/secrets", "/event-sources", "/report-definitions", "/engine", "/configuration-packs", "/session-templates"];
+const CONFIG_PATHS = ["/actors", "/manager", "/action-types", "/tools", "/toolsets", "/mcp-servers", "/secrets", "/event-sources", "/report-definitions", "/engine", "/configuration-packs", "/session-templates", "/settings"];
 
 export function AppSidebar() {
     const navigate = useNavigate();
@@ -86,6 +86,9 @@ export function AppSidebar() {
                             </NavItem>
                         </NavExpandable>
                         <NavExpandable title="Configuration" isActive={isConfigActive} isExpanded={isConfigActive}>
+                            <NavItem isActive={location.pathname === "/settings"} onClick={() => navigate("/settings")}>
+                                Settings
+                            </NavItem>
                             <NavItem isActive={location.pathname.startsWith("/engine")} onClick={() => navigate("/engine")}>
                                 AI Engine
                             </NavItem>

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -778,6 +778,45 @@ export async function updateManagerConfig(config: ManagerConfig): Promise<Manage
     return response.json();
 }
 
+// ── System Settings ─────────────────────────────────────────────
+
+export interface SystemSettings {
+    managerMaxTurns?: number;
+    managerConfidenceThreshold?: number;
+    managerTimeoutSeconds?: number;
+    managerModel?: string;
+    claudeCodeMaxTurns?: number;
+    claudeCodeMaxBudgetUsd?: number;
+    claudeCodeTimeoutSeconds?: number;
+    claudeCodeModel?: string;
+    claudeCodeAvailableModels?: string;
+    opencodeMaxSteps?: number;
+    opencodeTimeoutSeconds?: number;
+    opencodeModel?: string;
+    opencodeAvailableModels?: string;
+    assistantMaxSessions?: number;
+    assistantTimeoutSeconds?: number;
+    aiEngine?: string;
+    eventSourceLogRetentionDays?: number;
+    scriptTimeoutSeconds?: number;
+}
+
+export async function fetchSystemSettings(): Promise<SystemSettings> {
+    const response = await fetch(`${API}/system/settings`);
+    if (!response.ok) throw new Error(`Failed to fetch system settings: ${response.status}`);
+    return response.json();
+}
+
+export async function updateSystemSettings(settings: SystemSettings): Promise<SystemSettings> {
+    const response = await fetch(`${API}/system/settings`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(settings),
+    });
+    if (!response.ok) throw new Error(`Failed to update system settings: ${response.status}`);
+    return response.json();
+}
+
 // ── Event Sources ────────────────────────────────────────────────
 
 export interface EventSource {

--- a/ui/src/pages/SystemSettingsPage.tsx
+++ b/ui/src/pages/SystemSettingsPage.tsx
@@ -1,0 +1,269 @@
+import { useState, useEffect, useCallback } from "react";
+import {
+    Button,
+    EmptyState,
+    EmptyStateBody,
+    Flex,
+    FlexItem,
+    Form,
+    FormGroup,
+    FormSection,
+    NumberInput,
+    PageSection,
+    Tab,
+    TabContent,
+    TabTitleText,
+    Tabs,
+    TextInput,
+    Title,
+} from "@patternfly/react-core";
+import SaveIcon from "@patternfly/react-icons/dist/esm/icons/save-icon";
+import {
+    type SystemSettings,
+    fetchSystemSettings,
+    updateSystemSettings,
+} from "../config/api";
+
+export function SystemSettingsPage() {
+    const [settings, setSettings] = useState<SystemSettings>({});
+    const [loading, setLoading] = useState(true);
+    const [saving, setSaving] = useState(false);
+    const [dirty, setDirty] = useState(false);
+    const [activeTab, setActiveTab] = useState(0);
+
+    const loadSettings = useCallback(() => {
+        setLoading(true);
+        fetchSystemSettings()
+            .then((s) => { setSettings(s); setDirty(false); })
+            .catch(console.error)
+            .finally(() => setLoading(false));
+    }, []);
+
+    useEffect(() => { loadSettings(); }, [loadSettings]);
+
+    const handleSave = () => {
+        setSaving(true);
+        updateSystemSettings(settings)
+            .then((s) => { setSettings(s); setDirty(false); })
+            .catch(console.error)
+            .finally(() => setSaving(false));
+    };
+
+    const update = (field: keyof SystemSettings, value: string | number | undefined) => {
+        setSettings({ ...settings, [field]: value });
+        setDirty(true);
+    };
+
+    const numInput = (
+        field: keyof SystemSettings,
+        min: number = 1,
+        step: number = 1,
+    ) => {
+        const val = (settings[field] as number | undefined) ?? 0;
+        return (
+            <NumberInput
+                value={val}
+                min={min}
+                onMinus={() => update(field, Math.max(min, val - step))}
+                onPlus={() => update(field, val + step)}
+                onChange={(event: React.FormEvent<HTMLInputElement>) => {
+                    const n = parseInt((event.target as HTMLInputElement).value, 10);
+                    if (!isNaN(n)) update(field, Math.max(min, n));
+                }}
+                widthChars={8}
+            />
+        );
+    };
+
+    if (loading) {
+        return (
+            <PageSection>
+                <EmptyState><EmptyStateBody>Loading system settings...</EmptyStateBody></EmptyState>
+            </PageSection>
+        );
+    }
+
+    return (
+        <PageSection>
+            <Flex
+                justifyContent={{ default: "justifyContentSpaceBetween" }}
+                alignItems={{ default: "alignItemsCenter" }}
+                style={{ marginBottom: "16px" }}
+            >
+                <FlexItem>
+                    <Title headingLevel="h1" size="lg">System Settings</Title>
+                </FlexItem>
+                <FlexItem>
+                    <Button
+                        variant="primary" icon={<SaveIcon />}
+                        onClick={handleSave}
+                        isDisabled={!dirty || saving}
+                        isLoading={saving}
+                    >
+                        {saving ? "Saving..." : "Save Changes"}
+                    </Button>
+                </FlexItem>
+            </Flex>
+
+            <Tabs activeKey={activeTab} onSelect={(_e, k) => setActiveTab(k as number)}>
+                <Tab eventKey={0} title={<TabTitleText>General</TabTitleText>}>
+                    <TabContent id="general-tab" eventKey={0} activeKey={activeTab}
+                        style={{ marginTop: "16px" }}>
+                        <Form isHorizontal>
+                            <FormSection title="AI Engine">
+                                <FormGroup label="Active Engine" fieldId="ai-engine">
+                                    <TextInput
+                                        id="ai-engine"
+                                        value={settings.aiEngine ?? ""}
+                                        onChange={(_e, v) => update("aiEngine", v)}
+                                    />
+                                </FormGroup>
+                            </FormSection>
+                            <FormSection title="Event Source Logs">
+                                <FormGroup label="Retention (days)" fieldId="retention-days">
+                                    {numInput("eventSourceLogRetentionDays")}
+                                </FormGroup>
+                            </FormSection>
+                            <FormSection title="Script Execution">
+                                <FormGroup label="Timeout (seconds)" fieldId="script-timeout">
+                                    {numInput("scriptTimeoutSeconds")}
+                                </FormGroup>
+                            </FormSection>
+                        </Form>
+                    </TabContent>
+                </Tab>
+
+                <Tab eventKey={1} title={<TabTitleText>Manager</TabTitleText>}>
+                    <TabContent id="manager-tab" eventKey={1} activeKey={activeTab}
+                        style={{ marginTop: "16px" }}>
+                        <Form isHorizontal>
+                            <FormGroup label="Max Turns" fieldId="mgr-max-turns">
+                                {numInput("managerMaxTurns")}
+                            </FormGroup>
+                            <FormGroup label="Confidence Threshold" fieldId="mgr-confidence"
+                                helperText="Value between 0.0 and 1.0">
+                                <NumberInput
+                                    value={settings.managerConfidenceThreshold ?? 0.7}
+                                    min={0} max={1}
+                                    onMinus={() => update("managerConfidenceThreshold",
+                                        Math.max(0, (settings.managerConfidenceThreshold ?? 0.7) - 0.05))}
+                                    onPlus={() => update("managerConfidenceThreshold",
+                                        Math.min(1, (settings.managerConfidenceThreshold ?? 0.7) + 0.05))}
+                                    onChange={(event: React.FormEvent<HTMLInputElement>) => {
+                                        const n = parseFloat((event.target as HTMLInputElement).value);
+                                        if (!isNaN(n)) update("managerConfidenceThreshold",
+                                            Math.max(0, Math.min(1, n)));
+                                    }}
+                                    widthChars={8}
+                                />
+                            </FormGroup>
+                            <FormGroup label="Timeout (seconds)" fieldId="mgr-timeout">
+                                {numInput("managerTimeoutSeconds")}
+                            </FormGroup>
+                            <FormGroup label="Model Override" fieldId="mgr-model"
+                                helperText="Leave empty to use the engine default">
+                                <TextInput
+                                    id="mgr-model"
+                                    value={settings.managerModel ?? ""}
+                                    onChange={(_e, v) => update("managerModel", v)}
+                                    placeholder="(engine default)"
+                                />
+                            </FormGroup>
+                        </Form>
+                    </TabContent>
+                </Tab>
+
+                <Tab eventKey={2} title={<TabTitleText>Claude Code</TabTitleText>}>
+                    <TabContent id="claude-code-tab" eventKey={2} activeKey={activeTab}
+                        style={{ marginTop: "16px" }}>
+                        <Form isHorizontal>
+                            <FormGroup label="Max Turns" fieldId="cc-max-turns">
+                                {numInput("claudeCodeMaxTurns")}
+                            </FormGroup>
+                            <FormGroup label="Max Budget (USD)" fieldId="cc-budget">
+                                <NumberInput
+                                    value={settings.claudeCodeMaxBudgetUsd ?? 5.0}
+                                    min={0}
+                                    onMinus={() => update("claudeCodeMaxBudgetUsd",
+                                        Math.max(0, (settings.claudeCodeMaxBudgetUsd ?? 5.0) - 0.5))}
+                                    onPlus={() => update("claudeCodeMaxBudgetUsd",
+                                        (settings.claudeCodeMaxBudgetUsd ?? 5.0) + 0.5)}
+                                    onChange={(event: React.FormEvent<HTMLInputElement>) => {
+                                        const n = parseFloat((event.target as HTMLInputElement).value);
+                                        if (!isNaN(n)) update("claudeCodeMaxBudgetUsd", Math.max(0, n));
+                                    }}
+                                    widthChars={8}
+                                />
+                            </FormGroup>
+                            <FormGroup label="Timeout (seconds)" fieldId="cc-timeout">
+                                {numInput("claudeCodeTimeoutSeconds")}
+                            </FormGroup>
+                            <FormGroup label="Model Override" fieldId="cc-model"
+                                helperText="Leave empty to use the engine default">
+                                <TextInput
+                                    id="cc-model"
+                                    value={settings.claudeCodeModel ?? ""}
+                                    onChange={(_e, v) => update("claudeCodeModel", v)}
+                                    placeholder="(engine default)"
+                                />
+                            </FormGroup>
+                            <FormGroup label="Available Models" fieldId="cc-models"
+                                helperText="Comma-separated list of model names">
+                                <TextInput
+                                    id="cc-models"
+                                    value={settings.claudeCodeAvailableModels ?? ""}
+                                    onChange={(_e, v) => update("claudeCodeAvailableModels", v)}
+                                />
+                            </FormGroup>
+                        </Form>
+                    </TabContent>
+                </Tab>
+
+                <Tab eventKey={3} title={<TabTitleText>OpenCode</TabTitleText>}>
+                    <TabContent id="opencode-tab" eventKey={3} activeKey={activeTab}
+                        style={{ marginTop: "16px" }}>
+                        <Form isHorizontal>
+                            <FormGroup label="Max Steps" fieldId="oc-max-steps">
+                                {numInput("opencodeMaxSteps")}
+                            </FormGroup>
+                            <FormGroup label="Timeout (seconds)" fieldId="oc-timeout">
+                                {numInput("opencodeTimeoutSeconds")}
+                            </FormGroup>
+                            <FormGroup label="Model Override" fieldId="oc-model"
+                                helperText="Leave empty to use the engine default">
+                                <TextInput
+                                    id="oc-model"
+                                    value={settings.opencodeModel ?? ""}
+                                    onChange={(_e, v) => update("opencodeModel", v)}
+                                    placeholder="(engine default)"
+                                />
+                            </FormGroup>
+                            <FormGroup label="Available Models" fieldId="oc-models"
+                                helperText="Comma-separated list of provider/model names">
+                                <TextInput
+                                    id="oc-models"
+                                    value={settings.opencodeAvailableModels ?? ""}
+                                    onChange={(_e, v) => update("opencodeAvailableModels", v)}
+                                />
+                            </FormGroup>
+                        </Form>
+                    </TabContent>
+                </Tab>
+
+                <Tab eventKey={4} title={<TabTitleText>Assistant</TabTitleText>}>
+                    <TabContent id="assistant-tab" eventKey={4} activeKey={activeTab}
+                        style={{ marginTop: "16px" }}>
+                        <Form isHorizontal>
+                            <FormGroup label="Max Sessions" fieldId="asst-max-sessions">
+                                {numInput("assistantMaxSessions")}
+                            </FormGroup>
+                            <FormGroup label="Timeout (seconds)" fieldId="asst-timeout">
+                                {numInput("assistantTimeoutSeconds")}
+                            </FormGroup>
+                        </Form>
+                    </TabContent>
+                </Tab>
+            </Tabs>
+        </PageSection>
+    );
+}


### PR DESCRIPTION
## Summary

- Move 18 operational tuning knobs from static `@ConfigProperty` injections into a new single-row
  `system_settings` database table, editable at runtime via REST API and UI
- Add `SystemSettingsService` with in-memory cache, typed getters, and `@ConfigProperty` fallback
  for graceful first-startup behavior
- Add `GET/PUT /api/v1/system/settings` endpoints with input validation
- Migrate 13 consumer classes to read settings from the service instead of static injection
- Add a new **Settings** page in the UI with tabbed form sections (General, Manager, Claude Code,
  OpenCode, Assistant)

Infrastructure-level properties (`executable`, `server.hostname/port`, `workspace.root`, poll
intervals) remain static `@ConfigProperty` only.

Closes #111

## Test plan

- [ ] `mvn install` builds successfully (verified)
- [ ] Start app — confirm `system_settings` table is created with one seeded row
- [ ] `GET /api/v1/system/settings` returns all default values
- [ ] `PUT /api/v1/system/settings` with modified values persists and returns updated values
- [ ] Validation rejects invalid values (e.g. negative timeouts, confidence > 1)
- [ ] Change a setting via PUT (e.g. `managerMaxTurns` → 3), trigger a manager evaluation,
  confirm it respects the new value without restart
- [ ] Navigate to Settings page in UI, verify all fields display current values
- [ ] Modify settings in UI, save, reload page — confirm persistence
- [ ] Delete the `system_settings` row from DB, confirm app still works using fallback defaults