### PR TITLE
Add copy-as-markdown button to assistant chat messages

### DIFF
--- a/ui/src/components/assistant/AssistantMessageList.css
+++ b/ui/src/components/assistant/AssistantMessageList.css
@@ -59,11 +59,34 @@
 }
 
 .axiom-message-list__assistant-bubble {
+    position: relative;
     max-width: 80%;
     padding: 10px 14px;
     border-radius: 12px 12px 12px 2px;
     background-color: var(--pf-t--global--background--color--secondary--default, #f0f0f0);
     font-size: 14px;
+}
+
+.axiom-message-list__copy-btn {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    opacity: 0;
+    transition: opacity 0.15s ease-in-out;
+}
+
+.axiom-message-list__assistant-bubble:hover .axiom-message-list__copy-btn {
+    opacity: 1;
+}
+
+.axiom-message-list__copy-btn .pf-v6-c-button {
+    padding: 2px;
+    font-size: 12px;
+    color: var(--pf-t--global--text--color--subtle, #6a6e73);
+}
+
+.axiom-message-list__copy-btn .pf-v6-c-button:hover {
+    color: var(--pf-t--global--text--color--regular, #151515);
 }
 
 /* Processing spinner */

--- a/ui/src/components/assistant/AssistantMessageList.tsx
+++ b/ui/src/components/assistant/AssistantMessageList.tsx
@@ -35,7 +35,7 @@ interface AssistantMessageListProps {
 export function AssistantMessageList({ messages, onPermissionRespond, onCreateAutoApproval, isProcessing, processingText }: AssistantMessageListProps) {
     const endRef = useRef<HTMLDivElement>(null);
     const [copiedId, setCopiedId] = useState<string | null>(null);
-    const copyTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+    const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
     const handleCopyMarkdown = (msgId: string, content: string) => {
         navigator.clipboard.writeText(content).then(() => {
@@ -44,8 +44,18 @@ export function AssistantMessageList({ messages, onPermissionRespond, onCreateAu
             }
             setCopiedId(msgId);
             copyTimeoutRef.current = setTimeout(() => setCopiedId(null), 2000);
+        }).catch((err) => {
+            console.warn("Failed to copy to clipboard:", err);
         });
     };
+
+    useEffect(() => {
+        return () => {
+            if (copyTimeoutRef.current) {
+                clearTimeout(copyTimeoutRef.current);
+            }
+        };
+    }, []);
 
     useEffect(() => {
         endRef.current?.scrollIntoView({ behavior: "auto" });

--- a/ui/src/components/assistant/AssistantMessageList.tsx
+++ b/ui/src/components/assistant/AssistantMessageList.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { Content, Spinner } from "@patternfly/react-core";
+import { Button, Content, Spinner, Tooltip } from "@patternfly/react-core";
+import CheckCircleIcon from "@patternfly/react-icons/dist/esm/icons/check-circle-icon";
+import CopyIcon from "@patternfly/react-icons/dist/esm/icons/copy-icon";
 import ExclamationTriangleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon";
 import { AssistantToolUseBlock } from "./AssistantToolUseBlock";
 import { AssistantPermissionPrompt } from "./AssistantPermissionPrompt";
@@ -32,6 +34,18 @@ interface AssistantMessageListProps {
 
 export function AssistantMessageList({ messages, onPermissionRespond, onCreateAutoApproval, isProcessing, processingText }: AssistantMessageListProps) {
     const endRef = useRef<HTMLDivElement>(null);
+    const [copiedId, setCopiedId] = useState<string | null>(null);
+    const copyTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+
+    const handleCopyMarkdown = (msgId: string, content: string) => {
+        navigator.clipboard.writeText(content).then(() => {
+            if (copyTimeoutRef.current) {
+                clearTimeout(copyTimeoutRef.current);
+            }
+            setCopiedId(msgId);
+            copyTimeoutRef.current = setTimeout(() => setCopiedId(null), 2000);
+        });
+    };
 
     useEffect(() => {
         endRef.current?.scrollIntoView({ behavior: "auto" });
@@ -69,6 +83,20 @@ export function AssistantMessageList({ messages, onPermissionRespond, onCreateAu
                         return (
                             <div key={msg.id} className="axiom-message-list__assistant-row">
                                 <div className="assistant-markdown axiom-message-list__assistant-bubble">
+                                    <div className="axiom-message-list__copy-btn">
+                                        <Tooltip content={copiedId === msg.id ? "Copied!" : "Copy markdown"}>
+                                            <Button
+                                                variant="plain"
+                                                size="sm"
+                                                aria-label="Copy markdown"
+                                                onClick={() => handleCopyMarkdown(msg.id, msg.content?.trim() || "")}
+                                            >
+                                                {copiedId === msg.id
+                                                    ? <CheckCircleIcon color="var(--pf-t--global--color--status--success--default)" />
+                                                    : <CopyIcon />}
+                                            </Button>
+                                        </Tooltip>
+                                    </div>
                                     <Content>
                                         <Markdown remarkPlugins={[remarkGfm]}>
                                             {msg.content?.trim() || ""}


### PR DESCRIPTION
## Summary

- Add a hover-reveal copy icon to assistant message bubbles that copies raw markdown to the clipboard
- Icon appears in the top-right corner on hover and briefly swaps to a green checkmark after copying
- Only applies to assistant-type messages (not user, system, warning, tool-use, etc.)

Fixes #124

## Test plan

- [ ] Hover over an assistant message bubble — copy icon appears top-right
- [ ] Click the icon — clipboard contains raw markdown, icon swaps to green checkmark for ~2s
- [ ] Verify icon does **not** appear on user, system, warning, tool-use, thinking, or permission messages
- [ ] Verify no layout shift when icon appears/disappears
- [ ] Verify dark mode — icon colors adapt via PF CSS variables