### PR TITLE
Add label-based filtering to the Events page

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/rest/EventsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/EventsResourceImpl.java
@@ -17,6 +17,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.WebApplicationException;
 
 import java.math.BigInteger;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -42,7 +43,7 @@ public class EventsResourceImpl implements EventsResource {
     @Override
     public EventSearchResults listEvents(BigInteger page, BigInteger limit,
                                           String filterSource, String filterEventType,
-                                          String filterRepository) {
+                                          String filterRepository, String filterLabels) {
         int pageNum = page != null ? page.intValue() : 1;
         int pageSize = limit != null ? limit.intValue() : 20;
 
@@ -60,6 +61,15 @@ public class EventsResourceImpl implements EventsResource {
         if (filterRepository != null && !filterRepository.isBlank()) {
             hql.append(" and lower(repository) like :repository");
             params.put("repository", "%" + filterRepository.toLowerCase() + "%");
+        }
+        if (filterLabels != null && !filterLabels.isBlank()) {
+            List<String> labels = Arrays.stream(filterLabels.split(","))
+                    .map(String::trim).filter(s -> !s.isEmpty()).toList();
+            hql.append(" and eventSourceId in (SELECT es.id FROM EventSourceEntity es"
+                    + " JOIN es.labels esl WHERE esl IN :labels"
+                    + " GROUP BY es.id HAVING COUNT(DISTINCT esl) = :labelCount)");
+            params.put("labels", labels);
+            params.put("labelCount", (long) labels.size());
         }
 
         long totalCount = EventEntity.count(hql.toString(), params);

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -1679,6 +1679,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "filterLabels",
+            "in": "query",
+            "description": "Filter by labels (comma-separated, AND logic)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -1151,7 +1151,8 @@ export async function fetchProjectEvents(projectId: number): Promise<AxiomEvent[
 
 export async function fetchEvents(
     page = 1, limit = 20,
-    filterSource?: string, filterEventType?: string, filterRepository?: string
+    filterSource?: string, filterEventType?: string, filterRepository?: string,
+    filterLabels?: string
 ): Promise<SearchResults<AxiomEvent>> {
     const params = new URLSearchParams();
     params.set("page", String(page));
@@ -1159,6 +1160,7 @@ export async function fetchEvents(
     if (filterSource) params.set("filterSource", filterSource);
     if (filterEventType) params.set("filterEventType", filterEventType);
     if (filterRepository) params.set("filterRepository", filterRepository);
+    if (filterLabels) params.set("filterLabels", filterLabels);
     const response = await fetch(`${API}/events?${params}`);
     if (!response.ok) throw new Error(`Failed to fetch events: ${response.status}`);
     return response.json();

--- a/ui/src/pages/EventsPage.tsx
+++ b/ui/src/pages/EventsPage.tsx
@@ -12,6 +12,7 @@ import {
     ToolbarContent,
     ToolbarItem,
 } from "@patternfly/react-core";
+import { ColoredLabel } from "../components/ColoredLabel";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import SyncAltIcon from "@patternfly/react-icons/dist/esm/icons/sync-alt-icon";
 import {
@@ -33,6 +34,7 @@ const FILTER_TYPES: ChipFilterType[] = [
     { value: "source", label: "Source", testId: "event-filter-source" },
     { value: "eventType", label: "Event Type", testId: "event-filter-eventType" },
     { value: "repository", label: "Repository", testId: "event-filter-repository" },
+    { value: "labels", label: "Labels", testId: "event-filter-labels" },
 ];
 
 export function EventsPage() {
@@ -51,6 +53,10 @@ export function EventsPage() {
     const filterSource = filters.find((f) => f.filterBy.value === "source")?.filterValue;
     const filterEventType = filters.find((f) => f.filterBy.value === "eventType")?.filterValue;
     const filterRepository = filters.find((f) => f.filterBy.value === "repository")?.filterValue;
+    const filterLabels = filters
+        .filter((f) => f.filterBy.value === "labels")
+        .map((f) => f.filterValue)
+        .join(",");
     const isFiltered = filters.length > 0;
 
     const loadData = useCallback(() => {
@@ -59,7 +65,8 @@ export function EventsPage() {
             page, perPage,
             filterSource || undefined,
             filterEventType || undefined,
-            filterRepository || undefined
+            filterRepository || undefined,
+            filterLabels || undefined
         )
             .then((results) => {
                 setEvents(results.items);
@@ -67,19 +74,32 @@ export function EventsPage() {
             })
             .catch(console.error)
             .finally(() => setLoading(false));
-    }, [page, perPage, filterSource, filterEventType, filterRepository]);
+    }, [page, perPage, filterSource, filterEventType, filterRepository, filterLabels]);
 
     useEffect(() => { loadData(); }, [loadData]);
 
     const onAddFilterCriteria = (criteria: ChipFilterCriteria) => {
         if (!criteria.filterValue) return;
-        const updated = filters.filter((f) =>
+        const deduplicated = filters.filter((f) =>
             !(f.filterBy.value === criteria.filterBy.value && f.filterValue === criteria.filterValue));
-        // All filter types on this page are single-value
-        const withoutSame = updated.filter((f) => f.filterBy.value !== criteria.filterBy.value);
-        withoutSame.push(criteria);
-        setFilters(withoutSame);
+        if (criteria.filterBy.value === "labels") {
+            deduplicated.push(criteria);
+            setFilters(deduplicated);
+        } else {
+            const withoutSame = deduplicated.filter((f) => f.filterBy.value !== criteria.filterBy.value);
+            withoutSame.push(criteria);
+            setFilters(withoutSame);
+        }
         setPage(1);
+    };
+
+    const addLabelFilter = (label: string) => {
+        const already = filters.some((f) => f.filterBy.value === "labels" && f.filterValue === label);
+        if (!already) {
+            const labelType = FILTER_TYPES.find((t) => t.value === "labels")!;
+            setFilters([...filters, { filterBy: labelType, filterValue: label }]);
+            setPage(1);
+        }
     };
 
     const onRemoveFilterCriteria = (criteria: ChipFilterCriteria) => {
@@ -187,10 +207,14 @@ export function EventsPage() {
                                     <Td>
                                         {event.labels && event.labels.length > 0
                                             ? event.labels.map((lbl) => (
-                                                <Label key={lbl} isCompact color="yellow"
-                                                    style={{ marginRight: "4px" }}>
+                                                <ColoredLabel key={lbl} isCompact
+                                                    style={{ marginRight: "4px", cursor: "pointer" }}
+                                                    onClick={(e) => {
+                                                        e.stopPropagation();
+                                                        addLabelFilter(lbl);
+                                                    }}>
                                                     {lbl}
-                                                </Label>
+                                                </ColoredLabel>
                                             ))
                                             : "—"}
                                     </Td>


### PR DESCRIPTION
## Summary

- Adds a `filterLabels` query parameter to `GET /events` in the OpenAPI spec, matching the existing pattern used by `/projects`, `/reports`, and `/tools`
- Implements backend label filtering in `EventsResourceImpl` via an HQL subquery through `EventSourceEntity` (since events inherit labels from their event source)
- Wires `filterLabels` into the frontend `fetchEvents()` API client
- Adds label filtering UI to the Events page: labels in the filter dropdown, clickable `ColoredLabel` components in the table, and multi-value chip support (AND logic)

## Test plan

- [ ] Run `mvn install` to regenerate JAX-RS interfaces with the new `filterLabels` parameter
- [ ] Verify the app compiles and starts
- [ ] Navigate to `/logs/events` and confirm labels display with deterministic colors
- [ ] Click a label in the table and verify it adds a filter chip and filters results
- [ ] Add multiple label filters and verify AND logic (only events matching all labels shown)
- [ ] Remove label filter chips individually and verify results update
- [ ] Use the filter dropdown to type and add a label filter manually
- [ ] Verify existing source/eventType/repository filters still work correctly alongside label filters