### PR TITLE
fix: defer navigation after session creation (#126)

### DIFF
--- a/ui/src/components/assistant/CreateSessionModal.tsx
+++ b/ui/src/components/assistant/CreateSessionModal.tsx
@@ -92,9 +92,6 @@ export function CreateSessionModal({
         try {
             const session = await createAssistantSession(
                 selectedTemplate.templateId, newName || undefined, projectId);
-            setIsNameModalOpen(false);
-            setNewName("");
-            setSelectedTemplate(null);
             onSessionCreated(session);
         } catch (err: unknown) {
             const e = err as { message?: string };

--- a/ui/src/pages/AssistantPage.tsx
+++ b/ui/src/pages/AssistantPage.tsx
@@ -52,6 +52,7 @@ export function AssistantPage() {
     const [sessions, setSessions] = useState<AssistantSessionInfo[]>([]);
     const [loading, setLoading] = useState(true);
     const [isTemplatePickerOpen, setIsTemplatePickerOpen] = useState(false);
+    const [pendingSessionId, setPendingSessionId] = useState<string | null>(null);
 
     const [filterName, setFilterName] = useState("");
     const [filterTemplateId, setFilterTemplateId] = useState("");
@@ -73,6 +74,12 @@ export function AssistantPage() {
     useEffect(() => {
         load();
     }, [load]);
+
+    useEffect(() => {
+        if (pendingSessionId) {
+            navigate(`/assistant/${pendingSessionId}`);
+        }
+    }, [pendingSessionId, navigate]);
 
     const filteredSessions = sessions.filter((s) => {
         if (filterName && !s.name.toLowerCase().includes(filterName.toLowerCase())) {
@@ -265,7 +272,7 @@ export function AssistantPage() {
                 onClose={() => setIsTemplatePickerOpen(false)}
                 onSessionCreated={(session) => {
                     setIsTemplatePickerOpen(false);
-                    navigate(`/assistant/${session.id}`);
+                    setPendingSessionId(session.id);
                 }}
             />
 


### PR DESCRIPTION
## Summary

Fixes #126 — after creating a new AI Assistant session, the browser failed to navigate to the session page due to a timing conflict between React 19's concurrent rendering and React Router v7's `startTransition` wrapper.

**Root cause:** `CreateSessionModal.handleCreate()` fired multiple urgent state updates (closing modals, resetting form state) in the same synchronous block as the `navigate()` call. React Router v7 wraps navigation in `startTransition`, making it low-priority. React 19 processed the urgent modal-cleanup updates first, triggering PatternFly modal DOM mutations that interrupted the deferred navigation.

**Changes:**

- **`AssistantPage.tsx`** — Defer navigation into a `useEffect` via a `pendingSessionId` state, so it fires in a fresh render cycle after modal cleanup is complete
- **`CreateSessionModal.tsx`** — Remove unnecessary modal state cleanup (`setIsNameModalOpen`, `setNewName`, `setSelectedTemplate`) before calling `onSessionCreated()` — the component unmounts on navigation anyway, and these urgent updates were competing with the deferred navigation transition

## Test plan

- [ ] Navigate to `/assistant`, click **New Session**, pick a template, enter a name, click **Create Session** — confirm browser navigates to `/assistant/{id}`
- [ ] Repeat several times to confirm reliability (original bug was a race condition)
- [ ] Test cancel flow: open template picker, cancel — confirm no navigation occurs
- [ ] Test navigating back to session list after viewing a session