### PR TITLE
Event Source label UI improvements and labels on Events page

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/rest/EventsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/EventsResourceImpl.java
@@ -7,6 +7,7 @@ import io.apitomy.axiom.api.beans.NewEvent;
 import io.apitomy.axiom.api.beans.Trace;
 import io.apitomy.axiom.core.entities.TraceEntity;
 import io.apitomy.axiom.core.entities.EventEntity;
+import io.apitomy.axiom.core.entities.EventSourceEntity;
 import io.apitomy.axiom.events.core.EventService;
 import io.quarkus.panache.common.Page;
 import io.quarkus.panache.common.Sort;
@@ -16,10 +17,13 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.WebApplicationException;
 
 import java.math.BigInteger;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Implementation of the Events REST API. Provides paginated, filterable
@@ -59,12 +63,14 @@ public class EventsResourceImpl implements EventsResource {
         }
 
         long totalCount = EventEntity.count(hql.toString(), params);
-        List<Event> items = EventEntity.<EventEntity>find(
+        List<EventEntity> entities = EventEntity.<EventEntity>find(
                         hql.toString(), Sort.descending("receivedAt"), params)
                 .page(Page.of(pageNum - 1, pageSize))
-                .list()
-                .stream()
-                .map(this::toBean)
+                .list();
+
+        Map<Long, List<String>> labelsMap = loadEventSourceLabels(entities);
+        List<Event> items = entities.stream()
+                .map(e -> toBean(e, labelsMap.getOrDefault(e.eventSourceId, Collections.emptyList())))
                 .toList();
 
         EventSearchResults results = new EventSearchResults();
@@ -84,7 +90,8 @@ public class EventsResourceImpl implements EventsResource {
         if (entity == null) {
             throw new WebApplicationException("Event not found: " + eventId, 404);
         }
-        return toBean(entity);
+        List<String> labels = lookupEventSourceLabels(entity.eventSourceId);
+        return toBean(entity, labels);
     }
 
     /**
@@ -98,7 +105,8 @@ public class EventsResourceImpl implements EventsResource {
                 data.getIssueRef(),
                 data.getRepository(),
                 data.getPayload());
-        return toBean(entity);
+        List<String> labels = lookupEventSourceLabels(entity.eventSourceId);
+        return toBean(entity, labels);
     }
 
     /**
@@ -113,7 +121,34 @@ public class EventsResourceImpl implements EventsResource {
                 .toList();
     }
 
-    private Event toBean(EventEntity entity) {
+    /**
+     * Batch-loads Event Source labels for a list of event entities.
+     */
+    private Map<Long, List<String>> loadEventSourceLabels(List<EventEntity> entities) {
+        Set<Long> sourceIds = entities.stream()
+                .map(e -> e.eventSourceId)
+                .filter(id -> id != null)
+                .collect(Collectors.toSet());
+        if (sourceIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        return EventSourceEntity.<EventSourceEntity>list("id in ?1", List.copyOf(sourceIds))
+                .stream()
+                .collect(Collectors.toMap(es -> es.id, es -> es.labels));
+    }
+
+    /**
+     * Looks up labels for a single Event Source by ID.
+     */
+    private List<String> lookupEventSourceLabels(Long eventSourceId) {
+        if (eventSourceId == null) {
+            return Collections.emptyList();
+        }
+        EventSourceEntity source = EventSourceEntity.findById(eventSourceId);
+        return source != null ? source.labels : Collections.emptyList();
+    }
+
+    private Event toBean(EventEntity entity, List<String> labels) {
         Event event = new Event();
         event.setId(entity.id);
         event.setEventSourceId(entity.eventSourceId);
@@ -125,6 +160,7 @@ public class EventsResourceImpl implements EventsResource {
         event.setTaskId(entity.taskId);
         event.setPayload(entity.payload);
         event.setReceivedAt(Date.from(entity.receivedAt));
+        event.setLabels(labels);
         if (entity.traceId != null) {
             event.setTraceId(entity.traceId);
         }

--- a/app/src/main/java/io/apitomy/axiom/app/rest/ProjectsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/ProjectsResourceImpl.java
@@ -18,6 +18,7 @@ import io.apitomy.axiom.api.beans.UpdateProject;
 import io.apitomy.axiom.core.entities.ActivityLogEntity;
 import io.apitomy.axiom.core.entities.AiUsageEntity;
 import io.apitomy.axiom.core.entities.EventEntity;
+import io.apitomy.axiom.core.entities.EventSourceEntity;
 import io.apitomy.axiom.core.entities.ProjectEntity;
 import io.apitomy.axiom.core.entities.TaskEntity;
 import io.apitomy.axiom.core.entities.TraceNodeEntity;
@@ -41,10 +42,13 @@ import java.math.BigInteger;
 
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Implementation of the Projects REST API (includes tasks and threads).
@@ -362,9 +366,10 @@ public class ProjectsResourceImpl implements ProjectsResource {
     @Override
     public List<Event> listProjectEvents(long projectId) {
         ProjectEntity project = findProjectOrThrow(projectId);
-        return EventEntity.<EventEntity>list("issueRef", project.issueRef)
-                .stream()
-                .map(this::toEventBean)
+        List<EventEntity> entities = EventEntity.list("issueRef", project.issueRef);
+        Map<Long, List<String>> labelsMap = loadEventSourceLabels(entities);
+        return entities.stream()
+                .map(e -> toEventBean(e, labelsMap.getOrDefault(e.eventSourceId, Collections.emptyList())))
                 .toList();
     }
 
@@ -542,7 +547,23 @@ public class ProjectsResourceImpl implements ProjectsResource {
         return entry;
     }
 
-    private Event toEventBean(EventEntity entity) {
+    /**
+     * Batch-loads Event Source labels for a list of event entities.
+     */
+    private Map<Long, List<String>> loadEventSourceLabels(List<EventEntity> entities) {
+        Set<Long> sourceIds = entities.stream()
+                .map(e -> e.eventSourceId)
+                .filter(id -> id != null)
+                .collect(Collectors.toSet());
+        if (sourceIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        return EventSourceEntity.<EventSourceEntity>list("id in ?1", List.copyOf(sourceIds))
+                .stream()
+                .collect(Collectors.toMap(es -> es.id, es -> es.labels));
+    }
+
+    private Event toEventBean(EventEntity entity, List<String> labels) {
         Event event = new Event();
         event.setId(entity.id);
         event.setSource(entity.source);
@@ -552,6 +573,7 @@ public class ProjectsResourceImpl implements ProjectsResource {
         event.setProjectId(entity.projectId);
         event.setTaskId(entity.taskId);
         event.setReceivedAt(Date.from(entity.receivedAt));
+        event.setLabels(labels);
         if (entity.traceId != null) {
             event.setTraceId(entity.traceId);
         }

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -4896,6 +4896,13 @@
           "traceId": {
             "format": "uuid",
             "type": "string"
+          },
+          "labels": {
+            "description": "Labels inherited from the Event Source",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -1134,6 +1134,7 @@ export interface AxiomEvent {
     payload?: string;
     receivedAt: string;
     traceId?: string;
+    labels?: string[];
 }
 
 export async function fetchEvent(id: number): Promise<AxiomEvent> {

--- a/ui/src/pages/EventSourceDetailPage.tsx
+++ b/ui/src/pages/EventSourceDetailPage.tsx
@@ -77,6 +77,7 @@ export function EventSourceDetailPage() {
                     pollInterval: src.pollInterval,
                     secretName: src.secretName,
                     configuration: src.configuration,
+                    labels: src.labels || [],
                 });
                 setSourceUrl(buildUrlFromConfig(src));
                 setSecrets(secs);
@@ -161,7 +162,7 @@ export function EventSourceDetailPage() {
                         <InfoTab form={form} updateForm={updateForm}
                             sourceUrl={sourceUrl} setSourceUrl={(v) => { setSourceUrl(v); setDirty(true); }}
                             secrets={secrets}
-                            labels={source.labels || []}
+                            labels={form.labels || []}
                             onEditLabels={() => setIsLabelsOpen(true)} />
                     </TabContent>
                 </Tab>
@@ -181,10 +182,9 @@ export function EventSourceDetailPage() {
 
             <EditLabelsModal
                 isOpen={isLabelsOpen}
-                labels={source.labels || []}
+                labels={form.labels || []}
                 onSave={async (labels) => {
-                    const updated = await updateEventSource(id, { ...source, labels } as EventSource);
-                    setSource(updated);
+                    updateForm({ labels });
                 }}
                 onClose={() => setIsLabelsOpen(false)}
             />
@@ -203,12 +203,12 @@ function InfoTab({ form, updateForm, sourceUrl, setSourceUrl, secrets, labels, o
 }) {
     return (
         <Form style={{ maxWidth: "600px" }}>
-            <FormGroup label="Labels" fieldId="labels">
-                <LabelDisplay labels={labels} onEdit={onEditLabels} />
-            </FormGroup>
             <FormGroup label="Name" isRequired fieldId="name">
                 <TextInput id="name" isRequired value={form.name || ""}
                     onChange={(_e, v) => updateForm({ name: v })} />
+            </FormGroup>
+            <FormGroup label="Labels" fieldId="labels">
+                <LabelDisplay labels={labels} onEdit={onEditLabels} />
             </FormGroup>
             <FormGroup label="Source Type" fieldId="sourceType">
                 <TextInput id="sourceType" value={form.sourceType || ""} isDisabled />

--- a/ui/src/pages/EventSourcesPage.tsx
+++ b/ui/src/pages/EventSourcesPage.tsx
@@ -277,6 +277,10 @@ export function EventSourcesPage() {
                                 onChange={(_e, v) => setForm({ ...form, pollInterval: v ? parseInt(v) : undefined })}
                                 placeholder="60" />
                         </FormGroup>
+                        <FormGroup label="Labels" fieldId="labels">
+                            <LabelInput labels={form.labels || []}
+                                onChange={(labels) => setForm({ ...form, labels })} />
+                        </FormGroup>
                         <FormGroup label="Authentication Secret" fieldId="secretName">
                             <FormSelect id="secretName"
                                 value={form.secretName || ""}
@@ -287,10 +291,6 @@ export function EventSourcesPage() {
                                 ))}
                             </FormSelect>
                             <HelperText><HelperTextItem>Select a secret from the Secrets store for API authentication. If not set, falls back to the default provider secret (e.g. GH_TOKEN).</HelperTextItem></HelperText>
-                        </FormGroup>
-                        <FormGroup label="Labels" fieldId="labels">
-                            <LabelInput labels={form.labels || []}
-                                onChange={(labels) => setForm({ ...form, labels })} />
                         </FormGroup>
                     </Form>
                 </ModalBody>

--- a/ui/src/pages/EventsPage.tsx
+++ b/ui/src/pages/EventsPage.tsx
@@ -156,6 +156,7 @@ export function EventsPage() {
                                 <Th>#</Th>
                                 <Th>Time</Th>
                                 <Th>Source</Th>
+                                <Th>Labels</Th>
                                 <Th>Event Type</Th>
                                 <Th>Repository</Th>
                                 <Th>Issue</Th>
@@ -182,6 +183,16 @@ export function EventsPage() {
                                             }}>
                                             {event.source}
                                         </Label>
+                                    </Td>
+                                    <Td>
+                                        {event.labels && event.labels.length > 0
+                                            ? event.labels.map((lbl) => (
+                                                <Label key={lbl} isCompact color="gold"
+                                                    style={{ marginRight: "4px" }}>
+                                                    {lbl}
+                                                </Label>
+                                            ))
+                                            : "—"}
                                     </Td>
                                     <Td>{event.eventType}</Td>
                                     <Td>{event.repository || "—"}</Td>

--- a/ui/src/pages/EventsPage.tsx
+++ b/ui/src/pages/EventsPage.tsx
@@ -187,7 +187,7 @@ export function EventsPage() {
                                     <Td>
                                         {event.labels && event.labels.length > 0
                                             ? event.labels.map((lbl) => (
-                                                <Label key={lbl} isCompact color="gold"
+                                                <Label key={lbl} isCompact color="yellow"
                                                     style={{ marginRight: "4px" }}>
                                                     {lbl}
                                                 </Label>


### PR DESCRIPTION
## Summary

- **Event Source detail page**: Move Labels field below Name, and change the Edit Labels
  modal to update local form state (dirty flag) instead of saving to the server immediately.
  Labels are now persisted only when the user clicks "Save Changes", consistent with all
  other fields.
- **Event Source create modal**: Move Labels field to appear right after Name instead of at
  the bottom.
- **Events log page**: Add a Labels column showing gold-colored label chips inherited from
  the Event Source. Backend batch-loads Event Source labels to avoid N+1 queries.
- **OpenAPI spec**: Add `labels` array property to the `Event` schema.

## Test plan

- [ ] Edit labels on an Event Source detail page — verify changes are not saved until
      clicking "Save Changes"
- [ ] Create a new Event Source — verify Labels field appears after Name
- [ ] View the Events log page — verify labels column shows chips from the Event Source
- [ ] Verify events without an Event Source show "—" in the Labels column