### PR TITLE
Show full JSON payload in unhandled event warnings

### DIFF
--- a/app/src/test/java/io/apitomy/axiom/app/assistant/AssistantEventParserTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/assistant/AssistantEventParserTest.java
@@ -242,6 +242,13 @@ class AssistantEventParserTest {
         assertEquals(1, events.size());
         assertEquals("unhandled_event", events.get(0).type());
         assertEquals("something_else", events.get(0).data().path("rawType").asText());
+
+        String raw = events.get(0).data().path("raw").asText();
+        assertFalse(raw.isEmpty(), "raw field should contain the full JSON payload");
+        assertTrue(raw.contains("\"type\":\"something_else\""),
+                "raw field should contain the original event type");
+        assertTrue(raw.contains("\"data\":\"ignored\""),
+                "raw field should contain the original event data");
     }
 
     // ── Edge cases ──────────────────────────────────────────────────

--- a/ui/src/components/assistant/AssistantChatPanel.tsx
+++ b/ui/src/components/assistant/AssistantChatPanel.tsx
@@ -224,6 +224,7 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
                 addMessage({
                     type: "warning",
                     content: `Unhandled event type: ${data.rawType}`,
+                    rawPayload: data.raw as string,
                 });
                 break;
 

--- a/ui/src/components/assistant/AssistantMessageList.css
+++ b/ui/src/components/assistant/AssistantMessageList.css
@@ -25,6 +25,9 @@
     background-color: var(--axiom--color--warning--bg, #fdf7e7);
     border: 1px solid var(--axiom--color--warning--border, #f0d67b);
     border-radius: 4px;
+}
+
+.axiom-message-list__warning-header {
     display: flex;
     align-items: center;
     gap: 8px;
@@ -32,6 +35,15 @@
 
 .axiom-message-list__warning-icon {
     color: var(--axiom--color--warning--text, #795600);
+    flex-shrink: 0;
+}
+
+.axiom-message-list__warning-payload pre {
+    margin: 0;
+    border-radius: 4px;
+    font-size: 12px;
+    max-height: 250px;
+    overflow: auto;
 }
 
 /* User message */

--- a/ui/src/components/assistant/AssistantMessageList.tsx
+++ b/ui/src/components/assistant/AssistantMessageList.tsx
@@ -1,13 +1,20 @@
 import { useEffect, useRef, useState } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { Button, Content, Spinner, Tooltip } from "@patternfly/react-core";
+import { Button, Content, ExpandableSection, Spinner, Tooltip } from "@patternfly/react-core";
 import CheckCircleIcon from "@patternfly/react-icons/dist/esm/icons/check-circle-icon";
 import CopyIcon from "@patternfly/react-icons/dist/esm/icons/copy-icon";
 import ExclamationTriangleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon";
+import { Light as SyntaxHighlighter } from "react-syntax-highlighter";
+import json from "react-syntax-highlighter/dist/esm/languages/hljs/json";
+import { stackoverflowLight } from "react-syntax-highlighter/dist/esm/styles/hljs";
+import { stackoverflowDark } from "react-syntax-highlighter/dist/esm/styles/hljs";
+import { useEffectiveTheme } from "../../hooks/useTheme";
 import { AssistantToolUseBlock } from "./AssistantToolUseBlock";
 import { AssistantPermissionPrompt } from "./AssistantPermissionPrompt";
 import "./AssistantMessageList.css";
+
+SyntaxHighlighter.registerLanguage("json", json);
 
 export interface ChatMessage {
     id: string;
@@ -22,6 +29,44 @@ export interface ChatMessage {
     permissionResolved?: boolean;
     permissionAllowed?: boolean;
     elapsedSeconds?: number;
+    rawPayload?: string;
+}
+
+function formatPayload(raw: string): string {
+    try {
+        return JSON.stringify(JSON.parse(raw), null, 2);
+    } catch {
+        return raw;
+    }
+}
+
+function WarningBlock({ content, rawPayload }: { content?: string; rawPayload?: string }) {
+    const effectiveTheme = useEffectiveTheme();
+    const syntaxStyle = effectiveTheme === "dark" ? stackoverflowDark : stackoverflowLight;
+    const [isExpanded, setIsExpanded] = useState(false);
+
+    return (
+        <div className="axiom-message-list__warning">
+            <div className="axiom-message-list__warning-header">
+                <ExclamationTriangleIcon className="axiom-message-list__warning-icon" />
+                {content}
+            </div>
+            {rawPayload && (
+                <ExpandableSection
+                    toggleText={isExpanded ? "Hide payload" : "Show payload"}
+                    isExpanded={isExpanded}
+                    onToggle={(_e, expanded) => setIsExpanded(expanded)}
+                    isIndented
+                >
+                    <div className="axiom-message-list__warning-payload">
+                        <SyntaxHighlighter language="json" style={syntaxStyle} wrapLongLines>
+                            {formatPayload(rawPayload)}
+                        </SyntaxHighlighter>
+                    </div>
+                </ExpandableSection>
+            )}
+        </div>
+    );
 }
 
 interface AssistantMessageListProps {
@@ -75,10 +120,11 @@ export function AssistantMessageList({ messages, onPermissionRespond, onCreateAu
 
                     case "warning":
                         return (
-                            <div key={msg.id} className="axiom-message-list__warning">
-                                <ExclamationTriangleIcon className="axiom-message-list__warning-icon" />
-                                {msg.content}
-                            </div>
+                            <WarningBlock
+                                key={msg.id}
+                                content={msg.content}
+                                rawPayload={msg.rawPayload}
+                            />
                         );
 
                     case "user":


### PR DESCRIPTION
## Summary

- Pass the raw JSON payload (`data.raw`) through to the frontend when creating `unhandled_event`
  warning messages in `AssistantChatPanel`
- Add `rawPayload` field to `ChatMessage` interface
- Extract warning rendering into a `WarningBlock` component with a PatternFly `ExpandableSection`
  showing the full pretty-printed JSON with syntax highlighting (collapsed by default, supports
  dark mode)
- Strengthen the existing `parseUnknownTypeReturnsUnhandledEvent` test to verify the `raw` field
  contains the full original JSON payload

## Test plan

- [ ] `mvn install` passes (includes strengthened unhandled event test)
- [ ] Start an assistant session, trigger an event type that isn't handled — confirm the yellow
  warning appears with a "Show payload" toggle
- [ ] Click the toggle — verify the full JSON is displayed with syntax highlighting
- [ ] Toggle dark mode — verify the syntax highlighting theme switches correctly
- [ ] Warnings without a payload (if any) render as before with no toggle