### PR TITLE
Replace raw TextInput with LabelInput in dashboard pages

### DIFF
--- a/ui/src/pages/DashboardViewPage.tsx
+++ b/ui/src/pages/DashboardViewPage.tsx
@@ -32,6 +32,7 @@ import {
 import { WidgetCard } from "../components/dashboards/WidgetCard";
 import { AddWidgetModal } from "../components/dashboards/AddWidgetModal";
 import { ConfirmDeleteModal } from "../components/ConfirmDeleteModal";
+import { LabelInput } from "../components/LabelInput";
 import { getWidget, getDefaultConfig } from "../components/dashboards/widget-registry";
 
 import "../components/dashboards/widgets";
@@ -51,7 +52,7 @@ export function DashboardViewPage() {
 
     const [editName, setEditName] = useState("");
     const [editDescription, setEditDescription] = useState("");
-    const [editLabels, setEditLabels] = useState("");
+    const [editLabels, setEditLabels] = useState<string[]>([]);
     const [editWidgets, setEditWidgets] = useState<DashboardWidget[]>([]);
 
     const [addWidgetOpen, setAddWidgetOpen] = useState(false);
@@ -72,7 +73,7 @@ export function DashboardViewPage() {
         if (!dashboard) return;
         setEditName(dashboard.name);
         setEditDescription(dashboard.description ?? "");
-        setEditLabels(dashboard.labels.join(", "));
+        setEditLabels([...dashboard.labels]);
         setEditWidgets(structuredClone(dashboard.widgets));
         setIsEditing(true);
     };
@@ -83,11 +84,10 @@ export function DashboardViewPage() {
 
     const handleSave = () => {
         if (!dashboard) return;
-        const labels = editLabels.split(",").map(l => l.trim()).filter(l => l.length > 0);
         const data: NewDashboard = {
             name: editName,
             description: editDescription || undefined,
-            labels,
+            labels: editLabels,
             isDefault: dashboard.isDefault,
             widgets: editWidgets,
         };
@@ -146,9 +146,7 @@ export function DashboardViewPage() {
     };
 
     const activeWidgets = isEditing ? editWidgets : (dashboard?.widgets ?? []);
-    const activeLabels = isEditing
-        ? editLabels.split(",").map(l => l.trim()).filter(l => l.length > 0)
-        : (dashboard?.labels ?? []);
+    const activeLabels = isEditing ? editLabels : (dashboard?.labels ?? []);
 
     const gridItems: Layout[] = activeWidgets.map(w => {
         const entry = getWidget(w.type);
@@ -261,9 +259,9 @@ export function DashboardViewPage() {
                                       onChange={(_e, v) => setEditDescription(v)}
                                       rows={2} />
                         </FormGroup>
-                        <FormGroup label="Labels (comma-separated)" fieldId="edit-labels">
-                            <TextInput id="edit-labels" value={editLabels}
-                                       onChange={(_e, v) => setEditLabels(v)} />
+                        <FormGroup label="Labels" fieldId="edit-labels">
+                            <LabelInput labels={editLabels}
+                                onChange={(labels) => setEditLabels(labels)} />
                         </FormGroup>
                     </Form>
                 </div>

--- a/ui/src/pages/DashboardsPage.tsx
+++ b/ui/src/pages/DashboardsPage.tsx
@@ -29,6 +29,7 @@ import {
     deleteDashboard,
 } from "../config/api";
 import { ConfirmDeleteModal } from "../components/ConfirmDeleteModal";
+import { LabelInput } from "../components/LabelInput";
 
 export function DashboardsPage() {
     const navigate = useNavigate();
@@ -38,7 +39,7 @@ export function DashboardsPage() {
     const [deleteTarget, setDeleteTarget] = useState<number | null>(null);
     const [newName, setNewName] = useState("");
     const [newDescription, setNewDescription] = useState("");
-    const [newLabels, setNewLabels] = useState("");
+    const [newLabels, setNewLabels] = useState<string[]>([]);
 
     const load = useCallback(() => {
         setLoading(true);
@@ -48,11 +49,10 @@ export function DashboardsPage() {
     useEffect(() => { load(); }, [load]);
 
     const handleCreate = () => {
-        const labels = newLabels.split(",").map(l => l.trim()).filter(l => l.length > 0);
         const data: NewDashboard = {
             name: newName,
             description: newDescription || undefined,
-            labels,
+            labels: newLabels,
             isDefault: dashboards.length === 0,
             widgets: [],
         };
@@ -61,7 +61,7 @@ export function DashboardsPage() {
                 setIsCreateOpen(false);
                 setNewName("");
                 setNewDescription("");
-                setNewLabels("");
+                setNewLabels([]);
                 navigate(`/dashboards/${created.id}`);
             })
             .catch(console.error);
@@ -95,7 +95,7 @@ export function DashboardsPage() {
                     <Button variant="primary" icon={<PlusCircleIcon />} onClick={() => {
                         setNewName("");
                         setNewDescription("");
-                        setNewLabels("");
+                        setNewLabels([]);
                         setIsCreateOpen(true);
                     }}>
                         Create Dashboard
@@ -182,9 +182,9 @@ export function DashboardsPage() {
                             <TextArea id="description" value={newDescription}
                                       onChange={(_e, v) => setNewDescription(v)} />
                         </FormGroup>
-                        <FormGroup label="Labels (comma-separated)" fieldId="labels">
-                            <TextInput id="labels" value={newLabels}
-                                       onChange={(_e, v) => setNewLabels(v)} />
+                        <FormGroup label="Labels" fieldId="labels">
+                            <LabelInput labels={newLabels}
+                                onChange={(labels) => setNewLabels(labels)} />
                         </FormGroup>
                     </Form>
                 </ModalBody>


### PR DESCRIPTION
## Summary

Replaces the raw `TextInput` fields used for label editing in the dashboard pages with the `LabelInput` component, matching the pattern used throughout the rest of the application (e.g. `EventSourcesPage`, `ReportDefinitionDetailPage`, `EditLabelsModal`).

## Changes

- **`ui/src/pages/DashboardsPage.tsx`** — In the create modal, replaced the comma-separated `TextInput` for labels with `LabelInput`. Changed `newLabels` state from `string` to `string[]` and removed the manual comma-split parsing logic.

- **`ui/src/pages/DashboardViewPage.tsx`** — In the edit mode form, replaced the comma-separated `TextInput` for labels with `LabelInput`. Changed `editLabels` state from `string` to `string[]`, updated `enterEditMode` to copy the array directly, simplified `handleSave` and `activeLabels` computation by removing comma-split parsing.

Users now get the same press-Enter-to-add interaction with colored label chips and click-to-remove behavior that exists on every other page in the app.

Fixes #151