### PR TITLE
Handle conversation_reset event from /clear slash command

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantEventParser.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantEventParser.java
@@ -55,6 +55,7 @@ public class AssistantEventParser {
                 case "result" -> parseResult(node);
                 case "sdk_control_request" -> parseSdkControlRequest(node);
                 case "control_request" -> parseControlRequest(node);
+                case "conversation_reset" -> parseConversationReset(node);
                 default -> {
                     ObjectNode data = JsonNodeFactory.instance.objectNode();
                     data.put("rawType", type);
@@ -180,6 +181,18 @@ public class AssistantEventParser {
         data.put("description", request.path("description").asText());
         data.set("toolInput", request.path("input"));
         return List.of(new SseEvent("permission_request", data));
+    }
+
+    /**
+     * Parses a conversation_reset event emitted when the user sends the
+     * {@code /clear} slash command.
+     *
+     * @param root the raw NDJSON node
+     * @return a single conversation_reset SSE event
+     */
+    private List<SseEvent> parseConversationReset(JsonNode root) {
+        ObjectNode data = JsonNodeFactory.instance.objectNode();
+        return List.of(new SseEvent("conversation_reset", data));
     }
 
     /**

--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantEventParser.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantEventParser.java
@@ -25,6 +25,7 @@ import java.util.List;
  *   <li>{@code user} (with tool_use_result) → {@code tool_result}</li>
  *   <li>{@code result} → {@code turn_complete}</li>
  *   <li>{@code sdk_control_request} / {@code control_request} → {@code permission_request}</li>
+ *   <li>{@code conversation_reset} → {@code conversation_reset}</li>
  * </ul>
  */
 public class AssistantEventParser {
@@ -199,7 +200,8 @@ public class AssistantEventParser {
      * A normalised SSE event parsed from Claude Code's NDJSON output.
      *
      * @param type the normalised event type (session_init, assistant_text,
-     *             tool_use, tool_result, turn_complete, permission_request, thinking)
+     *             tool_use, tool_result, turn_complete, permission_request,
+     *             thinking, conversation_reset)
      * @param data the extracted/transformed JSON data
      */
     public record SseEvent(String type, JsonNode data) {

--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSession.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSession.java
@@ -521,6 +521,9 @@ public class AssistantSession {
                         accumulateCost(event);
                     }
                     synchronized (eventLock) {
+                        if ("conversation_reset".equals(event.type())) {
+                            eventHistory.clear();
+                        }
                         eventHistory.add(event);
                         lastActivityAt = Instant.now();
                         for (Consumer<SseEvent> listener : listeners) {

--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSession.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSession.java
@@ -257,13 +257,19 @@ public class AssistantSession {
      * Atomically snapshots the event history since a given event index and
      * registers a listener. Used for SSE reconnect with {@code Last-Event-Id}.
      *
+     * <p>If {@code sinceId} exceeds the current history size (e.g., because the
+     * history was cleared by a {@code conversation_reset}), the full current
+     * history is returned so the client can catch up from the reset.</p>
+     *
      * @param listener the event consumer to register
      * @param sinceId the last event index the client received, or -1 to replay all
      * @return the event history snapshot to replay (events after sinceId)
      */
     public List<SseEvent> addListenerWithHistory(Consumer<SseEvent> listener, long sinceId) {
         synchronized (eventLock) {
-            int fromIndex = (int) Math.min(sinceId + 1, eventHistory.size());
+            int fromIndex = (sinceId + 1 > eventHistory.size())
+                    ? 0
+                    : (int) (sinceId + 1);
             if (fromIndex < 0) {
                 fromIndex = 0;
             }

--- a/app/src/test/java/io/apitomy/axiom/app/assistant/AssistantEventParserTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/assistant/AssistantEventParserTest.java
@@ -193,6 +193,18 @@ class AssistantEventParserTest {
         assertTrue(events.isEmpty());
     }
 
+    // ── Conversation reset ────────────────────────────────────────
+
+    @Test
+    void parseConversationResetEvent() {
+        String line = """
+                {"type":"conversation_reset"}""";
+
+        List<SseEvent> events = parser.parse(line);
+        assertEquals(1, events.size());
+        assertEquals("conversation_reset", events.get(0).type());
+    }
+
     // ── Unknown types ───────────────────────────────────────────────
 
     @Test

--- a/ui/src/components/assistant/AssistantChatPanel.tsx
+++ b/ui/src/components/assistant/AssistantChatPanel.tsx
@@ -200,6 +200,7 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
                     type: "system",
                     content: "Conversation cleared.",
                 }]);
+                lastSeenIndexRef.current = -1;
                 setIsProcessing(false);
                 break;
 

--- a/ui/src/components/assistant/AssistantChatPanel.tsx
+++ b/ui/src/components/assistant/AssistantChatPanel.tsx
@@ -200,7 +200,6 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
                     type: "system",
                     content: "Conversation cleared.",
                 }]);
-                lastSeenIndexRef.current = -1;
                 setIsProcessing(false);
                 break;
 
@@ -243,6 +242,12 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
                     buffer.push({ eventType, eventData, eventIndex });
                     return;
                 }
+                if (eventType === "conversation_reset") {
+                    console.log(`[ChatPanel] Processing live ${eventType} idx=${eventIndex} for ${sessionShort} (bypass dedup)`);
+                    lastSeenIndexRef.current = eventIndex;
+                    processEvent(eventType, eventData);
+                    return;
+                }
                 if (eventIndex <= lastSeenIndexRef.current) {
                     console.log(`[ChatPanel] Skipping (already seen) ${eventType} idx=${eventIndex} <= ${lastSeenIndexRef.current} for ${sessionShort}`);
                     return;
@@ -264,12 +269,22 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
                     const newEvents = history.filter(e => e.eventIndex > lastSeenIndexRef.current);
                     console.log(`[ChatPanel] History: ${history.length} total, ${newEvents.length} new (lastSeen=${lastSeenIndexRef.current}) for ${sessionShort}`);
                     for (const event of history) {
+                        if (event.eventType === "conversation_reset") {
+                            lastSeenIndexRef.current = event.eventIndex;
+                            processEvent(event.eventType, event.eventData);
+                            continue;
+                        }
                         if (event.eventIndex <= lastSeenIndexRef.current) continue;
                         processEvent(event.eventType, event.eventData);
                         lastSeenIndexRef.current = Math.max(lastSeenIndexRef.current, event.eventIndex);
                     }
                     historyLoaded = true;
                     for (const event of buffer) {
+                        if (event.eventType === "conversation_reset") {
+                            lastSeenIndexRef.current = event.eventIndex;
+                            processEvent(event.eventType, event.eventData);
+                            continue;
+                        }
                         if (event.eventIndex <= lastSeenIndexRef.current) continue;
                         lastSeenIndexRef.current = event.eventIndex;
                         processEvent(event.eventType, event.eventData);
@@ -303,11 +318,18 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
     }, [sessionId, processEvent]);
 
     const handleSend = useCallback(async (message: string) => {
-        addMessage({ type: "user", content: message });
-        setProcessingText(
-            randomThinkingMessage()
-        );
-        setIsProcessing(true);
+        if (message.trim() === "/clear") {
+            setMessages([{
+                id: String(++messageIdCounter),
+                type: "system",
+                content: "Conversation cleared.",
+            }]);
+            setIsProcessing(false);
+        } else {
+            addMessage({ type: "user", content: message });
+            setProcessingText(randomThinkingMessage());
+            setIsProcessing(true);
+        }
         try {
             await sendAssistantMessage(sessionId, message);
         } catch (err) {

--- a/ui/src/components/assistant/AssistantChatPanel.tsx
+++ b/ui/src/components/assistant/AssistantChatPanel.tsx
@@ -194,6 +194,15 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
                 setIsProcessing(false);
                 break;
 
+            case "conversation_reset":
+                setMessages([{
+                    id: String(++messageIdCounter),
+                    type: "system",
+                    content: "Conversation cleared.",
+                }]);
+                setIsProcessing(false);
+                break;
+
             case "unhandled_event":
                 addMessage({
                     type: "warning",


### PR DESCRIPTION
## Summary

- Add `conversation_reset` case to `AssistantEventParser.parse()` so the backend emits a
  semantic event instead of falling through to `unhandled_event`
- Clear in-memory `eventHistory` in `AssistantSession.readStdout()` when a reset occurs,
  so page refreshes and SSE reconnects see a clean conversation
- Handle `conversation_reset` in `AssistantChatPanel.tsx` by replacing messages with a
  "Conversation cleared." system message

Resolves #106

## Test plan

- [ ] `mvn install` passes (includes new `parseConversationResetEvent` unit test)
- [ ] Start an assistant session, send messages, type `/clear` — messages clear with a
  system message, no "Unhandled event type" warning
- [ ] Refresh the page after `/clear` — only the "Conversation cleared." message appears
- [ ] Continue chatting after `/clear` — new messages appear normally