### PR TITLE
Add per-ActionType overrides for max steps and max budget

### DIFF
--- a/actors/claude-code/src/main/java/io/apitomy/axiom/actors/claudecode/ClaudeCodeActor.java
+++ b/actors/claude-code/src/main/java/io/apitomy/axiom/actors/claudecode/ClaudeCodeActor.java
@@ -67,8 +67,8 @@ public class ClaudeCodeActor implements Actor {
 
         ClaudeCodeCommandBuilder cmdBuilder = ClaudeCodeCommandBuilder
                 .fromContext(prompt, context)
-                .maxTurns(maxTurns)
-                .maxBudgetUsd(maxBudgetUsd);
+                .maxTurns(context.getMaxSteps() != null ? context.getMaxSteps() : maxTurns)
+                .maxBudgetUsd(context.getMaxBudgetUsd() != null ? context.getMaxBudgetUsd() : maxBudgetUsd);
 
         // Per-action-type model takes priority over the global default
         if (context.getModel() != null && !context.getModel().isBlank()) {

--- a/actors/spi/src/main/java/io/apitomy/axiom/actors/spi/ActorContext.java
+++ b/actors/spi/src/main/java/io/apitomy/axiom/actors/spi/ActorContext.java
@@ -18,6 +18,8 @@ public class ActorContext {
     private final Path mcpConfigFile;
     private final Map<String, String> environment;
     private final String model;
+    private final Integer maxSteps;
+    private final Double maxBudgetUsd;
 
     private ActorContext(Builder builder) {
         this.workingDirectory = builder.workingDirectory;
@@ -28,6 +30,8 @@ public class ActorContext {
         this.mcpConfigFile = builder.mcpConfigFile;
         this.environment = builder.environment;
         this.model = builder.model;
+        this.maxSteps = builder.maxSteps;
+        this.maxBudgetUsd = builder.maxBudgetUsd;
     }
 
     /**
@@ -86,6 +90,20 @@ public class ActorContext {
         return model;
     }
 
+    /**
+     * @return the max steps/turns override for this action type, or null to use the global default
+     */
+    public Integer getMaxSteps() {
+        return maxSteps;
+    }
+
+    /**
+     * @return the max budget (USD) override for this action type, or null to use the global default
+     */
+    public Double getMaxBudgetUsd() {
+        return maxBudgetUsd;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -99,6 +117,8 @@ public class ActorContext {
         private Path mcpConfigFile;
         private Map<String, String> environment = Map.of();
         private String model;
+        private Integer maxSteps;
+        private Double maxBudgetUsd;
 
         public Builder workingDirectory(Path workingDirectory) {
             this.workingDirectory = workingDirectory;
@@ -137,6 +157,16 @@ public class ActorContext {
 
         public Builder model(String model) {
             this.model = model;
+            return this;
+        }
+
+        public Builder maxSteps(Integer maxSteps) {
+            this.maxSteps = maxSteps;
+            return this;
+        }
+
+        public Builder maxBudgetUsd(Double maxBudgetUsd) {
+            this.maxBudgetUsd = maxBudgetUsd;
             return this;
         }
 

--- a/app/src/main/java/io/apitomy/axiom/app/ImportExportService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ImportExportService.java
@@ -293,6 +293,8 @@ public class ImportExportService {
             entity.scriptTemplate = textOrNull(item, "scriptTemplate");
             entity.model = textOrNull(item, "model");
             entity.engine = textOrNull(item, "engine");
+            entity.maxSteps = item.has("maxSteps") ? item.path("maxSteps").asInt() : null;
+            entity.maxBudgetUsd = item.has("maxBudgetUsd") ? item.path("maxBudgetUsd").asDouble() : null;
             entity.environment = jsonOrNull(item, "environment");
             entity.persist();
             count++;
@@ -378,6 +380,8 @@ public class ImportExportService {
             entity.scriptTemplate = textOrNull(item, "scriptTemplate");
             entity.model = textOrNull(item, "model");
             entity.engine = textOrNull(item, "engine");
+            entity.maxSteps = item.has("maxSteps") ? item.path("maxSteps").asInt() : null;
+            entity.maxBudgetUsd = item.has("maxBudgetUsd") ? item.path("maxBudgetUsd").asDouble() : null;
             entity.environment = jsonOrNull(item, "environment");
             entity.persist();
             if (isNew) created++;
@@ -537,6 +541,8 @@ public class ImportExportService {
         putIfNotNull(n, "scriptTemplate", e.scriptTemplate);
         putIfNotNull(n, "model", e.model);
         putIfNotNull(n, "engine", e.engine);
+        if (e.maxSteps != null) n.put("maxSteps", e.maxSteps);
+        if (e.maxBudgetUsd != null) n.put("maxBudgetUsd", e.maxBudgetUsd);
         putIfNotNull(n, "environment", e.environment);
         return n;
     }

--- a/app/src/main/java/io/apitomy/axiom/app/TaskExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/TaskExecutionService.java
@@ -181,6 +181,8 @@ public class TaskExecutionService {
                 .mcpConfigFile(mcpConfig)
                 .environment(env)
                 .model(actionTypeEntity != null ? actionTypeEntity.model : null)
+                .maxSteps(actionTypeEntity != null ? actionTypeEntity.maxSteps : null)
+                .maxBudgetUsd(actionTypeEntity != null ? actionTypeEntity.maxBudgetUsd : null)
                 .build();
 
         // Execute asynchronously

--- a/app/src/main/java/io/apitomy/axiom/app/rest/ActionResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/ActionResourceImpl.java
@@ -181,6 +181,9 @@ public class ActionResourceImpl implements ActionResource {
         entity.promptTemplate = data.getPromptTemplate();
         entity.scriptTemplate = data.getScriptTemplate();
         entity.model = data.getModel();
+        entity.engine = data.getEngine();
+        entity.maxSteps = data.getMaxSteps();
+        entity.maxBudgetUsd = data.getMaxBudgetUsd();
         entity.emitsEvent = data.getEmitsEvent() != null ? data.getEmitsEvent() : false;
         entity.environment = environmentToJson(data.getEnvironment());
     }
@@ -209,6 +212,9 @@ public class ActionResourceImpl implements ActionResource {
         actionType.setPromptTemplate(entity.promptTemplate);
         actionType.setScriptTemplate(entity.scriptTemplate);
         actionType.setModel(entity.model);
+        actionType.setEngine(entity.engine);
+        actionType.setMaxSteps(entity.maxSteps);
+        actionType.setMaxBudgetUsd(entity.maxBudgetUsd);
         actionType.setEmitsEvent(entity.emitsEvent);
         actionType.setEnvironment(jsonToEnvironment(entity.environment));
         return actionType;

--- a/app/src/main/resources/db/migration/V31__add_max_steps_and_max_budget_to_action_type.sql
+++ b/app/src/main/resources/db/migration/V31__add_max_steps_and_max_budget_to_action_type.sql
@@ -1,0 +1,8 @@
+-- =============================================================================
+-- V31: Add maxSteps and maxBudgetUsd columns to action_type
+-- Allows per-action-type overrides for the global max-steps and max-budget-usd
+-- defaults. When NULL, the global defaults apply.
+-- =============================================================================
+
+ALTER TABLE action_type ADD COLUMN IF NOT EXISTS max_steps INTEGER;
+ALTER TABLE action_type ADD COLUMN IF NOT EXISTS max_budget_usd DOUBLE PRECISION;

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -4618,6 +4618,16 @@
           "engine": {
             "description": "AI engine override for this action type (e.g. opencode, claude-code). When empty, the global default engine is used.",
             "type": "string"
+          },
+          "maxSteps": {
+            "format": "int32",
+            "description": "Maximum number of agent steps/turns for this action type. When empty, the global default is used.",
+            "type": "integer"
+          },
+          "maxBudgetUsd": {
+            "format": "double",
+            "description": "Maximum budget in USD for this action type. When empty, the global default is used.",
+            "type": "number"
           }
         }
       },
@@ -4682,6 +4692,16 @@
           "engine": {
             "description": "AI engine override for this action type (e.g. opencode, claude-code). When empty, the global default engine is used.",
             "type": "string"
+          },
+          "maxSteps": {
+            "format": "int32",
+            "description": "Maximum number of agent steps/turns for this action type. When empty, the global default is used.",
+            "type": "integer"
+          },
+          "maxBudgetUsd": {
+            "format": "double",
+            "description": "Maximum budget in USD for this action type. When empty, the global default is used.",
+            "type": "number"
           }
         }
       },

--- a/core/src/main/java/io/apitomy/axiom/core/entities/ActionTypeEntity.java
+++ b/core/src/main/java/io/apitomy/axiom/core/entities/ActionTypeEntity.java
@@ -55,6 +55,20 @@ public class ActionTypeEntity extends PanacheEntity {
     @Column(name = "engine")
     public String engine;
 
+    /**
+     * Optional max steps/turns override for this action type.
+     * When null, the global default max-steps is used.
+     */
+    @Column(name = "max_steps")
+    public Integer maxSteps;
+
+    /**
+     * Optional max budget (USD) override for this action type.
+     * When null, the global default max-budget-usd is used.
+     */
+    @Column(name = "max_budget_usd")
+    public Double maxBudgetUsd;
+
     @Column(name = "manager_triggerable", nullable = false)
     public boolean managerTriggerable;
 

--- a/engine/opencode/src/main/java/io/apitomy/axiom/engine/opencode/OpenCodeActor.java
+++ b/engine/opencode/src/main/java/io/apitomy/axiom/engine/opencode/OpenCodeActor.java
@@ -60,7 +60,7 @@ public class OpenCodeActor implements Actor {
                 .workingDirectory(context.getWorkingDirectory())
                 .environment(context.getEnvironment() != null ? context.getEnvironment() : Map.of())
                 .timeoutSeconds(timeoutSeconds)
-                .maxSteps(maxSteps)
+                .maxSteps(context.getMaxSteps() != null ? context.getMaxSteps() : maxSteps)
                 .model(resolveModel(context))
                 .mcpConfigFile(context.getMcpConfigFile())
                 .build();

--- a/ui/src/components/assistant/ActionTypeDetailModal.tsx
+++ b/ui/src/components/assistant/ActionTypeDetailModal.tsx
@@ -40,6 +40,8 @@ export function ActionTypeDetailModal({ isOpen, onClose, name, content, errors }
     const scriptTemplate = (content.scriptTemplate as string) || "";
     const model = (content.model as string) || "";
     const engine = (content.engine as string) || "";
+    const maxSteps = content.maxSteps as number | undefined;
+    const maxBudgetUsd = content.maxBudgetUsd as number | undefined;
 
     const toolsList = Array.isArray(rawAllowedTools)
         ? rawAllowedTools as string[]
@@ -117,6 +119,18 @@ export function ActionTypeDetailModal({ isOpen, onClose, name, content, errors }
                                     <DescriptionListGroup>
                                         <DescriptionListTerm>Engine</DescriptionListTerm>
                                         <DescriptionListDescription>{engine}</DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                )}
+                                {maxSteps != null && (
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm style={{ whiteSpace: "nowrap" }}>Max Steps</DescriptionListTerm>
+                                        <DescriptionListDescription>{maxSteps}</DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                )}
+                                {maxBudgetUsd != null && (
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm style={{ whiteSpace: "nowrap" }}>Max Budget (USD)</DescriptionListTerm>
+                                        <DescriptionListDescription>${maxBudgetUsd.toFixed(2)}</DescriptionListDescription>
                                     </DescriptionListGroup>
                                 )}
                             </DescriptionList>

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -331,6 +331,8 @@ export interface ActionType {
     scriptTemplate?: string;
     model?: string;
     engine?: string;
+    maxSteps?: number;
+    maxBudgetUsd?: number;
     emitsEvent: boolean;
     environment?: Record<string, string>;
 }

--- a/ui/src/pages/ActionTypeDetailPage.tsx
+++ b/ui/src/pages/ActionTypeDetailPage.tsx
@@ -106,6 +106,8 @@ export function ActionTypeDetailPage() {
                     scriptTemplate: at.scriptTemplate,
                     model: at.model,
                     engine: at.engine,
+                    maxSteps: at.maxSteps,
+                    maxBudgetUsd: at.maxBudgetUsd,
                 });
                 setTools(at.allowedTools || []);
                 setEnvVars(at.environment || {});
@@ -435,6 +437,34 @@ function InfoTab({ form, updateForm, availableModels, availableEngines }: {
                             ));
                         })()}
                     </FormSelect>
+                </FormGroup>
+            )}
+            {form.executionMode === "actor" && (
+                <FormGroup label="Max Steps" fieldId="maxSteps">
+                    <HelperText>
+                        <HelperTextItem>Maximum number of agent steps/turns. Leave empty to use the global default.</HelperTextItem>
+                    </HelperText>
+                    <TextInput
+                        id="maxSteps"
+                        type="number"
+                        value={form.maxSteps ?? ""}
+                        onChange={(_e, v) => updateForm({ maxSteps: v === "" ? undefined : Number(v) })}
+                        placeholder="Global default"
+                    />
+                </FormGroup>
+            )}
+            {form.executionMode === "actor" && (
+                <FormGroup label="Max Budget (USD)" fieldId="maxBudgetUsd">
+                    <HelperText>
+                        <HelperTextItem>Maximum budget in USD for this action type. Leave empty to use the global default.</HelperTextItem>
+                    </HelperText>
+                    <TextInput
+                        id="maxBudgetUsd"
+                        type="number"
+                        value={form.maxBudgetUsd ?? ""}
+                        onChange={(_e, v) => updateForm({ maxBudgetUsd: v === "" ? undefined : Number(v) })}
+                        placeholder="Global default"
+                    />
                 </FormGroup>
             )}
             <FormGroup fieldId="flags">


### PR DESCRIPTION
## Summary

Closes #120

- Adds optional `maxSteps` (integer) and `maxBudgetUsd` (double) fields to ActionType definitions
- When set on an ActionType, these values override the global `axiom.claude-code.max-turns`,
  `axiom.claude-code.max-budget-usd`, and `axiom.opencode.max-steps` config properties during
  task execution
- When null/unset, global defaults continue to apply (backward compatible)
- Includes an incidental fix for the `engine` field not being mapped in
  `ActionResourceImpl.applyFields()` and `toBean()`

### Changes across layers

| Layer | Files | What changed |
|-------|-------|-------------|
| OpenAPI | `openapi.json` | Added `maxSteps` and `maxBudgetUsd` to `ActionType` and `NewActionType` schemas |
| Database | `V31__*.sql` | Added nullable `max_steps` and `max_budget_usd` columns |
| Entity | `ActionTypeEntity` | Added `Integer maxSteps` and `Double maxBudgetUsd` fields |
| REST | `ActionResourceImpl` | Added mapping in `applyFields()`/`toBean()` + fixed `engine` mapping |
| Context | `ActorContext` | Added fields, getters, and builder methods |
| Orchestration | `TaskExecutionService` | Passes ActionType overrides to ActorContext |
| Claude Code | `ClaudeCodeActor` | Prefers per-ActionType values over global config for both fields |
| OpenCode | `OpenCodeActor` | Prefers per-ActionType `maxSteps` over global config (no budget support) |
| Import/Export | `ImportExportService` | Added to both import sites and export serializer |
| UI Types | `api.ts` | Added `maxSteps?: number` and `maxBudgetUsd?: number` |
| UI Form | `ActionTypeDetailPage` | Added number inputs (actor-mode only) |
| UI Modal | `ActionTypeDetailModal` | Added read-only display |

## Test plan

- [ ] Run `mvn install` to regenerate API beans — confirm `getMaxSteps()`/`getMaxBudgetUsd()` exist
- [ ] Start the app — verify V31 migration runs cleanly
- [ ] Create/update an ActionType with `maxSteps` and `maxBudgetUsd` via REST — verify persistence
- [ ] Verify null values are accepted and mean "use global default"
- [ ] Open ActionType detail page — verify fields appear for actor-mode, hidden for script-mode
- [ ] Export config — verify new fields are included; import without them — verify backward compat