### PR TITLE
Add label filtering support to AiCostSummary, Inbox, and RecentActivity dashboard widgets

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/rest/ActivityResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/ActivityResourceImpl.java
@@ -30,7 +30,8 @@ public class ActivityResourceImpl implements ActivityResource {
     @Override
     public ActivityLogSearchResults listActivityLog(BigInteger page, BigInteger limit,
                                                      BigInteger filterEventId, String filterSummary,
-                                                     BigInteger filterProjectId, String filterEntryType) {
+                                                     BigInteger filterProjectId, String filterEntryType,
+                                                     String filterLabels) {
         int pageNum = page != null ? page.intValue() : 1;
         int pageSize = limit != null ? limit.intValue() : 20;
 
@@ -54,6 +55,15 @@ public class ActivityResourceImpl implements ActivityResource {
                     .map(String::trim).filter(s -> !s.isEmpty()).toList();
             hql.append(" and entryType in :types");
             params.put("types", types);
+        }
+        if (filterLabels != null && !filterLabels.isBlank()) {
+            List<String> labels = Arrays.stream(filterLabels.split(","))
+                    .map(String::trim).filter(s -> !s.isEmpty()).toList();
+            hql.append(" and projectId in (SELECT p.id FROM ProjectEntity p"
+                    + " JOIN p.labels pl WHERE pl IN :labels"
+                    + " GROUP BY p.id HAVING COUNT(DISTINCT pl) = :labelCount)");
+            params.put("labels", labels);
+            params.put("labelCount", (long) labels.size());
         }
 
         long totalCount = ActivityLogEntity.count(hql.toString(), params);

--- a/app/src/main/java/io/apitomy/axiom/app/rest/InboxResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/InboxResourceImpl.java
@@ -30,7 +30,9 @@ import jakarta.transaction.Transactional;
 import java.math.BigInteger;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -58,13 +60,28 @@ public class InboxResourceImpl implements InboxResource {
      * {@inheritDoc}
      */
     @Override
-    public InboxSearchResults listInboxItems(BigInteger page, BigInteger limit) {
+    public InboxSearchResults listInboxItems(BigInteger page, BigInteger limit,
+                                             String filterLabels) {
         int pageNum = page != null ? page.intValue() : 1;
         int pageSize = limit != null ? limit.intValue() : 20;
 
-        long totalCount = TaskEntity.count("status", "AwaitingInput");
+        StringBuilder hql = new StringBuilder("status = :status");
+        Map<String, Object> params = new HashMap<>();
+        params.put("status", "AwaitingInput");
+
+        if (filterLabels != null && !filterLabels.isBlank()) {
+            List<String> labels = Arrays.stream(filterLabels.split(","))
+                    .map(String::trim).filter(s -> !s.isEmpty()).toList();
+            hql.append(" and projectId in (SELECT p.id FROM ProjectEntity p"
+                    + " JOIN p.labels pl WHERE pl IN :labels"
+                    + " GROUP BY p.id HAVING COUNT(DISTINCT pl) = :labelCount)");
+            params.put("labels", labels);
+            params.put("labelCount", (long) labels.size());
+        }
+
+        long totalCount = TaskEntity.count(hql.toString(), params);
         List<TaskEntity> taskEntities = TaskEntity.<TaskEntity>find(
-                        "status = ?1", Sort.descending("createdOn"), "AwaitingInput")
+                        hql.toString(), Sort.descending("createdOn"), params)
                 .page(Page.of(pageNum - 1, pageSize))
                 .list();
 

--- a/app/src/main/java/io/apitomy/axiom/app/rest/UsageResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/UsageResourceImpl.java
@@ -19,6 +19,7 @@ import java.math.BigInteger;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -45,7 +46,8 @@ public class UsageResourceImpl implements UsageResource {
                                            BigInteger filterActorId,
                                            String filterActionType,
                                            String filterDateFrom,
-                                           String filterDateTo) {
+                                           String filterDateTo,
+                                           String filterLabels) {
         int pageNum = page != null ? page.intValue() : 1;
         int pageSize = limit != null ? limit.intValue() : 20;
 
@@ -79,6 +81,15 @@ public class UsageResourceImpl implements UsageResource {
                     .plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant();
             hql.append(" and createdOn < :dateTo");
             params.put("dateTo", toInstant);
+        }
+        if (filterLabels != null && !filterLabels.isBlank()) {
+            List<String> labels = Arrays.stream(filterLabels.split(","))
+                    .map(String::trim).filter(s -> !s.isEmpty()).toList();
+            hql.append(" and projectId in (SELECT p.id FROM ProjectEntity p"
+                    + " JOIN p.labels pl WHERE pl IN :labels"
+                    + " GROUP BY p.id HAVING COUNT(DISTINCT pl) = :labelCount)");
+            params.put("labels", labels);
+            params.put("labelCount", (long) labels.size());
         }
 
         long totalCount = AiUsageEntity.count(hql.toString(), params);

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -1507,6 +1507,14 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "filterLabels",
+            "in": "query",
+            "description": "Comma-separated list of project labels to filter by (AND logic)",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -1820,6 +1828,14 @@
             "name": "filterEntryType",
             "in": "query",
             "description": "Comma-separated list of entry types to include",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filterLabels",
+            "in": "query",
+            "description": "Comma-separated list of project labels to filter by (AND logic)",
             "schema": {
               "type": "string"
             }
@@ -3816,6 +3832,15 @@
             "required": false,
             "schema": {
               "type": "integer"
+            }
+          },
+          {
+            "name": "filterLabels",
+            "in": "query",
+            "description": "Comma-separated list of project labels to filter by (AND logic)",
+            "required": false,
+            "schema": {
+              "type": "string"
             }
           }
         ],

--- a/ui/src/components/dashboards/widgets/AiCostSummaryWidget.tsx
+++ b/ui/src/components/dashboards/widgets/AiCostSummaryWidget.tsx
@@ -8,7 +8,7 @@ const TIME_WINDOWS: Record<string, number> = {
     "24h": 1, "7d": 7, "30d": 30, "90d": 90,
 };
 
-function AiCostSummaryWidget({ config }: WidgetProps) {
+function AiCostSummaryWidget({ config, labels }: WidgetProps) {
     const [totalCost, setTotalCost] = useState(0);
     const [totalInput, setTotalInput] = useState(0);
     const [totalOutput, setTotalOutput] = useState(0);
@@ -21,7 +21,8 @@ function AiCostSummaryWidget({ config }: WidgetProps) {
         let cancelled = false;
         const days = TIME_WINDOWS[timeWindow] || 7;
         const from = new Date(Date.now() - days * 86400000).toISOString();
-        fetchUsage(1, 1, undefined, undefined, undefined, undefined, from)
+        const labelsParam = labels.length > 0 ? labels.join(",") : undefined;
+        fetchUsage(1, 1, undefined, undefined, undefined, undefined, from, undefined, labelsParam)
             .then(result => {
                 if (cancelled) return;
                 setTotalCost(result.totalCostUsd);
@@ -31,7 +32,7 @@ function AiCostSummaryWidget({ config }: WidgetProps) {
             })
             .catch(() => { if (!cancelled) setError(true); });
         return () => { cancelled = true; };
-    }, [timeWindow]);
+    }, [labels, timeWindow]);
 
     if (error) return <WidgetError />;
 

--- a/ui/src/components/dashboards/widgets/InboxWidget.tsx
+++ b/ui/src/components/dashboards/widgets/InboxWidget.tsx
@@ -6,7 +6,7 @@ import { type InboxItem, fetchInboxItems } from "../../../config/api";
 import { registerWidget, type WidgetProps } from "../widget-registry";
 import { WidgetError } from "../WidgetError";
 
-function InboxWidget({ config }: WidgetProps) {
+function InboxWidget({ config, labels }: WidgetProps) {
     const navigate = useNavigate();
     const [items, setItems] = useState<InboxItem[]>([]);
     const [error, setError] = useState(false);
@@ -14,11 +14,12 @@ function InboxWidget({ config }: WidgetProps) {
 
     useEffect(() => {
         let cancelled = false;
-        fetchInboxItems(1, maxRows)
+        const labelsParam = labels.length > 0 ? labels.join(",") : undefined;
+        fetchInboxItems(1, maxRows, labelsParam)
             .then(result => { if (!cancelled) setItems(result.items); })
             .catch(() => { if (!cancelled) setError(true); });
         return () => { cancelled = true; };
-    }, [maxRows]);
+    }, [labels, maxRows]);
 
     if (error) return <WidgetError />;
 

--- a/ui/src/components/dashboards/widgets/RecentActivityWidget.tsx
+++ b/ui/src/components/dashboards/widgets/RecentActivityWidget.tsx
@@ -8,18 +8,19 @@ const TYPE_COLORS: Record<string, "blue" | "green" | "orange" | "grey" | "purple
     decision: "blue", result: "green", update: "orange", error: "grey", message: "purple",
 };
 
-function RecentActivityWidget({ config }: WidgetProps) {
+function RecentActivityWidget({ config, labels }: WidgetProps) {
     const [entries, setEntries] = useState<ActivityLogEntry[]>([]);
     const [error, setError] = useState(false);
     const maxEntries = Number(config.maxEntries) || 15;
 
     useEffect(() => {
         let cancelled = false;
-        fetchActivityLog(1, maxEntries)
+        const labelsParam = labels.length > 0 ? labels.join(",") : undefined;
+        fetchActivityLog(1, maxEntries, undefined, undefined, undefined, undefined, labelsParam)
             .then(result => { if (!cancelled) setEntries(result.items); })
             .catch(() => { if (!cancelled) setError(true); });
         return () => { cancelled = true; };
-    }, [maxEntries]);
+    }, [labels, maxEntries]);
 
     if (error) return <WidgetError />;
 

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -1081,7 +1081,8 @@ export async function fetchUsage(
     page = 1, limit = 20,
     filterInvocationType?: string, filterProjectId?: number,
     filterActorId?: number, filterActionType?: string,
-    filterDateFrom?: string, filterDateTo?: string
+    filterDateFrom?: string, filterDateTo?: string,
+    filterLabels?: string
 ): Promise<AiUsageSearchResults> {
     const params = new URLSearchParams();
     params.set("page", String(page));
@@ -1092,6 +1093,7 @@ export async function fetchUsage(
     if (filterActionType) params.set("filterActionType", filterActionType);
     if (filterDateFrom) params.set("filterDateFrom", filterDateFrom);
     if (filterDateTo) params.set("filterDateTo", filterDateTo);
+    if (filterLabels) params.set("filterLabels", filterLabels);
     const response = await fetch(`${API}/usage/ai?${params}`);
     if (!response.ok) throw new Error(`Failed to fetch usage: ${response.status}`);
     return response.json();
@@ -1173,7 +1175,8 @@ export async function fetchEvents(
 export async function fetchActivityLog(
     page = 1, limit = 20,
     filterEventId?: number, filterSummary?: string,
-    filterProjectId?: number, filterEntryType?: string
+    filterProjectId?: number, filterEntryType?: string,
+    filterLabels?: string
 ): Promise<SearchResults<ActivityLogEntry>> {
     const params = new URLSearchParams();
     params.set("page", String(page));
@@ -1182,6 +1185,7 @@ export async function fetchActivityLog(
     if (filterSummary) params.set("filterSummary", filterSummary);
     if (filterProjectId != null) params.set("filterProjectId", String(filterProjectId));
     if (filterEntryType) params.set("filterEntryType", filterEntryType);
+    if (filterLabels) params.set("filterLabels", filterLabels);
     const response = await fetch(`${API}/activity?${params}`);
     if (!response.ok) throw new Error(`Failed to fetch activity log: ${response.status}`);
     return response.json();
@@ -1629,10 +1633,13 @@ export interface InboxCount {
     count: number;
 }
 
-export async function fetchInboxItems(page = 1, limit = 20): Promise<SearchResults<InboxItem>> {
+export async function fetchInboxItems(
+    page = 1, limit = 20, filterLabels?: string
+): Promise<SearchResults<InboxItem>> {
     const params = new URLSearchParams();
     params.set("page", String(page));
     params.set("limit", String(limit));
+    if (filterLabels) params.set("filterLabels", filterLabels);
     const response = await fetch(`${API}/inbox?${params}`);
     if (!response.ok) throw new Error(`Failed to fetch inbox items: ${response.status}`);
     return response.json();


### PR DESCRIPTION
## Summary

Fixes #149

Three dashboard widgets (`AiCostSummaryWidget`, `InboxWidget`, `RecentActivityWidget`) were ignoring the dashboard's `labels` prop, showing unfiltered data even when a dashboard had labels configured. This broke the label-scoping contract.

## Changes

### OpenAPI Spec
- Added optional `filterLabels` query parameter to `/usage/ai`, `/inbox`, and `/activity` GET endpoints

### Backend (Java)
- **`UsageResourceImpl`** — accepts `filterLabels`, filters AI usage records by matching project labels using the same HQL subquery pattern used by `ProjectsResourceImpl`
- **`InboxResourceImpl`** — accepts `filterLabels`, refactored the query from positional parameters to named parameters to support dynamic filter composition, filters inbox items by project labels
- **`ActivityResourceImpl`** — accepts `filterLabels`, filters activity log entries by project labels

### UI API Client (`api.ts`)
- `fetchUsage()` — added optional `filterLabels` parameter
- `fetchInboxItems()` — added optional `filterLabels` parameter  
- `fetchActivityLog()` — added optional `filterLabels` parameter

### Dashboard Widgets
- **`AiCostSummaryWidget`** — destructures `labels` prop, passes to `fetchUsage()`, adds `labels` to `useEffect` deps
- **`InboxWidget`** — destructures `labels` prop, passes to `fetchInboxItems()`, adds `labels` to `useEffect` deps
- **`RecentActivityWidget`** — destructures `labels` prop, passes to `fetchActivityLog()`, adds `labels` to `useEffect` deps

All three widgets now follow the same pattern used by `RecentEventsWidget` and `ActiveProjectsWidget`.