### PR TITLE
Fix AI Cost Summary widget "Error loading data"

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/rest/UsageResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/UsageResourceImpl.java
@@ -69,14 +69,15 @@ public class UsageResourceImpl implements UsageResource {
             params.put("actionType", "%" + filterActionType.toLowerCase() + "%");
         }
         if (filterDateFrom != null && !filterDateFrom.isBlank()) {
-            Instant fromInstant = LocalDate.parse(filterDateFrom)
-                    .atStartOfDay(ZoneId.systemDefault()).toInstant();
+            Instant fromInstant = parseInstant(filterDateFrom);
             hql.append(" and createdOn >= :dateFrom");
             params.put("dateFrom", fromInstant);
         }
         if (filterDateTo != null && !filterDateTo.isBlank()) {
-            Instant toInstant = LocalDate.parse(filterDateTo)
-                    .plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant();
+            Instant toInstant = filterDateTo.contains("T")
+                    ? Instant.parse(filterDateTo)
+                    : LocalDate.parse(filterDateTo).plusDays(1)
+                            .atStartOfDay(ZoneId.systemDefault()).toInstant();
             hql.append(" and createdOn < :dateTo");
             params.put("dateTo", toInstant);
         }
@@ -163,6 +164,17 @@ public class UsageResourceImpl implements UsageResource {
         project.setProjectName(entity.name);
         project.setDiskUsageBytes(entity.diskUsageBytes != null ? entity.diskUsageBytes : 0L);
         return project;
+    }
+
+    /**
+     * Parses a date string that may be either ISO-8601 datetime (e.g. "2026-07-30T12:00:00.000Z")
+     * or date-only (e.g. "2026-07-30"), returning an {@link Instant}.
+     */
+    private Instant parseInstant(String value) {
+        if (value.contains("T")) {
+            return Instant.parse(value);
+        }
+        return LocalDate.parse(value).atStartOfDay(ZoneId.systemDefault()).toInstant();
     }
 
     private AiUsage toBean(AiUsageEntity entity) {

--- a/app/src/main/java/io/apitomy/axiom/app/rest/UsageResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/UsageResourceImpl.java
@@ -19,6 +19,7 @@ import java.math.BigInteger;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -74,10 +75,10 @@ public class UsageResourceImpl implements UsageResource {
             params.put("dateFrom", fromInstant);
         }
         if (filterDateTo != null && !filterDateTo.isBlank()) {
-            Instant toInstant = filterDateTo.contains("T")
-                    ? Instant.parse(filterDateTo)
-                    : LocalDate.parse(filterDateTo).plusDays(1)
-                            .atStartOfDay(ZoneId.systemDefault()).toInstant();
+            Instant toInstant = parseInstant(filterDateTo);
+            if (!filterDateTo.contains("T")) {
+                toInstant = toInstant.plus(1, ChronoUnit.DAYS);
+            }
             hql.append(" and createdOn < :dateTo");
             params.put("dateTo", toInstant);
         }


### PR DESCRIPTION
## Summary
- The AI Cost Summary and AI Cost by Project dashboard widgets send `filterDateFrom` as a full
  ISO-8601 datetime string (e.g. `2026-07-30T12:34:56.789Z`) via `new Date(...).toISOString()`
- The backend `UsageResourceImpl` parsed this with `LocalDate.parse()`, which only accepts
  date-only format (`2026-07-30`), causing a `DateTimeParseException` and a 500 error
- The standalone AI Usage page was unaffected because its date inputs produce date-only strings
- Added a `parseInstant()` helper that detects the format and parses accordingly

## Test plan
- [ ] Verify the AI Cost Summary widget loads data on the dashboard
- [ ] Verify the AI Cost by Project widget loads data on the dashboard
- [ ] Verify the AI Usage page date filters still work correctly
- [ ] Test with different time windows (24h, 7d, 30d, 90d) on both widgets