### PR TITLE
fix: subprocess join timeout + pre-filter bot events

### DIFF
--- a/actors/claude-code/src/main/java/io/apitomy/axiom/actors/claudecode/ClaudeCodeSubprocess.java
+++ b/actors/claude-code/src/main/java/io/apitomy/axiom/actors/claudecode/ClaudeCodeSubprocess.java
@@ -87,7 +87,7 @@ public class ClaudeCodeSubprocess {
     public void kill() {
         if (process != null && process.isAlive()) {
             LOG.warn("Killing Claude Code subprocess");
-            process.destroyForcibly();
+            destroyProcessTree();
         }
     }
 

--- a/actors/claude-code/src/main/java/io/apitomy/axiom/actors/claudecode/ClaudeCodeSubprocess.java
+++ b/actors/claude-code/src/main/java/io/apitomy/axiom/actors/claudecode/ClaudeCodeSubprocess.java
@@ -13,7 +13,9 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
 /**
@@ -164,17 +166,19 @@ public class ClaudeCodeSubprocess {
         boolean completed = process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS);
         if (!completed) {
             LOG.warnf("Claude Code subprocess timed out after %s", timeout);
-            process.destroyForcibly();
-            process.waitFor(5, TimeUnit.SECONDS);
+            destroyProcessTree();
             logBuilder.footer("Timed Out", null, null, null,
                     Duration.between(startTime, Instant.now()));
             return new ClaudeCodeResult("Process timed out after " + timeout,
                     null, null, null, null, 124, logBuilder.build());
         }
 
-        // Wait for stream readers to finish
-        stdoutFuture.join();
-        stderrFuture.join();
+        // Kill any orphan child processes that may hold pipes open
+        destroyProcessTree();
+
+        // Wait for stream readers to finish (bounded to avoid hanging on orphan pipes)
+        joinWithTimeout(stdoutFuture, "stdout");
+        joinWithTimeout(stderrFuture, "stderr");
 
         int exitCode = process.exitValue();
         LOG.tracef("Claude Code subprocess exited with code %d", exitCode);
@@ -254,6 +258,33 @@ public class ClaudeCodeSubprocess {
                     jsonLine.substring(0, Math.min(jsonLine.length(), 200)));
             // Fall back to treating the raw output as the result text
             return new ClaudeCodeResult(jsonLine, null, null, null, null, exitCode, null);
+        }
+    }
+
+    private void destroyProcessTree() {
+        process.descendants().forEach(ph -> {
+            LOG.tracef("Killing descendant process %d", ph.pid());
+            ph.destroyForcibly();
+        });
+        process.destroyForcibly();
+        try {
+            process.waitFor(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void joinWithTimeout(CompletableFuture<Void> future, String name) {
+        try {
+            future.get(30, TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+            LOG.warnf("%s reader did not finish within 30s after process exit, cancelling", name);
+            future.cancel(true);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            future.cancel(true);
+        } catch (ExecutionException e) {
+            LOG.warnf(e.getCause(), "Error in %s reader", name);
         }
     }
 

--- a/app/src/main/java/io/apitomy/axiom/app/PipelineOrchestrator.java
+++ b/app/src/main/java/io/apitomy/axiom/app/PipelineOrchestrator.java
@@ -41,6 +41,11 @@ public class PipelineOrchestrator {
 
     private static final Logger LOG = Logger.getLogger(PipelineOrchestrator.class);
 
+    private static final Set<String> SLASH_COMMANDS = Set.of(
+            "/ready", "/retry", "/accept", "/reject", "/disable-tests",
+            "/enable-tests", "/unstale", "/skip-review", "/auto-merge", "/merge"
+    );
+
     @Inject
     ManagerService managerService;
 
@@ -95,6 +100,46 @@ public class PipelineOrchestrator {
             }
             return entry;
         });
+    }
+
+    /**
+     * Returns a skip reason if the event should be filtered out without
+     * invoking the AI Manager, or {@code null} if the event should be processed.
+     */
+    private String shouldSkipEvent(EventEntity event) {
+        if (event.payload == null || event.payload.isBlank()) {
+            return null;
+        }
+        try {
+            JsonNode payload = objectMapper.readTree(event.payload);
+
+            // Extract the author login from the event payload
+            String login = null;
+            JsonNode comment = payload.path("comment");
+            if (!comment.isMissingNode()) {
+                login = comment.path("user").path("login").asText(null);
+            }
+            if (login == null) {
+                login = payload.path("user").path("login").asText(null);
+            }
+
+            // Skip events from GitHub App bot accounts (all use the [bot] suffix)
+            if (login != null && login.endsWith("[bot]")) {
+                return "bot activity from " + login;
+            }
+
+            // Skip slash command comments (lifecycle orchestrator handles these)
+            if ("comment-added".equals(event.eventType) && !comment.isMissingNode()) {
+                String body = comment.path("body").asText("").trim();
+                if (SLASH_COMMANDS.stream().anyMatch(cmd ->
+                        body.equals(cmd) || body.startsWith(cmd + " "))) {
+                    return "slash command: " + body.split("\\s+")[0];
+                }
+            }
+        } catch (Exception e) {
+            LOG.tracef("Failed to parse event payload for pre-filtering: %s", e.getMessage());
+        }
+        return null;
     }
 
     /**
@@ -622,56 +667,6 @@ public class PipelineOrchestrator {
     /**
      * Completes the trace with a failed status on pipeline error.
      */
-    private static final Set<String> BOT_LOGINS = Set.of(
-            "github-actions[bot]", "sonarqubecloud[bot]", "sonarcloud[bot]",
-            "renovate[bot]", "dependabot[bot]", "codecov[bot]"
-    );
-
-    private static final Set<String> SLASH_COMMANDS = Set.of(
-            "/ready", "/retry", "/accept", "/reject", "/disable-tests",
-            "/enable-tests", "/unstale", "/skip-review", "/auto-merge", "/merge"
-    );
-
-    /**
-     * Returns a skip reason if the event should be filtered out without
-     * invoking the AI Manager, or {@code null} if the event should be processed.
-     */
-    private String shouldSkipEvent(EventEntity event) {
-        if (event.payload == null || event.payload.isBlank()) {
-            return null;
-        }
-        try {
-            JsonNode payload = objectMapper.readTree(event.payload);
-
-            // Extract the author login from the event payload
-            String login = null;
-            JsonNode comment = payload.path("comment");
-            if (!comment.isMissingNode()) {
-                login = comment.path("user").path("login").asText(null);
-            }
-            if (login == null) {
-                login = payload.path("user").path("login").asText(null);
-            }
-
-            // Skip events from known bots
-            if (login != null && BOT_LOGINS.contains(login)) {
-                return "bot activity from " + login;
-            }
-
-            // Skip slash command comments (lifecycle orchestrator handles these)
-            if ("comment-added".equals(event.eventType) && !comment.isMissingNode()) {
-                String body = comment.path("body").asText("").trim();
-                if (SLASH_COMMANDS.stream().anyMatch(cmd ->
-                        body.equals(cmd) || body.startsWith(cmd + " "))) {
-                    return "slash command: " + body.split("\\s+")[0];
-                }
-            }
-        } catch (Exception e) {
-            LOG.tracef("Failed to parse event payload for pre-filtering: %s", e.getMessage());
-        }
-        return null;
-    }
-
     private void completeTraceFailed(TraceContext traceCtx) {
         if (traceCtx == null) {
             return;

--- a/app/src/main/java/io/apitomy/axiom/app/PipelineOrchestrator.java
+++ b/app/src/main/java/io/apitomy/axiom/app/PipelineOrchestrator.java
@@ -24,6 +24,7 @@ import org.jboss.logging.Logger;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Set;
 
 /**
  * The central event processing pipeline. Dequeues events, invokes the AI Manager
@@ -122,6 +123,18 @@ public class PipelineOrchestrator {
 
         LOG.infof("Processing event %d: %s [%s] from %s",
                 event.id, event.eventType, event.issueRef, event.source);
+
+        // Pre-filter: skip events from known bots without invoking the AI Manager
+        String skipReason = shouldSkipEvent(event);
+        if (skipReason != null) {
+            LOG.infof("Pre-filtered event %d: %s", event.id, skipReason);
+            QuarkusTransaction.requiringNew().run(() -> {
+                logActivity(null, null, event.id, "event-pre-filtered",
+                        "Event pre-filtered: " + event.eventType + " — " + skipReason);
+                markQueueEntry(queueEntryId, "completed");
+            });
+            return;
+        }
 
         // Trace creation (TraceService manages its own transactions)
         TraceContext traceCtx = null;
@@ -609,6 +622,56 @@ public class PipelineOrchestrator {
     /**
      * Completes the trace with a failed status on pipeline error.
      */
+    private static final Set<String> BOT_LOGINS = Set.of(
+            "github-actions[bot]", "sonarqubecloud[bot]", "sonarcloud[bot]",
+            "renovate[bot]", "dependabot[bot]", "codecov[bot]"
+    );
+
+    private static final Set<String> SLASH_COMMANDS = Set.of(
+            "/ready", "/retry", "/accept", "/reject", "/disable-tests",
+            "/enable-tests", "/unstale", "/skip-review", "/auto-merge", "/merge"
+    );
+
+    /**
+     * Returns a skip reason if the event should be filtered out without
+     * invoking the AI Manager, or {@code null} if the event should be processed.
+     */
+    private String shouldSkipEvent(EventEntity event) {
+        if (event.payload == null || event.payload.isBlank()) {
+            return null;
+        }
+        try {
+            JsonNode payload = objectMapper.readTree(event.payload);
+
+            // Extract the author login from the event payload
+            String login = null;
+            JsonNode comment = payload.path("comment");
+            if (!comment.isMissingNode()) {
+                login = comment.path("user").path("login").asText(null);
+            }
+            if (login == null) {
+                login = payload.path("user").path("login").asText(null);
+            }
+
+            // Skip events from known bots
+            if (login != null && BOT_LOGINS.contains(login)) {
+                return "bot activity from " + login;
+            }
+
+            // Skip slash command comments (lifecycle orchestrator handles these)
+            if ("comment-added".equals(event.eventType) && !comment.isMissingNode()) {
+                String body = comment.path("body").asText("").trim();
+                if (SLASH_COMMANDS.stream().anyMatch(cmd ->
+                        body.equals(cmd) || body.startsWith(cmd + " "))) {
+                    return "slash command: " + body.split("\\s+")[0];
+                }
+            }
+        } catch (Exception e) {
+            LOG.tracef("Failed to parse event payload for pre-filtering: %s", e.getMessage());
+        }
+        return null;
+    }
+
     private void completeTraceFailed(TraceContext traceCtx) {
         if (traceCtx == null) {
             return;


### PR DESCRIPTION
## Summary

Two fixes for event processing efficiency:

1. **Subprocess join timeout** — `stdoutFuture.join()` / `stderrFuture.join()` in `ClaudeCodeSubprocess` can hang indefinitely when orphan child processes keep pipes open. Adds 30-second bounded wait and kills the full process tree on exit.

2. **Pre-filter bot events** — Events from known bots (`github-actions[bot]`, `sonarqubecloud[bot]`, `renovate[bot]`, `dependabot[bot]`, `codecov[bot]`) and slash-command comments (`/ready`, `/retry`, `/accept`, etc.) are skipped before invoking the AI Manager. These were 50%+ of all events and were always ignored after an expensive Manager evaluation.

## Impact

On a repo with 225 events over 3 days:
- 74 bot comments (43 github-actions, 31 sonarqubecloud) → would be pre-filtered
- 10+ slash commands (/retry, /accept) → would be pre-filtered
- Saves ~$5 per 225 events in Manager evaluation costs
- Subprocess fix prevents 65-minute actor slot blockage on auth failures

## Test plan

- [x] `mvn test -pl actors/claude-code` — 36 tests pass
- [x] `mvn test-compile -pl app -am -DskipTests` compiles cleanly
- [ ] Verify pre-filtered events logged as "event-pre-filtered" in activity log
- [ ] Verify bot events no longer reach the Manager

Closes #121