### PR TITLE
Add "Allow All" toggle to AI Assistant session toolbar

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSession.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSession.java
@@ -70,6 +70,7 @@ public class AssistantSession {
     private final CopyOnWriteArrayList<Consumer<SseEvent>> listeners = new CopyOnWriteArrayList<>();
     private final Object eventLock = new Object();
     private final CopyOnWriteArrayList<AutoApprovalRule> autoApprovalRules = new CopyOnWriteArrayList<>();
+    private volatile boolean allowAll;
     private final Long projectId;
     private final String projectName;
 
@@ -480,6 +481,24 @@ public class AssistantSession {
     }
 
     /**
+     * Returns whether Allow All mode is active for this session.
+     *
+     * @return true if all permissions are auto-approved
+     */
+    public boolean isAllowAll() {
+        return allowAll;
+    }
+
+    /**
+     * Enables or disables Allow All mode for this session.
+     *
+     * @param allowAll true to auto-approve all permissions
+     */
+    public void setAllowAll(boolean allowAll) {
+        this.allowAll = allowAll;
+    }
+
+    /**
      * Checks whether a tool permission request matches any auto-approval rule.
      *
      * @param toolName the tool name from the permission request
@@ -555,10 +574,25 @@ public class AssistantSession {
         }
         String toolName = event.data().path("toolName").asText("");
         JsonNode toolInput = event.data().path("toolInput");
+        String requestId = event.data().path("requestId").asText("");
+
+        // Allow All short-circuit: auto-approve everything but keep the event
+        // visible in the stream so the UI can show it as auto-approved.
+        if (allowAll) {
+            LOG.infof("Auto-approving %s (allow-all) in session %s", toolName, id);
+            try {
+                addEvent(event);
+                respondToPermission(requestId, true, toolInput);
+            } catch (IOException e) {
+                LOG.warnf(e, "Failed to auto-approve %s in session %s", toolName, id);
+                return false;
+            }
+            return true;
+        }
+
         if (!checkAutoApproval(toolName, toolInput)) {
             return false;
         }
-        String requestId = event.data().path("requestId").asText("");
         LOG.infof("Auto-approving %s (rule matched) in session %s", toolName, id);
         try {
             respondToPermission(requestId, true, toolInput);

--- a/app/src/main/java/io/apitomy/axiom/app/rest/AssistantResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/AssistantResourceImpl.java
@@ -516,9 +516,10 @@ public class AssistantResourceImpl implements AssistantResource {
     @Override
     public void setAllowAll(String sessionId, SetAllowAllRequest data) {
         AssistantSession session = requireSession(sessionId);
-        session.setAllowAll(data.getEnabled());
+        boolean enabled = data.getEnabled() != null && data.getEnabled();
+        session.setAllowAll(enabled);
         ObjectNode eventData = objectMapper.createObjectNode();
-        eventData.put("enabled", data.getEnabled());
+        eventData.put("enabled", enabled);
         session.addEvent(new SseEvent("allow_all_changed", eventData));
     }
 

--- a/app/src/main/java/io/apitomy/axiom/app/rest/AssistantResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/AssistantResourceImpl.java
@@ -3,6 +3,7 @@ package io.apitomy.axiom.app.rest;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.apitomy.axiom.api.beans.Environment;
 import io.apitomy.axiom.api.AssistantResource;
 import io.apitomy.axiom.api.beans.AssistantApplyResult;
@@ -16,6 +17,7 @@ import io.apitomy.axiom.api.beans.NewSessionTemplate;
 import io.apitomy.axiom.api.beans.RenameAssistantSessionRequest;
 import io.apitomy.axiom.api.beans.SendAssistantMessageRequest;
 import io.apitomy.axiom.api.beans.SessionTemplate;
+import io.apitomy.axiom.api.beans.SetAllowAllRequest;
 import io.apitomy.axiom.app.assistant.AssistantEventParser.SseEvent;
 import io.apitomy.axiom.app.assistant.AssistantSession;
 import io.apitomy.axiom.app.ImportExportService;
@@ -508,6 +510,18 @@ public class AssistantResourceImpl implements AssistantResource {
         session.removeAutoApprovalRule(ruleId);
     }
 
+    // ── Allow All ───────────────────────────────────────────────────
+
+    /** {@inheritDoc} */
+    @Override
+    public void setAllowAll(String sessionId, SetAllowAllRequest data) {
+        AssistantSession session = requireSession(sessionId);
+        session.setAllowAll(data.getEnabled());
+        ObjectNode eventData = objectMapper.createObjectNode();
+        eventData.put("enabled", data.getEnabled());
+        session.addEvent(new SseEvent("allow_all_changed", eventData));
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────
 
     private AssistantSession requireSession(String sessionId) {
@@ -541,6 +555,7 @@ public class AssistantResourceImpl implements AssistantResource {
         info.setTurnCount(session.getTurnCount());
         info.setProjectId(session.getProjectId());
         info.setProjectName(session.getProjectName());
+        info.setAllowAll(session.isAllowAll());
         return info;
     }
 

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -4132,6 +4132,44 @@
           }
         }
       }
+    },
+    "/assistant/sessions/{sessionId}/allow-all": {
+      "put": {
+        "tags": [
+          "assistant"
+        ],
+        "summary": "Enable or disable Allow All mode for a session",
+        "description": "Sets the Allow All mode for the specified assistant session. When enabled, all tool permission requests are automatically approved without user interaction. The state is transient and resets when the session ends.",
+        "operationId": "setAllowAll",
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "description": "The assistant session ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetAllowAllRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Allow All mode updated successfully"
+          },
+          "404": {
+            "description": "Session not found"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -6125,6 +6163,10 @@
           "projectName": {
             "description": "Project name if session is scoped to a project",
             "type": "string"
+          },
+          "allowAll": {
+            "description": "Whether Allow All mode is active for this session",
+            "type": "boolean"
           }
         }
       },
@@ -7002,6 +7044,18 @@
           "permissionId": {
             "description": "Optional pending permission ID to also approve immediately",
             "type": "string"
+          }
+        }
+      },
+      "SetAllowAllRequest": {
+        "required": [
+          "enabled"
+        ],
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "description": "Whether to enable or disable the Allow All mode",
+            "type": "boolean"
           }
         }
       }

--- a/ui/src/components/assistant/AssistantChatPanel.tsx
+++ b/ui/src/components/assistant/AssistantChatPanel.tsx
@@ -17,13 +17,14 @@ interface AssistantChatPanelProps {
     onItemsChanged?: () => void;
     onModeChange?: (mode: SessionMode) => void;
     onAutoApprovalCountChange?: () => void;
+    onAllowAllChanged?: (enabled: boolean) => void;
     onModelDetected?: (model: string) => void;
     onCostUpdate?: (costUsd: number, inputTokens: number, outputTokens: number) => void;
 }
 
 let messageIdCounter = 0;
 
-export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, onAutoApprovalCountChange, onModelDetected, onCostUpdate }: AssistantChatPanelProps) {
+export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, onAutoApprovalCountChange, onAllowAllChanged, onModelDetected, onCostUpdate }: AssistantChatPanelProps) {
     const [messages, setMessages] = useState<ChatMessage[]>([]);
     const [isProcessing, setIsProcessing] = useState(false);
     const [processingText, setProcessingText] = useState("");
@@ -34,9 +35,11 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
     const onItemsChangedRef = useRef(onItemsChanged);
     const onModeChangeRef = useRef(onModeChange);
     const onModelDetectedRef = useRef(onModelDetected);
+    const onAllowAllChangedRef = useRef(onAllowAllChanged);
     const onCostUpdateRef = useRef(onCostUpdate);
     useEffect(() => { onItemsChangedRef.current = onItemsChanged; }, [onItemsChanged]);
     useEffect(() => { onModeChangeRef.current = onModeChange; }, [onModeChange]);
+    useEffect(() => { onAllowAllChangedRef.current = onAllowAllChanged; }, [onAllowAllChanged]);
     useEffect(() => { onModelDetectedRef.current = onModelDetected; }, [onModelDetected]);
     useEffect(() => { onCostUpdateRef.current = onCostUpdate; }, [onCostUpdate]);
 
@@ -211,6 +214,10 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
                             : m
                     )
                 );
+                break;
+
+            case "allow_all_changed":
+                onAllowAllChangedRef.current?.(data.enabled as boolean);
                 break;
 
             case "unhandled_event":

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -1234,6 +1234,7 @@ export interface AssistantSessionInfo {
     turnCount?: number;
     projectId?: number;
     projectName?: string;
+    allowAll?: boolean;
 }
 
 export interface AssistantItem {
@@ -1401,6 +1402,15 @@ export async function deleteAutoApproval(sessionId: string, ruleId: string): Pro
         { method: "DELETE" }
     );
     if (!response.ok) throw new Error("Failed to delete auto-approval");
+}
+
+export async function setAllowAll(sessionId: string, enabled: boolean): Promise<void> {
+    const response = await fetch(`${API}/assistant/sessions/${sessionId}/allow-all`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled }),
+    });
+    if (!response.ok) throw new Error("Failed to update Allow All mode");
 }
 
 export function assistantEventsUrl(sessionId: string): string {

--- a/ui/src/pages/AssistantSessionPage.css
+++ b/ui/src/pages/AssistantSessionPage.css
@@ -65,6 +65,19 @@
     margin-right: 8px;
 }
 
+/* Allow All toggle */
+.axiom-session-page__allow-all-switch {
+    margin-right: 12px;
+}
+
+.axiom-session-page__allow-all-switch--active .pf-v6-c-switch__toggle {
+    --pf-v6-c-switch__toggle--before--BackgroundColor: var(--pf-t--global--color--status--warning--default, #f0ab00);
+}
+
+.axiom-session-page__header[data-allow-all="true"] {
+    border-left: 3px solid var(--pf-t--global--color--status--warning--default, #f0ab00);
+}
+
 .axiom-session-page__shield-btn {
     margin-right: 4px;
 }

--- a/ui/src/pages/AssistantSessionPage.tsx
+++ b/ui/src/pages/AssistantSessionPage.tsx
@@ -67,6 +67,7 @@ export function AssistantSessionPage() {
     const [autoApprovalRules, setAutoApprovalRules] = useState<AutoApprovalRule[]>([]);
     const [isAutoApprovalModalOpen, setIsAutoApprovalModalOpen] = useState(false);
     const [allowAll, setAllowAll] = useState(false);
+    const [allowAllError, setAllowAllError] = useState<string | null>(null);
     const [isAllowAllConfirmOpen, setIsAllowAllConfirmOpen] = useState(false);
 
     useEffect(() => {
@@ -153,21 +154,25 @@ export function AssistantSessionPage() {
     const handleAllowAllConfirm = async () => {
         if (!sessionId) return;
         setIsAllowAllConfirmOpen(false);
+        setAllowAllError(null);
         try {
             await apiSetAllowAll(sessionId, true);
             setAllowAll(true);
         } catch (err) {
             console.error("Failed to enable Allow All:", err);
+            setAllowAllError((err as Error).message || "Failed to enable Allow All");
         }
     };
 
     const handleAllowAllDisable = async () => {
         if (!sessionId) return;
+        setAllowAllError(null);
         try {
             await apiSetAllowAll(sessionId, false);
             setAllowAll(false);
         } catch (err) {
             console.error("Failed to disable Allow All:", err);
+            setAllowAllError((err as Error).message || "Failed to disable Allow All");
         }
     };
 
@@ -399,6 +404,18 @@ export function AssistantSessionPage() {
                     className="axiom-session-page__rename-error"
                 >
                     {renameError}
+                </Alert>
+            )}
+
+            {allowAllError && (
+                <Alert
+                    variant="danger"
+                    isInline
+                    title="Allow All toggle failed"
+                    actionClose={<AlertActionCloseButton onClose={() => setAllowAllError(null)} />}
+                    className="axiom-session-page__allow-all-error"
+                >
+                    {allowAllError}
                 </Alert>
             )}
 

--- a/ui/src/pages/AssistantSessionPage.tsx
+++ b/ui/src/pages/AssistantSessionPage.tsx
@@ -4,6 +4,7 @@ import {
     Badge,
     PageSection,
     Button,
+    Switch,
     TextInput,
     Flex,
     FlexItem,
@@ -32,6 +33,7 @@ import {
     renameAssistantSession,
     fetchAutoApprovals,
     deleteAutoApproval,
+    setAllowAll as apiSetAllowAll,
     type AssistantSessionInfo,
     type AutoApprovalRule,
     type AssistantApplyResult,
@@ -64,6 +66,8 @@ export function AssistantSessionPage() {
     const [autoApprovalCount, setAutoApprovalCount] = useState(0);
     const [autoApprovalRules, setAutoApprovalRules] = useState<AutoApprovalRule[]>([]);
     const [isAutoApprovalModalOpen, setIsAutoApprovalModalOpen] = useState(false);
+    const [allowAll, setAllowAll] = useState(false);
+    const [isAllowAllConfirmOpen, setIsAllowAllConfirmOpen] = useState(false);
 
     useEffect(() => {
         if (!sessionId) return;
@@ -71,6 +75,7 @@ export function AssistantSessionPage() {
         fetchAssistantSession(sessionId)
             .then((s) => {
                 setSession(s);
+                setAllowAll(!!s.allowAll);
                 if (isBreakout) {
                     document.title = `${s.name} — AI Assistant`;
                 }
@@ -145,6 +150,31 @@ export function AssistantSessionPage() {
         }
     };
 
+    const handleAllowAllConfirm = async () => {
+        if (!sessionId) return;
+        setIsAllowAllConfirmOpen(false);
+        try {
+            await apiSetAllowAll(sessionId, true);
+            setAllowAll(true);
+        } catch (err) {
+            console.error("Failed to enable Allow All:", err);
+        }
+    };
+
+    const handleAllowAllDisable = async () => {
+        if (!sessionId) return;
+        try {
+            await apiSetAllowAll(sessionId, false);
+            setAllowAll(false);
+        } catch (err) {
+            console.error("Failed to disable Allow All:", err);
+        }
+    };
+
+    const handleAllowAllChanged = useCallback((enabled: boolean) => {
+        setAllowAll(enabled);
+    }, []);
+
     const handleEndSession = async () => {
         if (!sessionId) return;
         setEndSessionError(null);
@@ -213,7 +243,8 @@ export function AssistantSessionPage() {
             className="axiom-session-page">
             {/* Header — fixed at top */}
             <Flex className="axiom-session-page__header"
-                data-mode={sessionMode === "plan" ? "plan" : undefined}>
+                data-mode={sessionMode === "plan" ? "plan" : undefined}
+                data-allow-all={allowAll ? "true" : undefined}>
                 {!isBreakout && (
                     <FlexItem>
                         <Button variant="plain" onClick={() => navigate("/assistant")}>
@@ -288,6 +319,23 @@ export function AssistantSessionPage() {
                             Apply All
                         </Button>
                     )}
+                    <Tooltip content={allowAll
+                        ? "All tool permissions are being auto-approved"
+                        : "Auto-approve all tool permissions for this session"}>
+                        <Switch
+                            id="allow-all-toggle"
+                            label="Allow All"
+                            isChecked={allowAll}
+                            onChange={(_event, checked) => {
+                                if (checked) {
+                                    setIsAllowAllConfirmOpen(true);
+                                } else {
+                                    handleAllowAllDisable();
+                                }
+                            }}
+                            className={`axiom-session-page__allow-all-switch${allowAll ? " axiom-session-page__allow-all-switch--active" : ""}`}
+                        />
+                    </Tooltip>
                     {autoApprovalCount > 0 && (
                         <Tooltip content={`${autoApprovalCount} auto-approval rule(s) active`}>
                             <Button variant="plain" onClick={openAutoApprovalModal}
@@ -362,6 +410,7 @@ export function AssistantSessionPage() {
                         onItemsChanged={isConfigAssistant ? handleItemsChanged : undefined}
                         onModeChange={setSessionMode}
                         onAutoApprovalCountChange={handleAutoApprovalCountChange}
+                        onAllowAllChanged={handleAllowAllChanged}
                         onModelDetected={setSessionModel}
                         onCostUpdate={(cost, tokensIn, tokensOut) => {
                             setSessionCost(cost);
@@ -400,6 +449,29 @@ export function AssistantSessionPage() {
                         End Session
                     </Button>
                     <Button variant="link" onClick={() => setIsEndConfirmOpen(false)}>
+                        Cancel
+                    </Button>
+                </ModalFooter>
+            </Modal>
+
+            {/* Allow All confirmation */}
+            <Modal
+                isOpen={isAllowAllConfirmOpen}
+                onClose={() => setIsAllowAllConfirmOpen(false)}
+                variant="small"
+                aria-label="Enable Allow All confirmation"
+            >
+                <ModalHeader title="Enable Allow All?" />
+                <ModalBody>
+                    All tool invocations will be approved automatically without prompting.
+                    This includes file modifications, command execution, and any other tool
+                    actions. You can disable this at any time.
+                </ModalBody>
+                <ModalFooter>
+                    <Button variant="warning" onClick={handleAllowAllConfirm}>
+                        Enable
+                    </Button>
+                    <Button variant="link" onClick={() => setIsAllowAllConfirmOpen(false)}>
                         Cancel
                     </Button>
                 </ModalFooter>


### PR DESCRIPTION
## Summary

Adds a per-session "Allow All" toggle to the AI Assistant session toolbar that auto-approves all
tool permission requests without user interaction. Closes #109.

- **API**: New `PUT /assistant/sessions/{sessionId}/allow-all` endpoint with `SetAllowAllRequest`
  schema; `AssistantSessionInfo` extended with `allowAll` field
- **Backend**: `allowAll` short-circuit in `handleAutoApproval()` that auto-approves permissions
  while keeping them visible in the event stream; emits `allow_all_changed` SSE event for
  cross-tab sync
- **Frontend**: `Switch` toggle in session header with confirmation modal on enable, warning-colored
  visual indicator when active, and SSE-driven state sync across tabs

## Test plan

- [ ] Start a session — verify the Allow All switch is visible and OFF by default
- [ ] Toggle ON — confirmation modal appears with warning text
- [ ] Confirm — switch activates, header shows warning-colored left border
- [ ] Trigger a tool invocation — permission is auto-approved and visible in chat as resolved
- [ ] Toggle OFF — normal permission prompting resumes for subsequent requests
- [ ] Open a second tab/window — verify Allow All state syncs via SSE
- [ ] End session and start a new one — verify Allow All defaults to OFF (not persisted)
- [ ] Toggle on/off rapidly — no errors or stuck state