### PR TITLE
Make time window optional on report definitions

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/ReportExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ReportExecutionService.java
@@ -111,22 +111,24 @@ public class ReportExecutionService {
             LOG.warnf(e, "Failed to create trace for report %d", reportId);
         }
 
-        // Compute time range
+        // Compute time range (null when no time window is configured)
         Instant now = Instant.now();
-        Instant rangeStart = computeTimeRangeStart(definition, now);
-        Instant rangeEnd = now;
+        boolean hasTimeWindow = definition.timeWindow != null && !definition.timeWindow.isBlank();
+        Instant rangeStart = hasTimeWindow ? computeTimeRangeStart(definition, now) : null;
+        Instant rangeEnd = hasTimeWindow ? now : null;
 
         // Resolve repositories
         String repoList = resolveRepositories(definition);
 
         // Build prompt from template
         DateTimeFormatter fmt = DateTimeFormatter.ISO_INSTANT;
-        String humanWindow = describeTimeWindow(definition.timeWindow, rangeStart, rangeEnd);
+        String humanWindow = hasTimeWindow
+                ? describeTimeWindow(definition.timeWindow, rangeStart, rangeEnd) : "";
 
         String prompt = definition.promptTemplate
                 .replace("{{repositories}}", repoList)
-                .replace("{{timeRangeStart}}", fmt.format(rangeStart))
-                .replace("{{timeRangeEnd}}", fmt.format(rangeEnd))
+                .replace("{{timeRangeStart}}", rangeStart != null ? fmt.format(rangeStart) : "")
+                .replace("{{timeRangeEnd}}", rangeEnd != null ? fmt.format(rangeEnd) : "")
                 .replace("{{timeWindow}}", humanWindow);
 
         // Resolve allowed tools from the definition, falling back to defaults

--- a/app/src/main/resources/db/migration/V30__make_time_window_nullable.sql
+++ b/app/src/main/resources/db/migration/V30__make_time_window_nullable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE report_definition ALTER COLUMN time_window DROP NOT NULL;

--- a/app/src/test/java/io/apitomy/axiom/core/services/ReportDefinitionValidatorTest.java
+++ b/app/src/test/java/io/apitomy/axiom/core/services/ReportDefinitionValidatorTest.java
@@ -204,13 +204,21 @@ class ReportDefinitionValidatorTest {
     // ── Time window validation ──────────────────────────────────────
 
     @Test
-    void missingTimeWindowIsError() {
+    void nullTimeWindowIsAccepted() {
         NewReportDefinition def = makeDef("test", "desc", "daily", null, "prompt {{repositories}}");
 
         ValidationResult result = ReportDefinitionValidator.validate(def);
 
-        assertTrue(result.hasErrors());
-        assertTrue(result.errors().stream().anyMatch(m -> m.field().equals("timeWindow")));
+        assertFalse(result.errors().stream().anyMatch(m -> m.field().equals("timeWindow")));
+    }
+
+    @Test
+    void blankTimeWindowIsAccepted() {
+        NewReportDefinition def = makeDef("test", "desc", "daily", "  ", "prompt {{repositories}}");
+
+        ValidationResult result = ReportDefinitionValidator.validate(def);
+
+        assertFalse(result.errors().stream().anyMatch(m -> m.field().equals("timeWindow")));
     }
 
     @Test

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -4991,7 +4991,6 @@
         "required": [
           "name",
           "schedule",
-          "timeWindow",
           "promptTemplate"
         ],
         "type": "object",

--- a/core/src/main/java/io/apitomy/axiom/core/entities/ReportDefinitionEntity.java
+++ b/core/src/main/java/io/apitomy/axiom/core/entities/ReportDefinitionEntity.java
@@ -47,8 +47,9 @@ public class ReportDefinitionEntity extends PanacheEntity {
 
     /**
      * Time window for the report: "since-last-run", "last-24h", "last-7d", "last-30d".
+     * Null when the report has no time-based scope.
      */
-    @Column(name = "time_window", nullable = false)
+    @Column(name = "time_window")
     public String timeWindow;
 
     /**

--- a/core/src/main/java/io/apitomy/axiom/core/services/ReportDefinitionValidator.java
+++ b/core/src/main/java/io/apitomy/axiom/core/services/ReportDefinitionValidator.java
@@ -159,7 +159,6 @@ public final class ReportDefinitionValidator {
     private static void validateTimeWindow(NewReportDefinition def, List<ValidationMessage> messages) {
         String timeWindow = def.getTimeWindow();
         if (timeWindow == null || timeWindow.isBlank()) {
-            messages.add(error("timeWindow", "Time window is required."));
             return;
         }
         if (!VALID_TIME_WINDOWS.contains(timeWindow)) {

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -868,7 +868,7 @@ export interface ReportDefinition {
     schedule: string;
     scheduleTime?: string;
     scheduleDayOfWeek?: string;
-    timeWindow: string;
+    timeWindow?: string;
     promptTemplate: string;
     titleTemplate?: string;
     allowedTools?: string[];

--- a/ui/src/pages/ReportDefinitionDetailPage.tsx
+++ b/ui/src/pages/ReportDefinitionDetailPage.tsx
@@ -54,7 +54,7 @@ export function ReportDefinitionDetailPage() {
 
     const [definition, setDefinition] = useState<ReportDefinition | null>(null);
     const [form, setForm] = useState<NewReportDefinition>({
-        name: "", schedule: "daily", timeWindow: "last-24h", promptTemplate: "", enabled: false,
+        name: "", schedule: "daily", promptTemplate: "", enabled: false,
     });
     const [loading, setLoading] = useState(true);
     const [saving, setSaving] = useState(false);
@@ -389,9 +389,10 @@ function InfoTab({ form, updateForm, initialLabels, onLabelsChange }: {
                         placeholder="08:00" />
                 </FormGroup>
             )}
-            <FormGroup label="Time Window" isRequired fieldId="timeWindow">
-                <FormSelect id="timeWindow" value={form.timeWindow}
-                    onChange={(_e, v) => updateForm({ timeWindow: v })}>
+            <FormGroup label="Time Window" fieldId="timeWindow">
+                <FormSelect id="timeWindow" value={form.timeWindow || ""}
+                    onChange={(_e, v) => updateForm({ timeWindow: v || undefined })}>
+                    <FormSelectOption value="" label="None" />
                     <FormSelectOption value="since-last-run" label="Since Last Run" />
                     <FormSelectOption value="last-24h" label="Last 24 Hours" />
                     <FormSelectOption value="last-7d" label="Last 7 Days" />

--- a/ui/src/pages/ReportDefinitionsPage.tsx
+++ b/ui/src/pages/ReportDefinitionsPage.tsx
@@ -65,7 +65,6 @@ export function ReportDefinitionsPage() {
         createReportDefinition({
             name: newName,
             schedule: newSchedule,
-            timeWindow: "last-24h",
             promptTemplate: "Summarize recent activity across all repositories.",
             enabled: false,
         })
@@ -123,7 +122,10 @@ export function ReportDefinitionsPage() {
                                             </span>
                                         )}
                                     </Td>
-                                    <Td><Label isCompact>{def.timeWindow}</Label></Td>
+                                    <Td>{def.timeWindow
+                                        ? <Label isCompact>{def.timeWindow}</Label>
+                                        : <span className="axiom-text-subtle">—</span>
+                                    }</Td>
                                     <Td>
                                         <Label isCompact color={def.enabled ? "green" : "grey"}>
                                             {def.enabled ? "Yes" : "No"}


### PR DESCRIPTION
## Summary

Some reports give current status without regard to a time window. This change makes the `timeWindow` field optional across all layers so that report definitions can be created without a time-based scope.

## Changes

- **OpenAPI spec** — Removed `timeWindow` from the `required` array in `NewReportDefinition`
- **Database** — Added `V30` migration to make `time_window` column nullable
- **Entity** — Removed `nullable = false` from `ReportDefinitionEntity.timeWindow`
- **Validator** — Null/blank `timeWindow` is now accepted; still validates if a value is provided
- **ReportExecutionService** — Skips time range computation when `timeWindow` is null; time-related prompt placeholders resolve to empty strings
- **UI** — Added "None" option to Time Window dropdown, removed `isRequired`, list page shows em-dash when absent
- **TypeScript types** — Made `timeWindow` optional on `ReportDefinition` interface
- **Tests** — Replaced `missingTimeWindowIsError` with `nullTimeWindowIsAccepted` and `blankTimeWindowIsAccepted`