### PR TITLE
Remove duplicate Max Steps and Max Budget fields

### DIFF
--- a/ui/src/pages/ActionTypeDetailPage.tsx
+++ b/ui/src/pages/ActionTypeDetailPage.tsx
@@ -467,34 +467,6 @@ function InfoTab({ form, updateForm, availableModels, availableEngines }: {
                     </FormSelect>
                 </FormGroup>
             )}
-            {form.executionMode === "actor" && (
-                <FormGroup label="Max Steps" fieldId="maxSteps">
-                    <HelperText>
-                        <HelperTextItem>Maximum number of agent steps/turns. Leave empty to use the global default.</HelperTextItem>
-                    </HelperText>
-                    <TextInput
-                        id="maxSteps"
-                        type="number"
-                        value={form.maxSteps ?? ""}
-                        onChange={(_e, v) => updateForm({ maxSteps: v === "" ? undefined : Number(v) })}
-                        placeholder="Global default"
-                    />
-                </FormGroup>
-            )}
-            {form.executionMode === "actor" && (
-                <FormGroup label="Max Budget (USD)" fieldId="maxBudgetUsd">
-                    <HelperText>
-                        <HelperTextItem>Maximum budget in USD for this action type. Leave empty to use the global default.</HelperTextItem>
-                    </HelperText>
-                    <TextInput
-                        id="maxBudgetUsd"
-                        type="number"
-                        value={form.maxBudgetUsd ?? ""}
-                        onChange={(_e, v) => updateForm({ maxBudgetUsd: v === "" ? undefined : Number(v) })}
-                        placeholder="Global default"
-                    />
-                </FormGroup>
-            )}
             <FormGroup fieldId="flags">
                 <Checkbox
                     id="userTriggerable"


### PR DESCRIPTION
## Summary\n\nFixes #142 — the Max Steps and Max Budget (USD) form fields were rendered twice on the Action Type detail page (Info tab) when execution mode was set to "actor". Removed the duplicate block that appeared after the Model field.\n\n## Test Plan\n\n- Open the Action Type detail page with execution mode set to "actor"\n- Confirm Max Steps and Max Budget (USD) each appear exactly once\n- Confirm the fields still accept input and clear to global default