### PR TITLE
Add AI Assistant Session Templates to Configuration Packs

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/ImportExportService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ImportExportService.java
@@ -96,6 +96,14 @@ public class ImportExportService {
             }
         }
 
+        if (request.getSessionTemplateIds() != null && !request.getSessionTemplateIds().isEmpty()) {
+            ArrayNode arr = pack.putArray("sessionTemplates");
+            for (String templateId : request.getSessionTemplateIds()) {
+                SessionTemplateEntity entity = SessionTemplateEntity.find("templateId", templateId).firstResult();
+                if (entity != null) arr.add(serializeSessionTemplate(entity));
+            }
+        }
+
         LOG.infof("Exported configuration pack '%s'", request.getName());
         return pack;
     }
@@ -116,6 +124,7 @@ public class ImportExportService {
         checkConflicts(pack, "mcpServers", "name", "mcpServer", conflicts);
         checkConflicts(pack, "actionTypes", "name", "actionType", conflicts);
         checkConflicts(pack, "reportDefinitions", "name", "reportDefinition", conflicts);
+        checkConflicts(pack, "sessionTemplates", "templateId", "sessionTemplate", conflicts);
 
         if (!conflicts.isEmpty()) {
             ObjectNode error = objectMapper.createObjectNode();
@@ -135,11 +144,13 @@ public class ImportExportService {
         int mcpServers = importMcpServers(pack.path("mcpServers"));
         int actionTypes = importActionTypes(pack.path("actionTypes"));
         int reportDefinitions = importReportDefinitions(pack.path("reportDefinitions"));
+        int sessionTemplates = importSessionTemplates(pack.path("sessionTemplates"));
 
         String packName = pack.path("metadata").path("name").asText("unnamed");
         LOG.infof("Imported configuration pack '%s': %d tools, %d toolsets, %d MCP servers, "
-                        + "%d action types, %d report definitions",
-                packName, tools, toolsets, mcpServers, actionTypes, reportDefinitions);
+                        + "%d action types, %d report definitions, %d session templates",
+                packName, tools, toolsets, mcpServers, actionTypes, reportDefinitions,
+                sessionTemplates);
 
         ImportResult result = new ImportResult();
         result.setTools(tools);
@@ -147,6 +158,7 @@ public class ImportExportService {
         result.setMcpServers(mcpServers);
         result.setActionTypes(actionTypes);
         result.setReportDefinitions(reportDefinitions);
+        result.setSessionTemplates(sessionTemplates);
         return result;
     }
 
@@ -214,6 +226,7 @@ public class ImportExportService {
                 case "mcpServer" -> McpServerEntity.count("name", name) > 0;
                 case "actionType" -> ActionTypeEntity.count("name", name) > 0;
                 case "reportDefinition" -> ReportDefinitionEntity.count("name", name) > 0;
+                case "sessionTemplate" -> SessionTemplateEntity.count("templateId", name) > 0;
                 default -> false;
             };
             if (exists) {
@@ -321,6 +334,47 @@ public class ImportExportService {
             entity.enabled = false;
             entity.createdOn = Instant.now();
             entity.updatedOn = Instant.now();
+            entity.persist();
+            count++;
+        }
+        return count;
+    }
+
+    private int importSessionTemplates(JsonNode items) {
+        if (!items.isArray()) return 0;
+        int count = 0;
+        for (JsonNode item : items) {
+            String templateId = item.path("templateId").asText(null);
+            if (templateId == null || templateId.isBlank()) {
+                templateId = java.util.UUID.randomUUID().toString();
+            }
+            if (sessionTemplateService.isBuiltIn(templateId)) {
+                LOG.warnf("Skipping built-in session template '%s' — cannot be imported", templateId);
+                continue;
+            }
+            SessionTemplateEntity entity = new SessionTemplateEntity();
+            entity.templateId = templateId;
+            entity.name = item.path("name").asText("");
+            entity.description = textOrNull(item, "description");
+            entity.systemPrompt = textOrNull(item, "systemPrompt");
+            entity.welcomeMessage = textOrNull(item, "welcomeMessage");
+            entity.workingDirectory = textOrNull(item, "workingDirectory");
+            entity.model = textOrNull(item, "model");
+            entity.initScript = textOrNull(item, "initScript");
+            entity.initScriptType = textOrNull(item, "initScriptType");
+            entity.environment = jsonOrNull(item, "environment");
+            JsonNode mcpNode = item.path("mcpServers");
+            if (mcpNode.isArray()) {
+                for (JsonNode s : mcpNode) {
+                    entity.mcpServers.add(s.asText());
+                }
+            }
+            JsonNode toolsNode = item.path("allowedTools");
+            if (toolsNode.isArray()) {
+                for (JsonNode t : toolsNode) {
+                    entity.allowedTools.add(t.asText());
+                }
+            }
             entity.persist();
             count++;
         }
@@ -559,6 +613,29 @@ public class ImportExportService {
         putIfNotNull(n, "allowedTools", e.allowedTools);
         putIfNotNull(n, "environment", e.environment);
         if (e.timeoutSeconds != null) n.put("timeoutSeconds", e.timeoutSeconds);
+        return n;
+    }
+
+    private ObjectNode serializeSessionTemplate(SessionTemplateEntity e) {
+        ObjectNode n = objectMapper.createObjectNode();
+        n.put("templateId", e.templateId);
+        n.put("name", e.name);
+        putIfNotNull(n, "description", e.description);
+        putIfNotNull(n, "systemPrompt", e.systemPrompt);
+        putIfNotNull(n, "welcomeMessage", e.welcomeMessage);
+        putIfNotNull(n, "workingDirectory", e.workingDirectory);
+        putIfNotNull(n, "model", e.model);
+        putIfNotNull(n, "initScript", e.initScript);
+        putIfNotNull(n, "initScriptType", e.initScriptType);
+        putIfNotNull(n, "environment", e.environment);
+        if (e.mcpServers != null && !e.mcpServers.isEmpty()) {
+            ArrayNode arr = n.putArray("mcpServers");
+            e.mcpServers.forEach(arr::add);
+        }
+        if (e.allowedTools != null && !e.allowedTools.isEmpty()) {
+            ArrayNode arr = n.putArray("allowedTools");
+            e.allowedTools.forEach(arr::add);
+        }
         return n;
     }
 

--- a/app/src/main/java/io/apitomy/axiom/app/ImportExportService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ImportExportService.java
@@ -363,6 +363,7 @@ public class ImportExportService {
             entity.initScript = textOrNull(item, "initScript");
             entity.initScriptType = textOrNull(item, "initScriptType");
             entity.environment = jsonOrNull(item, "environment");
+            entity.initialMessage = textOrNull(item, "initialMessage");
             JsonNode mcpNode = item.path("mcpServers");
             if (mcpNode.isArray()) {
                 for (JsonNode s : mcpNode) {
@@ -528,6 +529,7 @@ public class ImportExportService {
             entity.initScript = textOrNull(item, "initScript");
             entity.initScriptType = textOrNull(item, "initScriptType");
             entity.environment = jsonOrNull(item, "environment");
+            entity.initialMessage = textOrNull(item, "initialMessage");
             JsonNode mcpNode = item.path("mcpServers");
             if (mcpNode.isArray()) {
                 for (JsonNode s : mcpNode) {
@@ -628,6 +630,7 @@ public class ImportExportService {
         putIfNotNull(n, "initScript", e.initScript);
         putIfNotNull(n, "initScriptType", e.initScriptType);
         putIfNotNull(n, "environment", e.environment);
+        putIfNotNull(n, "initialMessage", e.initialMessage);
         if (e.mcpServers != null && !e.mcpServers.isEmpty()) {
             ArrayNode arr = n.putArray("mcpServers");
             e.mcpServers.forEach(arr::add);

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -6073,6 +6073,13 @@
               "format": "int64",
               "type": "integer"
             }
+          },
+          "sessionTemplateIds": {
+            "description": "Template IDs of session templates to include",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },
@@ -6092,6 +6099,9 @@
             "type": "integer"
           },
           "reportDefinitions": {
+            "type": "integer"
+          },
+          "sessionTemplates": {
             "type": "integer"
           }
         }

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -128,6 +128,7 @@ export interface PackExportRequest {
     toolsetIds?: number[];
     mcpServerIds?: number[];
     reportDefinitionIds?: number[];
+    sessionTemplateIds?: string[];
 }
 
 export interface ImportResult {
@@ -136,6 +137,7 @@ export interface ImportResult {
     toolsets?: number;
     mcpServers?: number;
     reportDefinitions?: number;
+    sessionTemplates?: number;
 }
 
 export interface AssistantApplyResult {

--- a/ui/src/pages/ConfigurationPacksPage.tsx
+++ b/ui/src/pages/ConfigurationPacksPage.tsx
@@ -37,6 +37,7 @@ import {
     type Toolset,
     type McpServer,
     type ReportDefinition,
+    type SessionTemplate,
     type PackExportRequest,
     type ImportResult,
     fetchActionTypes,
@@ -44,6 +45,7 @@ import {
     fetchToolsets,
     fetchMcpServers,
     fetchReportDefinitions,
+    fetchAssistantTemplates,
     exportPack,
     importPack,
 } from "../config/api";
@@ -54,6 +56,7 @@ export function ConfigurationPacksPage() {
     const [toolsets, setToolsets] = useState<Toolset[]>([]);
     const [mcpServers, setMcpServers] = useState<McpServer[]>([]);
     const [reportDefs, setReportDefs] = useState<ReportDefinition[]>([]);
+    const [sessionTemplates, setSessionTemplates] = useState<SessionTemplate[]>([]);
     const [loading, setLoading] = useState(true);
     const [activeTab, setActiveTab] = useState(0);
 
@@ -65,6 +68,7 @@ export function ConfigurationPacksPage() {
     const [selectedToolsets, setSelectedToolsets] = useState<Set<number>>(new Set());
     const [selectedMcpServers, setSelectedMcpServers] = useState<Set<number>>(new Set());
     const [selectedReportDefs, setSelectedReportDefs] = useState<Set<number>>(new Set());
+    const [selectedSessionTemplates, setSelectedSessionTemplates] = useState<Set<string>>(new Set());
     const [exporting, setExporting] = useState(false);
 
     // Import state
@@ -85,13 +89,15 @@ export function ConfigurationPacksPage() {
             fetchToolsets(),
             fetchMcpServers(),
             fetchReportDefinitions(),
+            fetchAssistantTemplates(),
         ])
-            .then(([at, t, ts, mcp, rd]) => {
+            .then(([at, t, ts, mcp, rd, st]) => {
                 setActionTypes(at);
                 setTools(t.items);
                 setToolsets(ts);
                 setMcpServers(mcp);
                 setReportDefs(rd);
+                setSessionTemplates(st.filter((s: SessionTemplate) => !s.builtIn));
             })
             .catch(console.error)
             .finally(() => setLoading(false));
@@ -100,7 +106,8 @@ export function ConfigurationPacksPage() {
     useEffect(() => { loadData(); }, [loadData]);
 
     const totalSelected = selectedActionTypes.size + selectedTools.size
-        + selectedToolsets.size + selectedMcpServers.size + selectedReportDefs.size;
+        + selectedToolsets.size + selectedMcpServers.size + selectedReportDefs.size
+        + selectedSessionTemplates.size;
 
     const handleExport = async () => {
         setExporting(true);
@@ -113,6 +120,7 @@ export function ConfigurationPacksPage() {
                 toolsetIds: [...selectedToolsets],
                 mcpServerIds: [...selectedMcpServers],
                 reportDefinitionIds: [...selectedReportDefs],
+                sessionTemplateIds: [...selectedSessionTemplates],
             };
             const blob = await exportPack(request);
             const url = URL.createObjectURL(blob);
@@ -144,6 +152,7 @@ export function ConfigurationPacksPage() {
                     if (json.toolsets?.length) preview["Toolsets"] = json.toolsets.length;
                     if (json.mcpServers?.length) preview["MCP Servers"] = json.mcpServers.length;
                     if (json.reportDefinitions?.length) preview["Report Definitions"] = json.reportDefinitions.length;
+                    if (json.sessionTemplates?.length) preview["Session Templates"] = json.sessionTemplates.length;
                     setImportPreview(preview);
                     setImportPackName(json.metadata?.name || "");
                 } catch {
@@ -261,9 +270,9 @@ export function ConfigurationPacksPage() {
             </Title>
             <p className="axiom-text-subtle" style={{ marginTop: "8px", marginBottom: "16px" }}>
                 Configuration packs bundle related items — action types, tools, toolsets,
-                MCP servers, and report definitions — into a portable JSON file. Create a pack
-                to share your setup with others, or import one to quickly add pre-configured
-                functionality to your Axiom instance.
+                MCP servers, report definitions, and session templates — into a portable JSON
+                file. Create a pack to share your setup with others, or import one to quickly
+                add pre-configured functionality to your Axiom instance.
             </p>
 
             <Tabs activeKey={activeTab} onSelect={(_e, k) => setActiveTab(k as number)}>
@@ -381,6 +390,29 @@ export function ConfigurationPacksPage() {
                                     renderModal={(props) => (
                                         <ReportDefinitionPickerModal {...props} allReportDefs={reportDefs} />
                                     )} />
+                                <SessionTemplateCheckboxSection
+                                    templates={sessionTemplates}
+                                    selected={selectedSessionTemplates}
+                                    onToggle={(templateId) => {
+                                        const next = new Set(selectedSessionTemplates);
+                                        if (next.has(templateId)) next.delete(templateId); else next.add(templateId);
+                                        setSelectedSessionTemplates(next);
+                                        // Auto-select referenced MCP servers
+                                        if (!next.has(templateId)) return;
+                                        const st = sessionTemplates.find((s) => s.templateId === templateId);
+                                        if (st?.mcpServers?.length) {
+                                            const newMcpIds = new Set(selectedMcpServers);
+                                            for (const serverName of st.mcpServers) {
+                                                const server = mcpServers.find((m) => m.name === serverName);
+                                                if (server) newMcpIds.add(server.id);
+                                            }
+                                            if (newMcpIds.size > selectedMcpServers.size) setSelectedMcpServers(newMcpIds);
+                                        }
+                                        // Auto-select referenced tools/toolsets
+                                        if (st?.allowedTools?.length) {
+                                            autoSelectReferencedItems([st.allowedTools]);
+                                        }
+                                    }} />
                             </div>
 
                             <div style={{ marginTop: "24px" }}>
@@ -464,6 +496,7 @@ export function ConfigurationPacksPage() {
                                         {importResult.mcpServers ? <li>{importResult.mcpServers} MCP server(s)</li> : null}
                                         {importResult.actionTypes ? <li>{importResult.actionTypes} action type(s)</li> : null}
                                         {importResult.reportDefinitions ? <li>{importResult.reportDefinitions} report definition(s)</li> : null}
+                                        {importResult.sessionTemplates ? <li>{importResult.sessionTemplates} session template(s)</li> : null}
                                     </ul>
                                 </Alert>
                             )}
@@ -931,6 +964,45 @@ function ToolsetPickerModal({ isOpen, onClose, availableItems, modalSelected, to
                 <Button variant="link" onClick={onClose}>Cancel</Button>
             </ModalFooter>
         </Modal>
+    );
+}
+
+function SessionTemplateCheckboxSection({ templates, selected, onToggle }: {
+    templates: SessionTemplate[];
+    selected: Set<string>;
+    onToggle: (templateId: string) => void;
+}) {
+    if (templates.length === 0) return null;
+
+    const selectedCount = templates.filter((t) => selected.has(t.templateId)).length;
+
+    return (
+        <div style={{ marginBottom: "16px" }}>
+            <div style={{ fontWeight: 600, marginBottom: "8px", fontSize: "14px" }}>
+                Session Templates
+                {selectedCount > 0 && (
+                    <Label isCompact color="blue" style={{ marginLeft: "8px" }}>
+                        {selectedCount} selected
+                    </Label>
+                )}
+            </div>
+            <div style={{
+                display: "flex", flexDirection: "column", gap: "4px",
+                maxHeight: "200px", overflowY: "auto",
+                padding: "8px 12px",
+                backgroundColor: "var(--pf-t--global--background--color--secondary--default)",
+                borderRadius: "4px",
+            }}>
+                {templates.map((t) => (
+                    <Checkbox key={t.templateId}
+                        id={`session-template-${t.templateId}`}
+                        label={t.name}
+                        description={t.description}
+                        isChecked={selected.has(t.templateId)}
+                        onChange={() => onToggle(t.templateId)} />
+                ))}
+            </div>
+        </div>
     );
 }
 


### PR DESCRIPTION
## Summary

Adds support for AI Assistant Session Templates in the Configuration Pack export/import feature. Users can now include user-defined session templates when creating and importing configuration packs.

Fixes #139

## Changes

### OpenAPI spec (`common/api/src/main/resources/openapi.json`)
- Added `sessionTemplateIds` (string array) field to `PackExportRequest` schema
- Added `sessionTemplates` (integer) field to `ImportResult` schema

### Backend (`ImportExportService.java`)
- **Export**: Added session template serialization in `exportPack()` — looks up entities by `templateId` and serializes all fields including MCP servers and allowed tools lists
- **Import**: Added conflict detection for session templates (by `templateId`), import creation via new `importSessionTemplates()` helper, and session template count in the result
- Added `serializeSessionTemplate()` helper that outputs all template fields
- Added `sessionTemplate` case to the conflict checking switch statement

### Frontend (`ui/src/config/api.ts`)
- Added `sessionTemplateIds?: string[]` to `PackExportRequest` interface
- Added `sessionTemplates?: number` to `ImportResult` interface

### Frontend (`ui/src/pages/ConfigurationPacksPage.tsx`)
- Added session template state and fetching (filters out built-in templates)
- Added `SessionTemplateCheckboxSection` component with checkbox UI matching the MCP Servers section style
- Auto-selects referenced MCP servers and tools/toolsets when a session template is selected
- Shows session templates in import preview and import result summary
- Updated description text to mention session templates