### PR TITLE
Add labels to Event Sources and propagate to auto-created Projects

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/PipelineOrchestrator.java
+++ b/app/src/main/java/io/apitomy/axiom/app/PipelineOrchestrator.java
@@ -7,6 +7,7 @@ import io.apitomy.axiom.core.tracing.TraceService;
 import io.apitomy.axiom.core.entities.ActivityLogEntity;
 import io.apitomy.axiom.core.entities.EventEntity;
 import io.apitomy.axiom.core.entities.EventQueueEntity;
+import io.apitomy.axiom.core.entities.EventSourceEntity;
 import io.apitomy.axiom.core.entities.ProjectEntity;
 import io.apitomy.axiom.core.entities.TaskEntity;
 import io.apitomy.axiom.core.entities.ThreadEntryEntity;
@@ -543,6 +544,12 @@ public class PipelineOrchestrator {
         project.repository = event.repository != null ? event.repository : "unknown";
         project.createdOn = Instant.now();
         project.updatedOn = Instant.now();
+        if (event.eventSourceId != null) {
+            EventSourceEntity eventSource = EventSourceEntity.findById(event.eventSourceId);
+            if (eventSource != null && eventSource.labels != null && !eventSource.labels.isEmpty()) {
+                project.labels.addAll(eventSource.labels);
+            }
+        }
         project.persist();
 
         LOG.infof("Auto-created project %d for issue %s", project.id, event.issueRef);

--- a/app/src/main/java/io/apitomy/axiom/app/rest/EventSourcesResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/EventSourcesResourceImpl.java
@@ -107,6 +107,10 @@ public class EventSourcesResourceImpl implements EventResource {
         } else {
             entity.configuration = "{}";
         }
+        entity.labels.clear();
+        if (data.getLabels() != null) {
+            entity.labels.addAll(data.getLabels());
+        }
     }
 
     /**
@@ -147,6 +151,7 @@ public class EventSourcesResourceImpl implements EventResource {
                 // ignore parse errors
             }
         }
+        bean.setLabels(entity.labels);
         return bean;
     }
 

--- a/app/src/main/resources/db/migration/V32__add_event_source_labels.sql
+++ b/app/src/main/resources/db/migration/V32__add_event_source_labels.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS event_source_label (
+    event_source_id BIGINT NOT NULL,
+    label VARCHAR(255) NOT NULL,
+    UNIQUE (event_source_id, label),
+    FOREIGN KEY (event_source_id) REFERENCES event_source(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_event_source_label ON event_source_label(label, event_source_id);

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -4793,6 +4793,13 @@
             "description": "Source-specific configuration (JSON object)",
             "type": "object",
             "additionalProperties": {}
+          },
+          "labels": {
+            "description": "Free-form labels for categorization",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },
@@ -4831,6 +4838,13 @@
             "description": "Source-specific configuration (JSON object)",
             "type": "object",
             "additionalProperties": {}
+          },
+          "labels": {
+            "description": "Free-form labels for categorization",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },

--- a/core/src/main/java/io/apitomy/axiom/core/entities/EventSourceEntity.java
+++ b/core/src/main/java/io/apitomy/axiom/core/entities/EventSourceEntity.java
@@ -1,11 +1,17 @@
 package io.apitomy.axiom.core.entities;
 
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Table;
 
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A configured event source that Axiom monitors for new events.
@@ -49,4 +55,9 @@ public class EventSourceEntity extends PanacheEntity {
      */
     @Column(nullable = false, columnDefinition = "TEXT")
     public String configuration;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "event_source_label", joinColumns = @JoinColumn(name = "event_source_id"))
+    @Column(name = "label")
+    public List<String> labels = new ArrayList<>();
 }

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -791,6 +791,7 @@ export interface EventSource {
     pollInterval?: number;
     secretName?: string;
     configuration?: Record<string, string>;
+    labels?: string[];
 }
 
 export type NewEventSource = Omit<EventSource, "id">;

--- a/ui/src/pages/EventSourceDetailPage.tsx
+++ b/ui/src/pages/EventSourceDetailPage.tsx
@@ -33,6 +33,8 @@ import {
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import SaveIcon from "@patternfly/react-icons/dist/esm/icons/save-icon";
 import SyncAltIcon from "@patternfly/react-icons/dist/esm/icons/sync-alt-icon";
+import { EditLabelsModal } from "../components/EditLabelsModal";
+import { LabelDisplay } from "../components/LabelDisplay";
 import {
     type EventSource,
     type EventSourceLog,
@@ -59,6 +61,7 @@ export function EventSourceDetailPage() {
     const [saving, setSaving] = useState(false);
     const [dirty, setDirty] = useState(false);
     const [activeTab, setActiveTab] = useState(0);
+    const [isLabelsOpen, setIsLabelsOpen] = useState(false);
 
     const loadData = useCallback(() => {
         if (!id) return;
@@ -157,7 +160,9 @@ export function EventSourceDetailPage() {
                         style={{ marginTop: "24px" }}>
                         <InfoTab form={form} updateForm={updateForm}
                             sourceUrl={sourceUrl} setSourceUrl={(v) => { setSourceUrl(v); setDirty(true); }}
-                            secrets={secrets} />
+                            secrets={secrets}
+                            labels={source.labels || []}
+                            onEditLabels={() => setIsLabelsOpen(true)} />
                     </TabContent>
                 </Tab>
                 <Tab eventKey={1} title={<TabTitleText>
@@ -173,19 +178,34 @@ export function EventSourceDetailPage() {
                     </TabContent>
                 </Tab>
             </Tabs>
+
+            <EditLabelsModal
+                isOpen={isLabelsOpen}
+                labels={source.labels || []}
+                onSave={async (labels) => {
+                    const updated = await updateEventSource(id, { ...source, labels } as EventSource);
+                    setSource(updated);
+                }}
+                onClose={() => setIsLabelsOpen(false)}
+            />
         </PageSection>
     );
 }
 
-function InfoTab({ form, updateForm, sourceUrl, setSourceUrl, secrets }: {
+function InfoTab({ form, updateForm, sourceUrl, setSourceUrl, secrets, labels, onEditLabels }: {
     form: Partial<EventSource>;
     updateForm: (updates: Partial<EventSource>) => void;
     sourceUrl: string;
     setSourceUrl: (v: string) => void;
     secrets: Secret[];
+    labels: string[];
+    onEditLabels: () => void;
 }) {
     return (
         <Form style={{ maxWidth: "600px" }}>
+            <FormGroup label="Labels" fieldId="labels">
+                <LabelDisplay labels={labels} onEdit={onEditLabels} />
+            </FormGroup>
             <FormGroup label="Name" isRequired fieldId="name">
                 <TextInput id="name" isRequired value={form.name || ""}
                     onChange={(_e, v) => updateForm({ name: v })} />

--- a/ui/src/pages/EventSourcesPage.tsx
+++ b/ui/src/pages/EventSourcesPage.tsx
@@ -25,6 +25,8 @@ import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import PlusCircleIcon from "@patternfly/react-icons/dist/esm/icons/plus-circle-icon";
 import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
 import { BooleanStatusIcon } from "../components/BooleanStatusIcon";
+import { ColoredLabel } from "../components/ColoredLabel";
+import { LabelInput } from "../components/LabelInput";
 import {
     type EventSource,
     type NewEventSource,
@@ -94,7 +96,7 @@ export function EventSourcesPage() {
 
     const openCreate = () => {
         setEditing(null);
-        setForm({ name: "", sourceType: "github", enabled: true });
+        setForm({ name: "", sourceType: "github", enabled: true, labels: [] });
         setGhUrl("");
         setJiraUrl("");
         setIsModalOpen(true);
@@ -189,6 +191,7 @@ export function EventSourcesPage() {
                                 <Th>Name</Th>
                                 <Th>Type</Th>
                                 <Th>Source</Th>
+                                <Th>Labels</Th>
                                 <Th>Enabled</Th>
                                 <Th>Poll Interval</Th>
                                 <Th />
@@ -200,6 +203,14 @@ export function EventSourcesPage() {
                                     <Td>{s.name}</Td>
                                     <Td>{s.sourceType}</Td>
                                     <Td><code>{describeSource(s)}</code></Td>
+                                    <Td>
+                                        {s.labels?.map((label) => (
+                                            <ColoredLabel key={label} isCompact
+                                                style={{ marginRight: "4px" }}>
+                                                {label}
+                                            </ColoredLabel>
+                                        ))}
+                                    </Td>
                                     <Td><BooleanStatusIcon value={s.enabled} /></Td>
                                     <Td>{s.pollInterval != null ? `${s.pollInterval}s` : "—"}</Td>
                                     <Td>
@@ -276,6 +287,10 @@ export function EventSourcesPage() {
                                 ))}
                             </FormSelect>
                             <HelperText><HelperTextItem>Select a secret from the Secrets store for API authentication. If not set, falls back to the default provider secret (e.g. GH_TOKEN).</HelperTextItem></HelperText>
+                        </FormGroup>
+                        <FormGroup label="Labels" fieldId="labels">
+                            <LabelInput labels={form.labels || []}
+                                onChange={(labels) => setForm({ ...form, labels })} />
                         </FormGroup>
                     </Form>
                 </ModalBody>


### PR DESCRIPTION
## Summary

- Add `labels` field to `EventSourceEntity` using `@ElementCollection` with a new
  `event_source_label` join table (Flyway V32), following the existing pattern from
  `project_label`, `tool_label`, and `report_label`.
- Update the OpenAPI spec to add `labels` to both `EventSource` and `NewEventSource` schemas.
- Handle labels in `EventSourcesResourceImpl` on create and update.
- Propagate event source labels to newly created projects in
  `PipelineOrchestrator.createProjectFromEvent()`. Labels are only set on initial
  project creation — subsequent events do not overwrite manually modified labels.
- Add labels column to the Event Sources list page using `ColoredLabel`.
- Add `LabelInput` to the create modal form.
- Add `LabelDisplay` + `EditLabelsModal` to the Event Source detail page.

Fixes #118