### PR TITLE
Add UI control to set a dashboard as default

### DIFF
--- a/ui/src/pages/DashboardViewPage.tsx
+++ b/ui/src/pages/DashboardViewPage.tsx
@@ -19,6 +19,7 @@ import {
 import PencilAltIcon from "@patternfly/react-icons/dist/esm/icons/pencil-alt-icon";
 import PlusCircleIcon from "@patternfly/react-icons/dist/esm/icons/plus-circle-icon";
 import SaveIcon from "@patternfly/react-icons/dist/esm/icons/save-icon";
+import StarIcon from "@patternfly/react-icons/dist/esm/icons/star-icon";
 import TimesIcon from "@patternfly/react-icons/dist/esm/icons/times-icon";
 import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
 import {
@@ -103,6 +104,20 @@ export function DashboardViewPage() {
         if (!dashboard) return;
         deleteDashboard(dashboard.id)
             .then(() => navigate("/dashboards"))
+            .catch(console.error);
+    };
+
+    const handleSetDefault = () => {
+        if (!dashboard || dashboard.isDefault) return;
+        const data: NewDashboard = {
+            name: dashboard.name,
+            description: dashboard.description,
+            labels: dashboard.labels,
+            isDefault: true,
+            widgets: dashboard.widgets,
+        };
+        updateDashboard(dashboard.id, data)
+            .then(setDashboard)
             .catch(console.error);
     };
 
@@ -202,6 +217,11 @@ export function DashboardViewPage() {
                             <FlexItem>
                                 <Title headingLevel="h1" size="lg">{dashboard.name}</Title>
                             </FlexItem>
+                            {dashboard.isDefault && (
+                                <FlexItem>
+                                    <Label isCompact color="blue">Default</Label>
+                                </FlexItem>
+                            )}
                             <FlexItem>
                                 {dashboard.labels.map(l => (
                                     <Label key={l} isCompact
@@ -241,12 +261,22 @@ export function DashboardViewPage() {
                                 </FlexItem>
                             </>
                         ) : (
-                            <FlexItem>
-                                <Button variant="secondary" icon={<PencilAltIcon />}
-                                        onClick={enterEditMode}>
-                                    Edit
-                                </Button>
-                            </FlexItem>
+                            <>
+                                {!dashboard.isDefault && (
+                                    <FlexItem>
+                                        <Button variant="secondary" icon={<StarIcon />}
+                                                onClick={handleSetDefault}>
+                                            Set as Default
+                                        </Button>
+                                    </FlexItem>
+                                )}
+                                <FlexItem>
+                                    <Button variant="secondary" icon={<PencilAltIcon />}
+                                            onClick={enterEditMode}>
+                                        Edit
+                                    </Button>
+                                </FlexItem>
+                            </>
                         )}
                     </Flex>
                 </FlexItem>

--- a/ui/src/pages/DashboardViewPage.tsx
+++ b/ui/src/pages/DashboardViewPage.tsx
@@ -12,6 +12,7 @@ import {
     FlexItem,
     Form,
     FormGroup,
+    Label,
     PageSection,
     TextArea,
     TextInput,

--- a/ui/src/pages/DashboardsPage.tsx
+++ b/ui/src/pages/DashboardsPage.tsx
@@ -20,6 +20,8 @@ import {
 } from "@patternfly/react-core";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import PlusCircleIcon from "@patternfly/react-icons/dist/esm/icons/plus-circle-icon";
+import StarIcon from "@patternfly/react-icons/dist/esm/icons/star-icon";
+import OutlinedStarIcon from "@patternfly/react-icons/dist/esm/icons/outlined-star-icon";
 import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
 import {
     type Dashboard,
@@ -27,6 +29,7 @@ import {
     fetchDashboards,
     createDashboard,
     deleteDashboard,
+    updateDashboard,
 } from "../config/api";
 import { ConfirmDeleteModal } from "../components/ConfirmDeleteModal";
 
@@ -65,6 +68,19 @@ export function DashboardsPage() {
                 navigate(`/dashboards/${created.id}`);
             })
             .catch(console.error);
+    };
+
+    const handleSetDefault = (e: React.MouseEvent, dashboard: Dashboard) => {
+        e.stopPropagation();
+        if (dashboard.isDefault) return;
+        const data: NewDashboard = {
+            name: dashboard.name,
+            description: dashboard.description,
+            labels: dashboard.labels,
+            isDefault: true,
+            widgets: dashboard.widgets,
+        };
+        updateDashboard(dashboard.id, data).then(load).catch(console.error);
     };
 
     const handleDelete = (e: React.MouseEvent, id: number) => {
@@ -146,11 +162,25 @@ export function DashboardsPage() {
                                     <Td>{d.widgets.length}</Td>
                                     <Td>{formatDate(d.updatedOn)}</Td>
                                     <Td>
-                                        <Button variant="plain" size="sm"
-                                                style={{ padding: 0 }}
-                                                onClick={(e) => handleDelete(e, d.id)}>
-                                            <TrashIcon />
-                                        </Button>
+                                        <Flex gap={{ default: "gapSm" }}
+                                              flexWrap={{ default: "nowrap" }}>
+                                            <FlexItem>
+                                                <Button variant="plain" size="sm"
+                                                        style={{ padding: 0 }}
+                                                        aria-label={d.isDefault ? "Default dashboard" : "Set as default"}
+                                                        isDisabled={d.isDefault}
+                                                        onClick={(e) => handleSetDefault(e, d)}>
+                                                    {d.isDefault ? <StarIcon color="var(--pf-t--global--color--status--info--default)" /> : <OutlinedStarIcon />}
+                                                </Button>
+                                            </FlexItem>
+                                            <FlexItem>
+                                                <Button variant="plain" size="sm"
+                                                        style={{ padding: 0 }}
+                                                        onClick={(e) => handleDelete(e, d.id)}>
+                                                    <TrashIcon />
+                                                </Button>
+                                            </FlexItem>
+                                        </Flex>
                                     </Td>
                                 </Tr>
                             ))}


### PR DESCRIPTION
## Summary

Adds UI controls to allow users to set a dashboard as the default, and displays a "Default" badge on the dashboard view page header.

### Changes

**DashboardsPage (`ui/src/pages/DashboardsPage.tsx`)**
- Added a star icon button in each dashboard row's action column:
  - Filled star (blue) for the current default dashboard (disabled)
  - Outlined star for non-default dashboards (clickable to set as default)
- Clicking the outlined star calls `updateDashboard` with `isDefault: true` and reloads the list

**DashboardViewPage (`ui/src/pages/DashboardViewPage.tsx`)**
- Added a "Default" badge (blue `Label`) next to the dashboard name in the header when `dashboard.isDefault` is true, matching the badge style already used on the DashboardsPage list table
- Added a "Set as Default" button in the view mode action bar (only shown when the dashboard is not already the default)
- Clicking the button calls `updateDashboard` with `isDefault: true` and updates the local state

The backend already handles clearing the `isDefault` flag on other dashboards automatically when a new default is set.

Fixes #152