### PR TITLE
Fix: DashboardsPage uses ColoredLabel for user labels

### DIFF
--- a/ui/src/pages/DashboardsPage.tsx
+++ b/ui/src/pages/DashboardsPage.tsx
@@ -28,6 +28,7 @@ import {
     createDashboard,
     deleteDashboard,
 } from "../config/api";
+import { ColoredLabel } from "../components/ColoredLabel";
 import { ConfirmDeleteModal } from "../components/ConfirmDeleteModal";
 
 export function DashboardsPage() {
@@ -138,8 +139,8 @@ export function DashboardsPage() {
                                     </Td>
                                     <Td>
                                         {d.labels.map(l => (
-                                            <Label key={l} isCompact
-                                                   style={{ marginRight: "4px" }}>{l}</Label>
+                                            <ColoredLabel key={l} isCompact
+                                                   style={{ marginRight: "4px" }}>{l}</ColoredLabel>
                                         ))}
                                         {d.labels.length === 0 && "—"}
                                     </Td>


### PR DESCRIPTION
## Summary

Replaces the plain PatternFly `Label` component with `ColoredLabel` for rendering user labels in the DashboardsPage list table. This ensures that the same label text always gets the same deterministic color, consistent with every other list page in the application (Projects, Events, EventSources, Reports, Tools).

## Changes

- **`ui/src/pages/DashboardsPage.tsx`**:
  - Added import for `ColoredLabel` from `../components/ColoredLabel`
  - Replaced `<Label>` with `<ColoredLabel>` for user label rendering in the Labels column
  - The "Default" badge on line 134 intentionally continues to use the plain `Label` with explicit `color="blue"` since it is a status indicator, not a user label

Fixes #150