### PR TITLE
Handle tool_progress event type in AssistantEventParser (#116)

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantEventParser.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantEventParser.java
@@ -26,6 +26,7 @@ import java.util.List;
  *   <li>{@code result} → {@code turn_complete}</li>
  *   <li>{@code sdk_control_request} / {@code control_request} → {@code permission_request}</li>
  *   <li>{@code conversation_reset} → {@code conversation_reset}</li>
+ *   <li>{@code tool_progress} → {@code tool_progress}</li>
  * </ul>
  */
 public class AssistantEventParser {
@@ -57,6 +58,7 @@ public class AssistantEventParser {
                 case "sdk_control_request" -> parseSdkControlRequest(node);
                 case "control_request" -> parseControlRequest(node);
                 case "conversation_reset" -> parseConversationReset(node);
+                case "tool_progress" -> parseToolProgress(node);
                 default -> {
                     ObjectNode data = JsonNodeFactory.instance.objectNode();
                     data.put("rawType", type);
@@ -197,11 +199,32 @@ public class AssistantEventParser {
     }
 
     /**
+     * Parses a tool_progress event that reports elapsed time while a tool
+     * is executing.
+     *
+     * @param root the raw NDJSON node
+     * @return a single tool_progress SSE event, or empty if required fields are missing
+     */
+    private List<SseEvent> parseToolProgress(JsonNode root) {
+        JsonNode toolUseId = root.path("tool_use_id");
+        JsonNode toolName = root.path("tool_name");
+        JsonNode elapsed = root.path("elapsed_time_seconds");
+        if (toolUseId.isMissingNode() || toolName.isMissingNode() || elapsed.isMissingNode()) {
+            return Collections.emptyList();
+        }
+        ObjectNode data = JsonNodeFactory.instance.objectNode();
+        data.put("toolUseId", toolUseId.asText());
+        data.put("toolName", toolName.asText());
+        data.put("elapsedSeconds", elapsed.asInt());
+        return List.of(new SseEvent("tool_progress", data));
+    }
+
+    /**
      * A normalised SSE event parsed from Claude Code's NDJSON output.
      *
      * @param type the normalised event type (session_init, assistant_text,
-     *             tool_use, tool_result, turn_complete, permission_request,
-     *             thinking, conversation_reset)
+     *             tool_use, tool_result, tool_progress, turn_complete,
+     *             permission_request, thinking, conversation_reset)
      * @param data the extracted/transformed JSON data
      */
     public record SseEvent(String type, JsonNode data) {

--- a/app/src/test/java/io/apitomy/axiom/app/assistant/AssistantEventParserTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/assistant/AssistantEventParserTest.java
@@ -205,6 +205,32 @@ class AssistantEventParserTest {
         assertEquals("conversation_reset", events.get(0).type());
     }
 
+    // ── Tool progress events ──────────────────────────────────────
+
+    @Test
+    void parseToolProgressEvent() {
+        String line = """
+                {"type":"tool_progress","tool_use_id":"tu-42","tool_name":"Bash","elapsed_time_seconds":5}""";
+
+        List<SseEvent> events = parser.parse(line);
+
+        assertEquals(1, events.size());
+        SseEvent event = events.get(0);
+        assertEquals("tool_progress", event.type());
+        assertEquals("tu-42", event.data().path("toolUseId").asText());
+        assertEquals("Bash", event.data().path("toolName").asText());
+        assertEquals(5, event.data().path("elapsedSeconds").asInt());
+    }
+
+    @Test
+    void parseToolProgressMissingFieldsIsIgnored() {
+        String line = """
+                {"type":"tool_progress","tool_use_id":"tu-42"}""";
+
+        List<SseEvent> events = parser.parse(line);
+        assertTrue(events.isEmpty());
+    }
+
     // ── Unknown types ───────────────────────────────────────────────
 
     @Test

--- a/ui/src/components/assistant/AssistantChatPanel.tsx
+++ b/ui/src/components/assistant/AssistantChatPanel.tsx
@@ -203,6 +203,16 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
                 setIsProcessing(false);
                 break;
 
+            case "tool_progress":
+                setMessages((prev) =>
+                    prev.map((m) =>
+                        m.type === "tool_use" && m.toolUseId === data.toolUseId
+                            ? { ...m, elapsedSeconds: data.elapsedSeconds as number }
+                            : m
+                    )
+                );
+                break;
+
             case "unhandled_event":
                 addMessage({
                     type: "warning",

--- a/ui/src/components/assistant/AssistantMessageList.tsx
+++ b/ui/src/components/assistant/AssistantMessageList.tsx
@@ -19,6 +19,7 @@ export interface ChatMessage {
     permissionId?: string;
     permissionResolved?: boolean;
     permissionAllowed?: boolean;
+    elapsedSeconds?: number;
 }
 
 interface AssistantMessageListProps {
@@ -86,6 +87,7 @@ export function AssistantMessageList({ messages, onPermissionRespond, onCreateAu
                                 input={msg.toolInput}
                                 result={msg.toolResult}
                                 isError={msg.isError}
+                                elapsedSeconds={msg.elapsedSeconds}
                                 permissionId={msg.permissionId}
                                 permissionResolved={msg.permissionResolved}
                                 permissionAllowed={msg.permissionAllowed}

--- a/ui/src/components/assistant/AssistantToolUseBlock.css
+++ b/ui/src/components/assistant/AssistantToolUseBlock.css
@@ -24,6 +24,14 @@
     font-size: 13px;
 }
 
+/* Elapsed time badge */
+.axiom-tool-use__elapsed {
+    margin-left: 8px;
+    font-family: var(--pf-t--global--font--family--mono, monospace);
+    font-size: 11px;
+    color: var(--pf-t--global--text--color--subtle, #6a6e73);
+}
+
 /* Input preview text */
 .axiom-tool-use__input-preview {
     margin-left: 8px;

--- a/ui/src/components/assistant/AssistantToolUseBlock.tsx
+++ b/ui/src/components/assistant/AssistantToolUseBlock.tsx
@@ -42,6 +42,7 @@ interface AssistantToolUseBlockProps {
     input?: Record<string, unknown>;
     result?: string;
     isError?: boolean;
+    elapsedSeconds?: number;
     permissionId?: string;
     permissionResolved?: boolean;
     permissionAllowed?: boolean;
@@ -51,7 +52,7 @@ interface AssistantToolUseBlockProps {
 }
 
 export function AssistantToolUseBlock({
-    toolName, input, result, isError,
+    toolName, input, result, isError, elapsedSeconds,
     permissionId, permissionResolved, permissionAllowed, onPermissionRespond,
     onCreateAutoApproval,
 }: AssistantToolUseBlockProps) {
@@ -84,6 +85,11 @@ export function AssistantToolUseBlock({
                             <Label isCompact color={isError ? "red" : getToolColor(toolName)}>
                                 {toolName}
                             </Label>
+                            {!result && elapsedSeconds != null && (
+                                <span className="axiom-tool-use__elapsed">
+                                    {formatElapsed(elapsedSeconds)}
+                                </span>
+                            )}
                             {inputPreview && (
                                 <span className="axiom-tool-use__input-preview">
                                     {inputPreview}{input && JSON.stringify(input).length > 100 ? "..." : ""}
@@ -422,6 +428,13 @@ function getSuggestedPatterns(toolName: string, input?: Record<string, unknown>)
     }
 
     return suggestions;
+}
+
+function formatElapsed(seconds: number): string {
+    if (seconds < 60) return `${seconds}s`;
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return secs > 0 ? `${mins}m ${secs}s` : `${mins}m`;
 }
 
 function escapeRegex(text: string): string {


### PR DESCRIPTION
## Summary

- Parse Claude Code's `tool_progress` streaming events in `AssistantEventParser` instead of
  falling through to the `unhandled_event` default branch
- Forward the normalised `tool_progress` SSE event to the frontend with `toolUseId`,
  `toolName`, and `elapsedSeconds` fields
- Display a live elapsed-time indicator (e.g. `5s`, `1m 30s`) on the corresponding tool-use
  block header while the tool is executing — the badge disappears once the tool result arrives

Fixes #116

## Test plan

- [x] Build passes (`build.sh` — 282 tests, 0 failures)
- [ ] New unit tests verify correct parsing and missing-field handling
- [ ] Open the AI Assistant, trigger tool use, and confirm:
  - No "Unhandled event type: tool_progress" warning appears
  - Elapsed-time badge appears on the tool block while the tool runs
  - Badge disappears once the tool result arrives