### PR TITLE
Fix AskUserQuestion radio buttons conflicting across multiple blocks

### DIFF
--- a/ui/src/components/assistant/AssistantAskUserQuestion.tsx
+++ b/ui/src/components/assistant/AssistantAskUserQuestion.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useId, useState } from "react";
 import {
     Button,
     ExpandableSection,
@@ -35,6 +35,7 @@ export function AssistantAskUserQuestion({
     onRespond,
     resolved,
 }: AssistantAskUserQuestionProps) {
+    const blockId = useId();
     const [answers, setAnswers] = useState<Record<number, string | string[]>>({});
     const [otherText, setOtherText] = useState<Record<number, string>>({});
     const [isExpanded, setIsExpanded] = useState(!resolved);
@@ -148,7 +149,7 @@ export function AssistantAskUserQuestion({
                                     return (
                                         <div key={opt.label}>
                                             <Checkbox
-                                                id={`q${qIdx}-${opt.label}`}
+                                                id={`${blockId}-q${qIdx}-${opt.label}`}
                                                 label={
                                                     <span>
                                                         {opt.label}
@@ -179,8 +180,8 @@ export function AssistantAskUserQuestion({
                                 return (
                                     <div key={opt.label}>
                                         <Radio
-                                            id={`q${qIdx}-${opt.label}`}
-                                            name={`question-${qIdx}`}
+                                            id={`${blockId}-q${qIdx}-${opt.label}`}
+                                            name={`${blockId}-question-${qIdx}`}
                                             label={
                                                 <span>
                                                     {opt.label}


### PR DESCRIPTION
## Summary

When multiple `AskUserQuestion` blocks appear in the same conversation, their radio button inputs conflict because they share the same `name` and `id` attributes (scoped only to question index, not to the block instance). Selecting an option in one block would deselect the option in another block.

## Changes

Uses React's `useId()` hook to generate a unique prefix per `AssistantAskUserQuestion` component instance, and incorporates it into:

- **Radio `name`** attributes — prevents radio groups from different blocks from being treated as one group
- **Radio `id`** attributes — prevents DOM ID collisions
- **Checkbox `id`** attributes — prevents DOM ID collisions for multi-select questions

## Files Modified

- `ui/src/components/assistant/AssistantAskUserQuestion.tsx`

Fixes #140