### PR TITLE
feat: user-configurable event source filtering

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/PipelineOrchestrator.java
+++ b/app/src/main/java/io/apitomy/axiom/app/PipelineOrchestrator.java
@@ -2,6 +2,9 @@ package io.apitomy.axiom.app;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.apitomy.axiom.core.filters.EventFilterEvaluator;
+import io.apitomy.axiom.core.filters.EventSourceFilters;
+import io.apitomy.axiom.core.filters.FilterResult;
 import io.apitomy.axiom.core.tracing.TraceContext;
 import io.apitomy.axiom.core.tracing.TraceService;
 import io.apitomy.axiom.core.entities.ActivityLogEntity;
@@ -42,10 +45,8 @@ public class PipelineOrchestrator {
 
     private static final Logger LOG = Logger.getLogger(PipelineOrchestrator.class);
 
-    private static final Set<String> SLASH_COMMANDS = Set.of(
-            "/ready", "/retry", "/accept", "/reject", "/disable-tests",
-            "/enable-tests", "/unstale", "/skip-review", "/auto-merge", "/merge"
-    );
+    @Inject
+    EventFilterEvaluator filterEvaluator;
 
     @Inject
     ManagerService managerService;
@@ -104,43 +105,27 @@ public class PipelineOrchestrator {
     }
 
     /**
-     * Returns a skip reason if the event should be filtered out without
-     * invoking the AI Manager, or {@code null} if the event should be processed.
+     * Evaluates event against the filters configured on its source.
+     *
+     * @param event the event to evaluate
+     * @return the filter evaluation result
      */
-    private String shouldSkipEvent(EventEntity event) {
-        if (event.payload == null || event.payload.isBlank()) {
-            return null;
+    private FilterResult evaluateFilters(EventEntity event) {
+        if (event.eventSourceId == null) {
+            return FilterResult.ALLOWED;
+        }
+        EventSourceEntity source = EventSourceEntity.findById(event.eventSourceId);
+        if (source == null || source.filters == null) {
+            return FilterResult.ALLOWED;
         }
         try {
+            EventSourceFilters filters = objectMapper.readValue(source.filters, EventSourceFilters.class);
             JsonNode payload = objectMapper.readTree(event.payload);
-
-            // Extract the author login from the event payload
-            String login = null;
-            JsonNode comment = payload.path("comment");
-            if (!comment.isMissingNode()) {
-                login = comment.path("user").path("login").asText(null);
-            }
-            if (login == null) {
-                login = payload.path("user").path("login").asText(null);
-            }
-
-            // Skip events from GitHub App bot accounts (all use the [bot] suffix)
-            if (login != null && login.endsWith("[bot]")) {
-                return "bot activity from " + login;
-            }
-
-            // Skip slash command comments (lifecycle orchestrator handles these)
-            if ("comment-added".equals(event.eventType) && !comment.isMissingNode()) {
-                String body = comment.path("body").asText("").trim();
-                if (SLASH_COMMANDS.stream().anyMatch(cmd ->
-                        body.equals(cmd) || body.startsWith(cmd + " "))) {
-                    return "slash command: " + body.split("\\s+")[0];
-                }
-            }
+            return filterEvaluator.evaluate(filters, event.eventType, payload);
         } catch (Exception e) {
-            LOG.tracef("Failed to parse event payload for pre-filtering: %s", e.getMessage());
+            LOG.warnf("Failed to evaluate filters for event %d: %s", event.id, e.getMessage());
+            return FilterResult.ALLOWED;
         }
-        return null;
     }
 
     /**
@@ -170,13 +155,13 @@ public class PipelineOrchestrator {
         LOG.infof("Processing event %d: %s [%s] from %s",
                 event.id, event.eventType, event.issueRef, event.source);
 
-        // Pre-filter: skip events from known bots without invoking the AI Manager
-        String skipReason = shouldSkipEvent(event);
-        if (skipReason != null) {
-            LOG.infof("Pre-filtered event %d: %s", event.id, skipReason);
+        // Pre-filter: evaluate event against source filters before invoking the AI Manager
+        FilterResult filterResult = evaluateFilters(event);
+        if (!filterResult.allowed()) {
+            LOG.infof("Pre-filtered event %d: %s", event.id, filterResult.matchedRule());
             QuarkusTransaction.requiringNew().run(() -> {
                 logActivity(null, null, event.id, "event-pre-filtered",
-                        "Event pre-filtered: " + event.eventType + " — " + skipReason);
+                        "Event pre-filtered: " + event.eventType + " — " + filterResult.matchedRule());
                 markQueueEntry(queueEntryId, "completed");
             });
             return;

--- a/app/src/main/java/io/apitomy/axiom/app/rest/EventSourcesResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/EventSourcesResourceImpl.java
@@ -52,6 +52,13 @@ public class EventSourcesResourceImpl implements EventResource {
     public EventSource createEventSource(NewEventSource data) {
         EventSourceEntity entity = new EventSourceEntity();
         applyFields(entity, data);
+        if (entity.filters == null) {
+            try {
+                entity.filters = objectMapper.writeValueAsString(defaultFilters());
+            } catch (Exception e) {
+                entity.filters = null;
+            }
+        }
         entity.persist();
         return toBean(entity);
     }
@@ -86,6 +93,34 @@ public class EventSourcesResourceImpl implements EventResource {
     }
 
     /**
+     * Creates the default filter configuration for new event sources.
+     *
+     * @return the default filters that skip bot activity and slash commands
+     */
+    private io.apitomy.axiom.api.beans.EventSourceFilters defaultFilters() {
+        io.apitomy.axiom.api.beans.EventSourceFilters filters = new io.apitomy.axiom.api.beans.EventSourceFilters();
+        filters.setInclude(List.of());
+
+        io.apitomy.axiom.api.beans.EventSourceFilterRule botRule = new io.apitomy.axiom.api.beans.EventSourceFilterRule();
+        botRule.setType(io.apitomy.axiom.api.beans.EventSourceFilterRule.Type.payload);
+        botRule.setPointer("/user/login");
+        botRule.setPattern("*[bot]");
+
+        io.apitomy.axiom.api.beans.EventSourceFilterRule commentBotRule = new io.apitomy.axiom.api.beans.EventSourceFilterRule();
+        commentBotRule.setType(io.apitomy.axiom.api.beans.EventSourceFilterRule.Type.payload);
+        commentBotRule.setPointer("/comment/user/login");
+        commentBotRule.setPattern("*[bot]");
+
+        io.apitomy.axiom.api.beans.EventSourceFilterRule slashRule = new io.apitomy.axiom.api.beans.EventSourceFilterRule();
+        slashRule.setType(io.apitomy.axiom.api.beans.EventSourceFilterRule.Type.payload);
+        slashRule.setPointer("/comment/body");
+        slashRule.setPattern("/*");
+
+        filters.setExclude(List.of(botRule, commentBotRule, slashRule));
+        return filters;
+    }
+
+    /**
      * Applies field values from the API bean to the entity.
      *
      * @param entity the entity to update
@@ -110,6 +145,15 @@ public class EventSourcesResourceImpl implements EventResource {
         entity.labels.clear();
         if (data.getLabels() != null) {
             entity.labels.addAll(data.getLabels());
+        }
+        if (data.getFilters() != null) {
+            try {
+                entity.filters = objectMapper.writeValueAsString(data.getFilters());
+            } catch (Exception e) {
+                entity.filters = null;
+            }
+        } else {
+            entity.filters = null;
         }
     }
 
@@ -152,6 +196,14 @@ public class EventSourcesResourceImpl implements EventResource {
             }
         }
         bean.setLabels(entity.labels);
+        if (entity.filters != null) {
+            try {
+                bean.setFilters(objectMapper.readValue(entity.filters,
+                        io.apitomy.axiom.api.beans.EventSourceFilters.class));
+            } catch (Exception e) {
+                // ignore parse errors
+            }
+        }
         return bean;
     }
 

--- a/app/src/main/java/io/apitomy/axiom/app/rest/EventSourcesResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/EventSourcesResourceImpl.java
@@ -1,13 +1,26 @@
 package io.apitomy.axiom.app.rest;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.apitomy.axiom.api.EventResource;
 import io.apitomy.axiom.api.beans.EventSource;
 import io.apitomy.axiom.api.beans.EventSourceLog;
 import io.apitomy.axiom.api.beans.EventSourceLogSearchResults;
+import io.apitomy.axiom.api.beans.FilterDryRunRequest;
+import io.apitomy.axiom.api.beans.FilterDryRunResponse;
+import io.apitomy.axiom.api.beans.FilterDryRunResult;
 import io.apitomy.axiom.api.beans.NewEventSource;
 import io.apitomy.axiom.core.entities.EventSourceEntity;
 import io.apitomy.axiom.core.entities.EventSourceLogEntity;
+import io.apitomy.axiom.core.entities.SecretEntity;
+import io.apitomy.axiom.core.filters.EventFilterEvaluator;
+import io.apitomy.axiom.core.filters.EventSourceFilterRule;
+import io.apitomy.axiom.core.filters.EventSourceFilters;
+import io.apitomy.axiom.core.filters.FilterResult;
+import io.apitomy.axiom.core.services.EncryptionService;
+import io.apitomy.axiom.events.core.DryRunEvent;
+import io.apitomy.axiom.events.github.GitHubDryRunService;
+import io.apitomy.axiom.events.jira.JiraDryRunService;
 import io.quarkus.panache.common.Page;
 import io.quarkus.panache.common.Sort;
 import io.smallrye.common.annotation.RunOnVirtualThread;
@@ -15,8 +28,10 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.WebApplicationException;
+import org.jboss.logging.Logger;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
@@ -29,8 +44,22 @@ import java.util.Map;
 @RunOnVirtualThread
 public class EventSourcesResourceImpl implements EventResource {
 
+    private static final Logger LOG = Logger.getLogger(EventSourcesResourceImpl.class);
+
     @Inject
     ObjectMapper objectMapper;
+
+    @Inject
+    GitHubDryRunService githubDryRunService;
+
+    @Inject
+    JiraDryRunService jiraDryRunService;
+
+    @Inject
+    EventFilterEvaluator filterEvaluator;
+
+    @Inject
+    EncryptionService encryptionService;
 
     /**
      * {@inheritDoc}
@@ -244,5 +273,114 @@ public class EventSourcesResourceImpl implements EventResource {
         log.setEventsIngested(entity.eventsIngested);
         log.setCreatedOn(Date.from(entity.createdOn));
         return log;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public FilterDryRunResponse dryRunFilters(FilterDryRunRequest request) {
+        // Convert API filter beans to core filter model
+        EventSourceFilters coreFilters = toCoreFilters(request.getFilters());
+
+        // Fetch recent events from the source
+        List<DryRunEvent> events = fetchDryRunEvents(request);
+
+        // Evaluate filters against each event
+        List<FilterDryRunResult> results = new ArrayList<>();
+        int allowed = 0;
+        int blocked = 0;
+
+        for (DryRunEvent event : events) {
+            FilterResult filterResult = filterEvaluator.evaluate(
+                    coreFilters, event.eventType(), event.payload());
+            FilterDryRunResult result = new FilterDryRunResult();
+            result.setEventType(event.eventType());
+            result.setIssueRef(event.issueRef());
+            result.setSummary(event.summary());
+            result.setAllowed(filterResult.allowed());
+            result.setMatchedRule(filterResult.matchedRule());
+            results.add(result);
+            if (filterResult.allowed()) allowed++;
+            else blocked++;
+        }
+
+        FilterDryRunResponse response = new FilterDryRunResponse();
+        response.setResults(results);
+        response.setTotalEvaluated(events.size());
+        response.setTotalAllowed(allowed);
+        response.setTotalBlocked(blocked);
+        return response;
+    }
+
+    /**
+     * Fetches recent events from the configured event source for dry-run evaluation.
+     *
+     * @param request the dry-run request containing source configuration
+     * @return list of classified events
+     */
+    private List<DryRunEvent> fetchDryRunEvents(FilterDryRunRequest request) {
+        String sourceType = request.getSourceType().value();
+        Map<String, Object> config = request.getConfiguration();
+        String token = resolveSecretValue(request.getSecretName());
+
+        if (token == null) {
+            throw new WebApplicationException("Secret not found or could not be decrypted", 401);
+        }
+
+        if ("github".equals(sourceType)) {
+            String owner = String.valueOf(config.get("owner"));
+            String name = String.valueOf(config.get("name"));
+            return githubDryRunService.fetchRecentEvents(owner, name, token);
+        } else if ("jira".equals(sourceType)) {
+            String baseUrl = String.valueOf(config.get("baseUrl"));
+            String project = String.valueOf(config.get("project"));
+            return jiraDryRunService.fetchRecentEvents(baseUrl, project, token);
+        }
+        return List.of();
+    }
+
+    /**
+     * Converts API filter beans to core filter model.
+     *
+     * @param apiFilters the API filter configuration
+     * @return the core filter model
+     */
+    private EventSourceFilters toCoreFilters(
+            io.apitomy.axiom.api.beans.EventSourceFilters apiFilters) {
+        if (apiFilters == null) return EventSourceFilters.allowAll();
+        List<EventSourceFilterRule> include = apiFilters.getInclude() != null
+                ? apiFilters.getInclude().stream()
+                    .map(r -> new EventSourceFilterRule(
+                            r.getType().value(), r.getPointer(), r.getPattern()))
+                    .toList()
+                : List.of();
+        List<EventSourceFilterRule> exclude = apiFilters.getExclude() != null
+                ? apiFilters.getExclude().stream()
+                    .map(r -> new EventSourceFilterRule(
+                            r.getType().value(), r.getPointer(), r.getPattern()))
+                    .toList()
+                : List.of();
+        return new EventSourceFilters(include, exclude);
+    }
+
+    /**
+     * Resolves a secret value by name using the same logic as the pollers.
+     *
+     * @param secretName the name of the secret to resolve
+     * @return the decrypted secret value, or null if not found
+     */
+    private String resolveSecretValue(String secretName) {
+        if (secretName != null && !secretName.isBlank()) {
+            SecretEntity secret = SecretEntity.find("name", secretName).firstResult();
+            if (secret != null) {
+                try {
+                    return encryptionService.decrypt(secret.encryptedValue);
+                } catch (Exception e) {
+                    LOG.warnf("Failed to decrypt secret '%s'", secretName);
+                }
+            }
+        }
+        return null;
     }
 }

--- a/app/src/main/java/io/apitomy/axiom/app/rest/EventSourcesResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/EventSourcesResourceImpl.java
@@ -298,6 +298,7 @@ public class EventSourcesResourceImpl implements EventResource {
             result.setSummary(event.summary());
             result.setAllowed(filterResult.allowed());
             result.setMatchedRule(filterResult.matchedRule());
+            result.setPayload(event.payload() != null ? event.payload().toString() : null);
             results.add(result);
             if (filterResult.allowed()) allowed++;
             else blocked++;
@@ -318,6 +319,7 @@ public class EventSourcesResourceImpl implements EventResource {
      * @return list of classified events
      */
     private List<DryRunEvent> fetchDryRunEvents(FilterDryRunRequest request) {
+        final int MAX_EVENTS = 200;
         String sourceType = request.getSourceType().value();
         Map<String, Object> config = request.getConfiguration().getAdditionalProperties();
         String token = resolveSecretValue(request.getSecretName(), sourceType);
@@ -326,16 +328,23 @@ public class EventSourcesResourceImpl implements EventResource {
             throw new WebApplicationException("Secret not found or could not be decrypted", 401);
         }
 
+        List<DryRunEvent> events;
         if ("github".equals(sourceType)) {
             String owner = String.valueOf(config.get("owner"));
             String name = String.valueOf(config.get("name"));
-            return githubDryRunService.fetchRecentEvents(owner, name, token);
+            events = githubDryRunService.fetchRecentEvents(owner, name, token);
         } else if ("jira".equals(sourceType)) {
             String baseUrl = String.valueOf(config.get("baseUrl"));
             String project = String.valueOf(config.get("project"));
-            return jiraDryRunService.fetchRecentEvents(baseUrl, project, token);
+            events = jiraDryRunService.fetchRecentEvents(baseUrl, project, token);
+        } else {
+            return List.of();
         }
-        return List.of();
+
+        if (events.size() > MAX_EVENTS) {
+            return events.subList(events.size() - MAX_EVENTS, events.size());
+        }
+        return events;
     }
 
     /**

--- a/app/src/main/java/io/apitomy/axiom/app/rest/EventSourcesResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/EventSourcesResourceImpl.java
@@ -181,8 +181,6 @@ public class EventSourcesResourceImpl implements EventResource {
             } catch (Exception e) {
                 entity.filters = null;
             }
-        } else {
-            entity.filters = null;
         }
     }
 
@@ -322,7 +320,7 @@ public class EventSourcesResourceImpl implements EventResource {
     private List<DryRunEvent> fetchDryRunEvents(FilterDryRunRequest request) {
         String sourceType = request.getSourceType().value();
         Map<String, Object> config = request.getConfiguration().getAdditionalProperties();
-        String token = resolveSecretValue(request.getSecretName());
+        String token = resolveSecretValue(request.getSecretName(), sourceType);
 
         if (token == null) {
             throw new WebApplicationException("Secret not found or could not be decrypted", 401);
@@ -365,12 +363,14 @@ public class EventSourcesResourceImpl implements EventResource {
     }
 
     /**
-     * Resolves a secret value by name using the same logic as the pollers.
+     * Resolves a secret value by name, with fallbacks to well-known secrets
+     * and environment variables matching the poller resolution logic.
      *
-     * @param secretName the name of the secret to resolve
+     * @param secretName the name of the secret to resolve (may be null)
+     * @param sourceType the source type ("github" or "jira") for fallback resolution
      * @return the decrypted secret value, or null if not found
      */
-    private String resolveSecretValue(String secretName) {
+    private String resolveSecretValue(String secretName, String sourceType) {
         if (secretName != null && !secretName.isBlank()) {
             SecretEntity secret = SecretEntity.find("name", secretName).firstResult();
             if (secret != null) {
@@ -379,6 +379,27 @@ public class EventSourcesResourceImpl implements EventResource {
                 } catch (Exception e) {
                     LOG.warnf("Failed to decrypt secret '%s'", secretName);
                 }
+            }
+        }
+
+        List<String> fallbackNames = "github".equals(sourceType)
+                ? List.of("GH_TOKEN", "GITHUB_TOKEN")
+                : List.of("JIRA_API_TOKEN");
+        for (String name : fallbackNames) {
+            SecretEntity secret = SecretEntity.find("name", name).firstResult();
+            if (secret != null) {
+                try {
+                    return encryptionService.decrypt(secret.encryptedValue);
+                } catch (Exception e) {
+                    LOG.warnf("Failed to decrypt %s secret", name);
+                }
+            }
+        }
+
+        for (String name : fallbackNames) {
+            String envValue = System.getenv(name);
+            if (envValue != null && !envValue.isBlank()) {
+                return envValue;
             }
         }
         return null;

--- a/app/src/main/java/io/apitomy/axiom/app/rest/EventSourcesResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/EventSourcesResourceImpl.java
@@ -131,17 +131,17 @@ public class EventSourcesResourceImpl implements EventResource {
         filters.setInclude(List.of());
 
         io.apitomy.axiom.api.beans.EventSourceFilterRule botRule = new io.apitomy.axiom.api.beans.EventSourceFilterRule();
-        botRule.setType(io.apitomy.axiom.api.beans.EventSourceFilterRule.Type.payload);
+        botRule.setType(io.apitomy.axiom.api.beans.EventSourceFilterRule.Type.PAYLOAD);
         botRule.setPointer("/user/login");
         botRule.setPattern("*[bot]");
 
         io.apitomy.axiom.api.beans.EventSourceFilterRule commentBotRule = new io.apitomy.axiom.api.beans.EventSourceFilterRule();
-        commentBotRule.setType(io.apitomy.axiom.api.beans.EventSourceFilterRule.Type.payload);
+        commentBotRule.setType(io.apitomy.axiom.api.beans.EventSourceFilterRule.Type.PAYLOAD);
         commentBotRule.setPointer("/comment/user/login");
         commentBotRule.setPattern("*[bot]");
 
         io.apitomy.axiom.api.beans.EventSourceFilterRule slashRule = new io.apitomy.axiom.api.beans.EventSourceFilterRule();
-        slashRule.setType(io.apitomy.axiom.api.beans.EventSourceFilterRule.Type.payload);
+        slashRule.setType(io.apitomy.axiom.api.beans.EventSourceFilterRule.Type.PAYLOAD);
         slashRule.setPointer("/comment/body");
         slashRule.setPattern("/*");
 
@@ -321,7 +321,7 @@ public class EventSourcesResourceImpl implements EventResource {
      */
     private List<DryRunEvent> fetchDryRunEvents(FilterDryRunRequest request) {
         String sourceType = request.getSourceType().value();
-        Map<String, Object> config = request.getConfiguration();
+        Map<String, Object> config = request.getConfiguration().getAdditionalProperties();
         String token = resolveSecretValue(request.getSecretName());
 
         if (token == null) {

--- a/app/src/main/resources/db/migration/V34__add_event_source_filters.sql
+++ b/app/src/main/resources/db/migration/V34__add_event_source_filters.sql
@@ -1,0 +1,13 @@
+-- Add filters column to event_source table
+ALTER TABLE event_source ADD COLUMN filters TEXT;
+
+-- Populate all existing event sources with default filter rules
+-- These defaults replace the hardcoded shouldSkipEvent() logic:
+--   *[bot] login suffix -> bot filter
+--   /* comment body -> slash command filter
+UPDATE event_source SET filters =
+    '{"include":[],"exclude":['
+    || '{"type":"payload","pointer":"/user/login","pattern":"*[bot]"},'
+    || '{"type":"payload","pointer":"/comment/user/login","pattern":"*[bot]"},'
+    || '{"type":"payload","pointer":"/comment/body","pattern":"/*"}'
+    || ']}';

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -2863,6 +2863,38 @@
         }
       ]
     },
+    "/event-sources/filters/dry-run": {
+      "post": {
+        "tags": [
+          "EventSources"
+        ],
+        "summary": "Test filter configuration against live events",
+        "description": "Fetches recent events from the source API and evaluates the provided filter configuration against them. No events are ingested. Use this to preview what filters would allow or block before saving.",
+        "operationId": "dryRunFilters",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FilterDryRunRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Dry run results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilterDryRunResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/system/packs/export": {
       "post": {
         "tags": [
@@ -4970,6 +5002,9 @@
             "items": {
               "type": "string"
             }
+          },
+          "filters": {
+            "$ref": "#/components/schemas/EventSourceFilters"
           }
         }
       },
@@ -5015,6 +5050,9 @@
             "items": {
               "type": "string"
             }
+          },
+          "filters": {
+            "$ref": "#/components/schemas/EventSourceFilters"
           }
         }
       },
@@ -7423,6 +7461,121 @@
             "items": {
               "$ref": "#/components/schemas/DashboardWidget"
             }
+          }
+        }
+      },
+      "EventSourceFilterRule": {
+        "required": [
+          "type",
+          "pattern"
+        ],
+        "type": "object",
+        "properties": {
+          "type": {
+            "description": "What the rule matches against: event-type or payload field",
+            "enum": [
+              "event-type",
+              "payload"
+            ],
+            "type": "string"
+          },
+          "pointer": {
+            "description": "JSON Pointer (RFC 6901) to the payload field. Required when type is payload.",
+            "type": "string"
+          },
+          "pattern": {
+            "description": "Glob pattern to match against. Supports * (any sequence) and ? (any single character) wildcards.",
+            "type": "string"
+          }
+        }
+      },
+      "EventSourceFilters": {
+        "type": "object",
+        "properties": {
+          "include": {
+            "description": "Rules for events to include. An empty list means allow all event types.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EventSourceFilterRule"
+            }
+          },
+          "exclude": {
+            "description": "Rules for events to exclude. Applied after include rules.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EventSourceFilterRule"
+            }
+          }
+        }
+      },
+      "FilterDryRunRequest": {
+        "required": [
+          "sourceType",
+          "configuration",
+          "filters"
+        ],
+        "type": "object",
+        "properties": {
+          "sourceType": {
+            "enum": [
+              "github",
+              "jira"
+            ],
+            "type": "string"
+          },
+          "configuration": {
+            "description": "Source-specific configuration (same shape as EventSource.configuration)",
+            "type": "object",
+            "additionalProperties": {}
+          },
+          "secretName": {
+            "description": "Name of the secret to use for authentication",
+            "type": "string"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/EventSourceFilters"
+          }
+        }
+      },
+      "FilterDryRunResponse": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterDryRunResult"
+            }
+          },
+          "totalEvaluated": {
+            "type": "integer"
+          },
+          "totalAllowed": {
+            "type": "integer"
+          },
+          "totalBlocked": {
+            "type": "integer"
+          }
+        }
+      },
+      "FilterDryRunResult": {
+        "type": "object",
+        "properties": {
+          "eventType": {
+            "type": "string"
+          },
+          "issueRef": {
+            "type": "string"
+          },
+          "summary": {
+            "description": "Human-readable summary of the event (e.g. issue title, comment author)",
+            "type": "string"
+          },
+          "allowed": {
+            "type": "boolean"
+          },
+          "matchedRule": {
+            "description": "Description of the filter rule that matched, if blocked",
+            "type": "string"
           }
         }
       }

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -7576,6 +7576,10 @@
           "matchedRule": {
             "description": "Description of the filter rule that matched, if blocked",
             "type": "string"
+          },
+          "payload": {
+            "description": "The raw event payload JSON",
+            "type": "string"
           }
         }
       }

--- a/core/src/main/java/io/apitomy/axiom/core/entities/EventSourceEntity.java
+++ b/core/src/main/java/io/apitomy/axiom/core/entities/EventSourceEntity.java
@@ -56,6 +56,9 @@ public class EventSourceEntity extends PanacheEntity {
     @Column(nullable = false, columnDefinition = "TEXT")
     public String configuration;
 
+    @Column(columnDefinition = "TEXT")
+    public String filters;
+
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "event_source_label", joinColumns = @JoinColumn(name = "event_source_id"))
     @Column(name = "label")

--- a/core/src/main/java/io/apitomy/axiom/core/filters/EventFilterEvaluator.java
+++ b/core/src/main/java/io/apitomy/axiom/core/filters/EventFilterEvaluator.java
@@ -1,0 +1,90 @@
+package io.apitomy.axiom.core.filters;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Evaluates events against a set of include/exclude filter rules.
+ */
+@ApplicationScoped
+public class EventFilterEvaluator {
+
+    /**
+     * Evaluates an event against the given filter configuration.
+     *
+     * <p>If filters is null or has empty include/exclude lists, all events pass.
+     * Otherwise, include rules are checked first (event must match at least one),
+     * then exclude rules (any match blocks the event).
+     *
+     * @param filters   the filter configuration (may be null)
+     * @param eventType the event type string (e.g. "issue-created")
+     * @param payload   the parsed event payload JSON (may be null)
+     * @return the evaluation result
+     */
+    public FilterResult evaluate(EventSourceFilters filters, String eventType, JsonNode payload) {
+        if (filters == null) {
+            return FilterResult.ALLOWED;
+        }
+
+        List<EventSourceFilterRule> includeRules = filters.include() != null ? filters.include() : List.of();
+        List<EventSourceFilterRule> excludeRules = filters.exclude() != null ? filters.exclude() : List.of();
+
+        if (!includeRules.isEmpty()) {
+            boolean matched = includeRules.stream()
+                    .anyMatch(rule -> ruleMatches(rule, eventType, payload));
+            if (!matched) {
+                return FilterResult.blocked("no include rule matched for event type: " + eventType);
+            }
+        }
+
+        for (EventSourceFilterRule rule : excludeRules) {
+            if (ruleMatches(rule, eventType, payload)) {
+                return FilterResult.blocked(describeRule("exclude", rule));
+            }
+        }
+
+        return FilterResult.ALLOWED;
+    }
+
+    private boolean ruleMatches(EventSourceFilterRule rule, String eventType, JsonNode payload) {
+        if ("event-type".equals(rule.type())) {
+            return matchesWildcard(eventType, rule.pattern());
+        } else if ("payload".equals(rule.type())) {
+            if (payload == null || rule.pointer() == null) {
+                return false;
+            }
+            JsonNode node = payload.at(rule.pointer());
+            if (node.isMissingNode() || node.isNull()) {
+                return false;
+            }
+            return matchesWildcard(node.asText(), rule.pattern());
+        }
+        return false;
+    }
+
+    private String describeRule(String phase, EventSourceFilterRule rule) {
+        if ("event-type".equals(rule.type())) {
+            return phase + " event-type " + rule.pattern();
+        }
+        return phase + " payload " + rule.pointer() + " matched " + rule.pattern();
+    }
+
+    static boolean matchesWildcard(String value, String pattern) {
+        if (value == null || pattern == null) {
+            return false;
+        }
+        StringBuilder regex = new StringBuilder("^");
+        for (char c : pattern.toCharArray()) {
+            switch (c) {
+                case '*' -> regex.append(".*");
+                case '?' -> regex.append(".");
+                default -> regex.append(Pattern.quote(String.valueOf(c)));
+            }
+        }
+        regex.append("$");
+        return Pattern.compile(regex.toString()).matcher(value).matches();
+    }
+}

--- a/core/src/main/java/io/apitomy/axiom/core/filters/EventSourceFilterRule.java
+++ b/core/src/main/java/io/apitomy/axiom/core/filters/EventSourceFilterRule.java
@@ -1,0 +1,11 @@
+package io.apitomy.axiom.core.filters;
+
+/**
+ * A single filter rule that matches either an event type or a payload field value.
+ *
+ * @param type    "event-type" or "payload"
+ * @param pointer JSON Pointer (RFC 6901) path into the payload; required when type is "payload"
+ * @param pattern glob pattern with * and ? wildcards
+ */
+public record EventSourceFilterRule(String type, String pointer, String pattern) {
+}

--- a/core/src/main/java/io/apitomy/axiom/core/filters/EventSourceFilters.java
+++ b/core/src/main/java/io/apitomy/axiom/core/filters/EventSourceFilters.java
@@ -1,0 +1,20 @@
+package io.apitomy.axiom.core.filters;
+
+import java.util.List;
+
+/**
+ * Include/exclude filter configuration for an event source.
+ *
+ * @param include rules for events to include (empty list means allow all)
+ * @param exclude rules for events to exclude (applied after include)
+ */
+public record EventSourceFilters(List<EventSourceFilterRule> include,
+                                  List<EventSourceFilterRule> exclude) {
+
+    /**
+     * Returns an empty filters instance that allows all events.
+     */
+    public static EventSourceFilters allowAll() {
+        return new EventSourceFilters(List.of(), List.of());
+    }
+}

--- a/core/src/main/java/io/apitomy/axiom/core/filters/FilterResult.java
+++ b/core/src/main/java/io/apitomy/axiom/core/filters/FilterResult.java
@@ -1,0 +1,20 @@
+package io.apitomy.axiom.core.filters;
+
+/**
+ * Result of evaluating an event against a filter configuration.
+ *
+ * @param allowed     true if the event passes the filter
+ * @param matchedRule human-readable description of the rule that matched, or null if allowed
+ */
+public record FilterResult(boolean allowed, String matchedRule) {
+
+    /** An event that passed all filters. */
+    public static final FilterResult ALLOWED = new FilterResult(true, null);
+
+    /**
+     * Creates a blocked result with a description of the matched rule.
+     */
+    public static FilterResult blocked(String matchedRule) {
+        return new FilterResult(false, matchedRule);
+    }
+}

--- a/core/src/test/java/io/apitomy/axiom/core/filters/EventFilterEvaluatorTest.java
+++ b/core/src/test/java/io/apitomy/axiom/core/filters/EventFilterEvaluatorTest.java
@@ -1,0 +1,181 @@
+package io.apitomy.axiom.core.filters;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EventFilterEvaluatorTest {
+
+    private final EventFilterEvaluator evaluator = new EventFilterEvaluator();
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    // --- Include rules ---
+
+    @Test
+    void emptyIncludeAllowsAllEventTypes() {
+        EventSourceFilters filters = new EventSourceFilters(List.of(), List.of());
+        FilterResult result = evaluator.evaluate(filters, "issue-created", mapper.createObjectNode());
+        assertTrue(result.allowed());
+    }
+
+    @Test
+    void includeEventTypeAllowsMatchingEvent() {
+        EventSourceFilters filters = new EventSourceFilters(
+                List.of(new EventSourceFilterRule("event-type", null, "issue-*")),
+                List.of());
+        FilterResult result = evaluator.evaluate(filters, "issue-created", mapper.createObjectNode());
+        assertTrue(result.allowed());
+    }
+
+    @Test
+    void includeEventTypeBlocksNonMatchingEvent() {
+        EventSourceFilters filters = new EventSourceFilters(
+                List.of(new EventSourceFilterRule("event-type", null, "issue-*")),
+                List.of());
+        FilterResult result = evaluator.evaluate(filters, "pr-created", mapper.createObjectNode());
+        assertFalse(result.allowed());
+        assertNotNull(result.matchedRule());
+    }
+
+    @Test
+    void includePayloadRuleAllowsMatchingPayload() {
+        EventSourceFilters filters = new EventSourceFilters(
+                List.of(new EventSourceFilterRule("payload", "/action", "opened")),
+                List.of());
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("action", "opened");
+        FilterResult result = evaluator.evaluate(filters, "issue-created", payload);
+        assertTrue(result.allowed());
+    }
+
+    @Test
+    void includePayloadRuleBlocksNonMatchingPayload() {
+        EventSourceFilters filters = new EventSourceFilters(
+                List.of(new EventSourceFilterRule("payload", "/action", "opened")),
+                List.of());
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("action", "closed");
+        FilterResult result = evaluator.evaluate(filters, "issue-created", payload);
+        assertFalse(result.allowed());
+    }
+
+    // --- Exclude rules ---
+
+    @Test
+    void excludeEventTypeBlocksMatchingEvent() {
+        EventSourceFilters filters = new EventSourceFilters(
+                List.of(),
+                List.of(new EventSourceFilterRule("event-type", null, "comment-added")));
+        FilterResult result = evaluator.evaluate(filters, "comment-added", mapper.createObjectNode());
+        assertFalse(result.allowed());
+        assertTrue(result.matchedRule().contains("comment-added"));
+    }
+
+    @Test
+    void excludePayloadRuleBlocksBotLogin() {
+        EventSourceFilters filters = new EventSourceFilters(
+                List.of(),
+                List.of(new EventSourceFilterRule("payload", "/user/login", "*[bot]")));
+        ObjectNode payload = mapper.createObjectNode();
+        payload.putObject("user").put("login", "dependabot[bot]");
+        FilterResult result = evaluator.evaluate(filters, "issue-created", payload);
+        assertFalse(result.allowed());
+        assertTrue(result.matchedRule().contains("/user/login"));
+    }
+
+    @Test
+    void excludePayloadRuleAllowsNonMatchingValue() {
+        EventSourceFilters filters = new EventSourceFilters(
+                List.of(),
+                List.of(new EventSourceFilterRule("payload", "/user/login", "*[bot]")));
+        ObjectNode payload = mapper.createObjectNode();
+        payload.putObject("user").put("login", "octocat");
+        FilterResult result = evaluator.evaluate(filters, "issue-created", payload);
+        assertTrue(result.allowed());
+    }
+
+    @Test
+    void excludeSlashCommandBlocksCommentStartingWithSlash() {
+        EventSourceFilters filters = new EventSourceFilters(
+                List.of(),
+                List.of(new EventSourceFilterRule("payload", "/comment/body", "/*")));
+        ObjectNode payload = mapper.createObjectNode();
+        payload.putObject("comment").put("body", "/ready");
+        FilterResult result = evaluator.evaluate(filters, "comment-added", payload);
+        assertFalse(result.allowed());
+    }
+
+    // --- Combined include + exclude ---
+
+    @Test
+    void excludeOverridesInclude() {
+        EventSourceFilters filters = new EventSourceFilters(
+                List.of(new EventSourceFilterRule("event-type", null, "issue-*")),
+                List.of(new EventSourceFilterRule("payload", "/user/login", "*[bot]")));
+        ObjectNode payload = mapper.createObjectNode();
+        payload.putObject("user").put("login", "dependabot[bot]");
+        FilterResult result = evaluator.evaluate(filters, "issue-created", payload);
+        assertFalse(result.allowed());
+    }
+
+    // --- Edge cases ---
+
+    @Test
+    void missingPointerFieldDoesNotMatch() {
+        EventSourceFilters filters = new EventSourceFilters(
+                List.of(),
+                List.of(new EventSourceFilterRule("payload", "/nonexistent/field", "*")));
+        FilterResult result = evaluator.evaluate(filters, "issue-created", mapper.createObjectNode());
+        assertTrue(result.allowed());
+    }
+
+    @Test
+    void nullFiltersAllowsAllEvents() {
+        FilterResult result = evaluator.evaluate(null, "issue-created", mapper.createObjectNode());
+        assertTrue(result.allowed());
+    }
+
+    @Test
+    void nullPayloadWithPayloadRuleDoesNotMatch() {
+        EventSourceFilters filters = new EventSourceFilters(
+                List.of(),
+                List.of(new EventSourceFilterRule("payload", "/user/login", "*")));
+        FilterResult result = evaluator.evaluate(filters, "issue-created", null);
+        assertTrue(result.allowed());
+    }
+
+    @Test
+    void questionMarkWildcardMatchesSingleCharacter() {
+        EventSourceFilters filters = new EventSourceFilters(
+                List.of(new EventSourceFilterRule("event-type", null, "pr-c????d")),
+                List.of());
+        assertTrue(evaluator.evaluate(filters, "pr-closed", mapper.createObjectNode()).allowed());
+        assertFalse(evaluator.evaluate(filters, "pr-created", mapper.createObjectNode()).allowed());
+    }
+
+    @Test
+    void exactMatchWithNoWildcards() {
+        EventSourceFilters filters = new EventSourceFilters(
+                List.of(new EventSourceFilterRule("event-type", null, "pr-merged")),
+                List.of());
+        assertTrue(evaluator.evaluate(filters, "pr-merged", mapper.createObjectNode()).allowed());
+        assertFalse(evaluator.evaluate(filters, "pr-created", mapper.createObjectNode()).allowed());
+    }
+
+    @Test
+    void multipleIncludeRulesAnyCanMatch() {
+        EventSourceFilters filters = new EventSourceFilters(
+                List.of(
+                        new EventSourceFilterRule("event-type", null, "issue-created"),
+                        new EventSourceFilterRule("event-type", null, "pr-created")),
+                List.of());
+        assertTrue(evaluator.evaluate(filters, "issue-created", mapper.createObjectNode()).allowed());
+        assertTrue(evaluator.evaluate(filters, "pr-created", mapper.createObjectNode()).allowed());
+        assertFalse(evaluator.evaluate(filters, "comment-added", mapper.createObjectNode()).allowed());
+    }
+}

--- a/docs/superpowers/plans/2026-08-07-event-source-filtering.md
+++ b/docs/superpowers/plans/2026-08-07-event-source-filtering.md
@@ -1,0 +1,1673 @@
+# Event Source Filtering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace hardcoded event pre-filters with user-configurable per-event-source
+include/exclude filtering, plus a dry-run endpoint for previewing filter behavior against live
+source data.
+
+**Architecture:** Filters are stored as a JSON column on `event_source`, evaluated post-ingest
+in `PipelineOrchestrator` before the AI Manager call. A shared `EventFilterEvaluator` in `core`
+handles glob-based rule matching. A dry-run endpoint fetches live events from the source API,
+classifies them using extracted poller logic, and returns filter verdicts. The frontend adds a
+Filters tab to the event source detail page with rule editing and dry-run preview.
+
+**Tech Stack:** Java 25, Quarkus 3.33, Panache (Active Record), Jackson, JUnit 5, React 19,
+PatternFly 6, TypeScript
+
+**Design Spec:**
+`docs/superpowers/specs/2026-08-07-event-source-filtering-design.md`
+
+**GitHub Issue:** #127
+
+## Global Constraints
+
+- Contract-first: all REST API changes start in `common/api/src/main/resources/openapi.json`,
+  then `mvn install` (or `build.sh`) generates JAX-RS interfaces and beans into
+  `common/api/target/generated-sources/jaxrs/`
+- Generated beans live in `io.apitomy.axiom.api.beans`
+- REST impl classes in `app/src/main/java/.../rest/` implement the generated interface — never
+  add `@Path` annotations directly on impls
+- Entities use Panache Active Record pattern (public fields, `PanacheEntity` base)
+- 4-space indentation, explicit types, camelCase variables, PascalCase classes
+- Javadoc on all public methods
+- JUnit 5 for tests
+- No Claude attribution in commits
+
+## File Map
+
+### New Files
+
+| File | Module | Purpose |
+|------|--------|---------|
+| `core/src/main/java/.../core/filters/EventSourceFilterRule.java` | core | Filter rule record |
+| `core/src/main/java/.../core/filters/EventSourceFilters.java` | core | Include/exclude filter container |
+| `core/src/main/java/.../core/filters/FilterResult.java` | core | Evaluation result record |
+| `core/src/main/java/.../core/filters/EventFilterEvaluator.java` | core | Filter evaluation logic |
+| `core/src/test/java/.../core/filters/EventFilterEvaluatorTest.java` | core | Unit tests for evaluator |
+| `app/src/main/resources/db/migration/V34__add_event_source_filters.sql` | app | DB migration |
+| `events/github/src/main/java/.../github/GitHubEventClassifier.java` | events/github | Extracted classify/wrap logic |
+| `events/github/src/main/java/.../github/GitHubDryRunService.java` | events/github | Dry-run fetch+classify for GitHub |
+| `events/jira/src/main/java/.../jira/JiraEventClassifier.java` | events/jira | Extracted classify/wrap logic |
+| `events/jira/src/main/java/.../jira/JiraDryRunService.java` | events/jira | Dry-run fetch+classify for Jira |
+| `events/core/src/main/java/.../events/core/DryRunEvent.java` | events/core | Shared dry-run event record |
+
+(All paths relative to project root. Package prefix: `io.apitomy.axiom`)
+
+### Modified Files
+
+| File | Module | Changes |
+|------|--------|---------|
+| `common/api/src/main/resources/openapi.json` | common/api | New schemas + endpoint |
+| `core/src/main/java/.../core/entities/EventSourceEntity.java` | core | Add `filters` field |
+| `app/src/main/java/.../app/rest/EventSourcesResourceImpl.java` | app | Filters serialization + dry-run impl |
+| `app/src/main/java/.../app/PipelineOrchestrator.java` | app | Replace `shouldSkipEvent()` |
+| `events/github/src/main/java/.../github/GitHubPoller.java` | events/github | Delegate to classifier |
+| `events/jira/src/main/java/.../jira/JiraPoller.java` | events/jira | Delegate to classifier |
+| `ui/src/config/api.ts` | ui | Filter types + dry-run API call |
+| `ui/src/pages/EventSourceDetailPage.tsx` | ui | Add Filters tab |
+
+---
+
+### Task 1: OpenAPI Schema and Endpoint Definitions
+
+**Files:**
+- Modify: `common/api/src/main/resources/openapi.json`
+
+**Interfaces:**
+- Consumes: nothing
+- Produces: `EventSourceFilterRule`, `EventSourceFilters`, `FilterDryRunRequest`,
+  `FilterDryRunResponse`, `FilterDryRunResult` schemas; `filters` property on `EventSource`
+  and `NewEventSource`; `POST /event-sources/filters/dry-run` endpoint. After `mvn install`,
+  generates corresponding Java beans and adds `dryRunFilters()` to the `EventResource`
+  interface.
+
+- [ ] **Step 1: Add `EventSourceFilterRule` schema**
+
+In `openapi.json`, in the `components.schemas` section (after the last schema `NewDashboard`
+around line 7428), add:
+
+```json
+"EventSourceFilterRule": {
+    "required": [
+        "type",
+        "pattern"
+    ],
+    "type": "object",
+    "properties": {
+        "type": {
+            "description": "What the rule matches against: event-type or payload field",
+            "enum": [
+                "event-type",
+                "payload"
+            ],
+            "type": "string"
+        },
+        "pointer": {
+            "description": "JSON Pointer (RFC 6901) to the payload field. Required when type is payload.",
+            "type": "string"
+        },
+        "pattern": {
+            "description": "Glob pattern to match against. Supports * (any sequence) and ? (any single character) wildcards.",
+            "type": "string"
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add `EventSourceFilters` schema**
+
+Immediately after `EventSourceFilterRule`:
+
+```json
+"EventSourceFilters": {
+    "type": "object",
+    "properties": {
+        "include": {
+            "description": "Rules for events to include. An empty list means allow all event types.",
+            "type": "array",
+            "items": {
+                "$ref": "#/components/schemas/EventSourceFilterRule"
+            }
+        },
+        "exclude": {
+            "description": "Rules for events to exclude. Applied after include rules.",
+            "type": "array",
+            "items": {
+                "$ref": "#/components/schemas/EventSourceFilterRule"
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Add `filters` property to `EventSource` schema**
+
+In the `EventSource` schema properties (around line 4970, after the `labels` property), add:
+
+```json
+"filters": {
+    "$ref": "#/components/schemas/EventSourceFilters"
+}
+```
+
+- [ ] **Step 4: Add `filters` property to `NewEventSource` schema**
+
+In the `NewEventSource` schema properties (around line 5015, after the `labels` property), add
+the same:
+
+```json
+"filters": {
+    "$ref": "#/components/schemas/EventSourceFilters"
+}
+```
+
+- [ ] **Step 5: Add dry-run request/response schemas**
+
+After `EventSourceFilters`, add:
+
+```json
+"FilterDryRunRequest": {
+    "required": [
+        "sourceType",
+        "configuration",
+        "filters"
+    ],
+    "type": "object",
+    "properties": {
+        "sourceType": {
+            "enum": [
+                "github",
+                "jira"
+            ],
+            "type": "string"
+        },
+        "configuration": {
+            "description": "Source-specific configuration (same shape as EventSource.configuration)",
+            "type": "object",
+            "additionalProperties": {}
+        },
+        "secretName": {
+            "description": "Name of the secret to use for authentication",
+            "type": "string"
+        },
+        "filters": {
+            "$ref": "#/components/schemas/EventSourceFilters"
+        }
+    }
+},
+"FilterDryRunResponse": {
+    "type": "object",
+    "properties": {
+        "results": {
+            "type": "array",
+            "items": {
+                "$ref": "#/components/schemas/FilterDryRunResult"
+            }
+        },
+        "totalEvaluated": {
+            "type": "integer"
+        },
+        "totalAllowed": {
+            "type": "integer"
+        },
+        "totalBlocked": {
+            "type": "integer"
+        }
+    }
+},
+"FilterDryRunResult": {
+    "type": "object",
+    "properties": {
+        "eventType": {
+            "type": "string"
+        },
+        "issueRef": {
+            "type": "string"
+        },
+        "summary": {
+            "description": "Human-readable summary of the event (e.g. issue title, comment author)",
+            "type": "string"
+        },
+        "allowed": {
+            "type": "boolean"
+        },
+        "matchedRule": {
+            "description": "Description of the filter rule that matched, if blocked",
+            "type": "string"
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Add dry-run endpoint**
+
+In the `paths` section, add a new path. Place it near the other event-source endpoints (after
+`/event-sources/{eventSourceId}/logs`, around line 2865):
+
+```json
+"/event-sources/filters/dry-run": {
+    "post": {
+        "tags": [
+            "EventSources"
+        ],
+        "summary": "Test filter configuration against live events",
+        "description": "Fetches recent events from the source API and evaluates the provided filter configuration against them. No events are ingested. Use this to preview what filters would allow or block before saving.",
+        "operationId": "dryRunFilters",
+        "requestBody": {
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "$ref": "#/components/schemas/FilterDryRunRequest"
+                    }
+                }
+            },
+            "required": true
+        },
+        "responses": {
+            "200": {
+                "description": "Dry run results",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/FilterDryRunResponse"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 7: Build to generate code**
+
+Run `mvn install` (or `build.sh`) from the project root. This generates:
+- `EventSourceFilterRule.java`, `EventSourceFilters.java` beans in
+  `io.apitomy.axiom.api.beans`
+- `FilterDryRunRequest.java`, `FilterDryRunResponse.java`, `FilterDryRunResult.java` beans
+- Updated `EventSource.java` and `NewEventSource.java` beans with `getFilters()`/`setFilters()`
+- Updated `EventResource.java` interface with `dryRunFilters()` method
+
+Verify the generated files exist in `common/api/target/generated-sources/jaxrs/`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add common/api/src/main/resources/openapi.json
+git commit -m "feat(api): add event source filter schemas and dry-run endpoint (#127)"
+```
+
+---
+
+### Task 2: Core Filter Model and Evaluator
+
+**Files:**
+- Create: `core/src/main/java/io/apitomy/axiom/core/filters/EventSourceFilterRule.java`
+- Create: `core/src/main/java/io/apitomy/axiom/core/filters/EventSourceFilters.java`
+- Create: `core/src/main/java/io/apitomy/axiom/core/filters/FilterResult.java`
+- Create: `core/src/main/java/io/apitomy/axiom/core/filters/EventFilterEvaluator.java`
+- Create: `core/src/test/java/io/apitomy/axiom/core/filters/EventFilterEvaluatorTest.java`
+
+**Interfaces:**
+- Consumes: nothing
+- Produces: `EventFilterEvaluator.evaluate(EventSourceFilters, String, JsonNode): FilterResult`
+  used by Task 4 (`PipelineOrchestrator`) and Task 5 (dry-run endpoint)
+
+- [ ] **Step 1: Write `EventSourceFilterRule` record**
+
+```java
+package io.apitomy.axiom.core.filters;
+
+/**
+ * A single filter rule that matches either an event type or a payload field value.
+ *
+ * @param type    "event-type" or "payload"
+ * @param pointer JSON Pointer (RFC 6901) path into the payload; required when type is "payload"
+ * @param pattern glob pattern with * and ? wildcards
+ */
+public record EventSourceFilterRule(String type, String pointer, String pattern) {
+}
+```
+
+- [ ] **Step 2: Write `EventSourceFilters` record**
+
+```java
+package io.apitomy.axiom.core.filters;
+
+import java.util.List;
+
+/**
+ * Include/exclude filter configuration for an event source.
+ *
+ * @param include rules for events to include (empty list means allow all)
+ * @param exclude rules for events to exclude (applied after include)
+ */
+public record EventSourceFilters(List<EventSourceFilterRule> include,
+                                  List<EventSourceFilterRule> exclude) {
+
+    /**
+     * Returns an empty filters instance that allows all events.
+     */
+    public static EventSourceFilters allowAll() {
+        return new EventSourceFilters(List.of(), List.of());
+    }
+}
+```
+
+- [ ] **Step 3: Write `FilterResult` record**
+
+```java
+package io.apitomy.axiom.core.filters;
+
+/**
+ * Result of evaluating an event against a filter configuration.
+ *
+ * @param allowed     true if the event passes the filter
+ * @param matchedRule human-readable description of the rule that matched, or null if allowed
+ */
+public record FilterResult(boolean allowed, String matchedRule) {
+
+    /** An event that passed all filters. */
+    public static final FilterResult ALLOWED = new FilterResult(true, null);
+
+    /**
+     * Creates a blocked result with a description of the matched rule.
+     */
+    public static FilterResult blocked(String matchedRule) {
+        return new FilterResult(false, matchedRule);
+    }
+}
+```
+
+- [ ] **Step 4: Write failing tests for `EventFilterEvaluator`**
+
+```java
+package io.apitomy.axiom.core.filters;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EventFilterEvaluatorTest {
+
+    private final EventFilterEvaluator evaluator = new EventFilterEvaluator();
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    // --- Include rules ---
+
+    @Test
+    void emptyIncludeAllowsAllEventTypes() {
+        EventSourceFilters filters = new EventSourceFilters(List.of(), List.of());
+        FilterResult result = evaluator.evaluate(filters, "issue-created", mapper.createObjectNode());
+        assertTrue(result.allowed());
+    }
+
+    @Test
+    void includeEventTypeAllowsMatchingEvent() {
+        EventSourceFilters filters = new EventSourceFilters(
+                List.of(new EventSourceFilterRule("event-type", null, "issue-*")),
+                List.of());
+        FilterResult result = evaluator.evaluate(filters, "issue-created", mapper.createObjectNode());
+        assertTrue(result.allowed());
+    }
+
+    @Test
+    void includeEventTypeBlocksNonMatchingEvent() {
+        EventSourceFilters filters = new EventSourceFilters(
+                List.of(new EventSourceFilterRule("event-type", null, "issue-*")),
+                List.of());
+        FilterResult result = evaluator.evaluate(filters, "pr-created", mapper.createObjectNode());
+        assertFalse(result.allowed());
+        assertNotNull(result.matchedRule());
+    }
+
+    @Test
+    void includePayloadRuleAllowsMatchingPayload() {
+        EventSourceFilters filters = new EventSourceFilters(
+                List.of(new EventSourceFilterRule("payload", "/action", "opened")),
+                List.of());
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("action", "opened");
+        FilterResult result = evaluator.evaluate(filters, "issue-created", payload);
+        assertTrue(result.allowed());
+    }
+
+    @Test
+    void includePayloadRuleBlocksNonMatchingPayload() {
+        EventSourceFilters filters = new EventSourceFilters(
+                List.of(new EventSourceFilterRule("payload", "/action", "opened")),
+                List.of());
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("action", "closed");
+        FilterResult result = evaluator.evaluate(filters, "issue-created", payload);
+        assertFalse(result.allowed());
+    }
+
+    // --- Exclude rules ---
+
+    @Test
+    void excludeEventTypeBlocksMatchingEvent() {
+        EventSourceFilters filters = new EventSourceFilters(
+                List.of(),
+                List.of(new EventSourceFilterRule("event-type", null, "comment-added")));
+        FilterResult result = evaluator.evaluate(filters, "comment-added", mapper.createObjectNode());
+        assertFalse(result.allowed());
+        assertTrue(result.matchedRule().contains("comment-added"));
+    }
+
+    @Test
+    void excludePayloadRuleBlocksBotLogin() {
+        EventSourceFilters filters = new EventSourceFilters(
+                List.of(),
+                List.of(new EventSourceFilterRule("payload", "/user/login", "*[bot]")));
+        ObjectNode payload = mapper.createObjectNode();
+        payload.putObject("user").put("login", "dependabot[bot]");
+        FilterResult result = evaluator.evaluate(filters, "issue-created", payload);
+        assertFalse(result.allowed());
+        assertTrue(result.matchedRule().contains("/user/login"));
+    }
+
+    @Test
+    void excludePayloadRuleAllowsNonMatchingValue() {
+        EventSourceFilters filters = new EventSourceFilters(
+                List.of(),
+                List.of(new EventSourceFilterRule("payload", "/user/login", "*[bot]")));
+        ObjectNode payload = mapper.createObjectNode();
+        payload.putObject("user").put("login", "octocat");
+        FilterResult result = evaluator.evaluate(filters, "issue-created", payload);
+        assertTrue(result.allowed());
+    }
+
+    @Test
+    void excludeSlashCommandBlocksCommentStartingWithSlash() {
+        EventSourceFilters filters = new EventSourceFilters(
+                List.of(),
+                List.of(new EventSourceFilterRule("payload", "/comment/body", "/*")));
+        ObjectNode payload = mapper.createObjectNode();
+        payload.putObject("comment").put("body", "/ready");
+        FilterResult result = evaluator.evaluate(filters, "comment-added", payload);
+        assertFalse(result.allowed());
+    }
+
+    // --- Combined include + exclude ---
+
+    @Test
+    void excludeOverridesInclude() {
+        EventSourceFilters filters = new EventSourceFilters(
+                List.of(new EventSourceFilterRule("event-type", null, "issue-*")),
+                List.of(new EventSourceFilterRule("payload", "/user/login", "*[bot]")));
+        ObjectNode payload = mapper.createObjectNode();
+        payload.putObject("user").put("login", "dependabot[bot]");
+        FilterResult result = evaluator.evaluate(filters, "issue-created", payload);
+        assertFalse(result.allowed());
+    }
+
+    // --- Edge cases ---
+
+    @Test
+    void missingPointerFieldDoesNotMatch() {
+        EventSourceFilters filters = new EventSourceFilters(
+                List.of(),
+                List.of(new EventSourceFilterRule("payload", "/nonexistent/field", "*")));
+        FilterResult result = evaluator.evaluate(filters, "issue-created", mapper.createObjectNode());
+        assertTrue(result.allowed());
+    }
+
+    @Test
+    void nullFiltersAllowsAllEvents() {
+        FilterResult result = evaluator.evaluate(null, "issue-created", mapper.createObjectNode());
+        assertTrue(result.allowed());
+    }
+
+    @Test
+    void nullPayloadWithPayloadRuleDoesNotMatch() {
+        EventSourceFilters filters = new EventSourceFilters(
+                List.of(),
+                List.of(new EventSourceFilterRule("payload", "/user/login", "*")));
+        FilterResult result = evaluator.evaluate(filters, "issue-created", null);
+        assertTrue(result.allowed());
+    }
+
+    @Test
+    void questionMarkWildcardMatchesSingleCharacter() {
+        EventSourceFilters filters = new EventSourceFilters(
+                List.of(new EventSourceFilterRule("event-type", null, "pr-c????d")),
+                List.of());
+        assertTrue(evaluator.evaluate(filters, "pr-closed", mapper.createObjectNode()).allowed());
+        assertFalse(evaluator.evaluate(filters, "pr-created", mapper.createObjectNode()).allowed());
+    }
+
+    @Test
+    void exactMatchWithNoWildcards() {
+        EventSourceFilters filters = new EventSourceFilters(
+                List.of(new EventSourceFilterRule("event-type", null, "pr-merged")),
+                List.of());
+        assertTrue(evaluator.evaluate(filters, "pr-merged", mapper.createObjectNode()).allowed());
+        assertFalse(evaluator.evaluate(filters, "pr-created", mapper.createObjectNode()).allowed());
+    }
+
+    @Test
+    void multipleIncludeRulesAnyCanMatch() {
+        EventSourceFilters filters = new EventSourceFilters(
+                List.of(
+                        new EventSourceFilterRule("event-type", null, "issue-created"),
+                        new EventSourceFilterRule("event-type", null, "pr-created")),
+                List.of());
+        assertTrue(evaluator.evaluate(filters, "issue-created", mapper.createObjectNode()).allowed());
+        assertTrue(evaluator.evaluate(filters, "pr-created", mapper.createObjectNode()).allowed());
+        assertFalse(evaluator.evaluate(filters, "comment-added", mapper.createObjectNode()).allowed());
+    }
+}
+```
+
+- [ ] **Step 5: Implement `EventFilterEvaluator`**
+
+```java
+package io.apitomy.axiom.core.filters;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Evaluates events against a set of include/exclude filter rules.
+ */
+@ApplicationScoped
+public class EventFilterEvaluator {
+
+    /**
+     * Evaluates an event against the given filter configuration.
+     *
+     * <p>If filters is null or has empty include/exclude lists, all events pass.
+     * Otherwise, include rules are checked first (event must match at least one),
+     * then exclude rules (any match blocks the event).
+     *
+     * @param filters   the filter configuration (may be null)
+     * @param eventType the event type string (e.g. "issue-created")
+     * @param payload   the parsed event payload JSON (may be null)
+     * @return the evaluation result
+     */
+    public FilterResult evaluate(EventSourceFilters filters, String eventType, JsonNode payload) {
+        if (filters == null) {
+            return FilterResult.ALLOWED;
+        }
+
+        List<EventSourceFilterRule> includeRules = filters.include() != null ? filters.include() : List.of();
+        List<EventSourceFilterRule> excludeRules = filters.exclude() != null ? filters.exclude() : List.of();
+
+        if (!includeRules.isEmpty()) {
+            boolean matched = includeRules.stream()
+                    .anyMatch(rule -> ruleMatches(rule, eventType, payload));
+            if (!matched) {
+                return FilterResult.blocked("no include rule matched for event type: " + eventType);
+            }
+        }
+
+        for (EventSourceFilterRule rule : excludeRules) {
+            if (ruleMatches(rule, eventType, payload)) {
+                return FilterResult.blocked(describeRule("exclude", rule));
+            }
+        }
+
+        return FilterResult.ALLOWED;
+    }
+
+    private boolean ruleMatches(EventSourceFilterRule rule, String eventType, JsonNode payload) {
+        if ("event-type".equals(rule.type())) {
+            return matchesWildcard(eventType, rule.pattern());
+        } else if ("payload".equals(rule.type())) {
+            if (payload == null || rule.pointer() == null) {
+                return false;
+            }
+            JsonNode node = payload.at(rule.pointer());
+            if (node.isMissingNode() || node.isNull()) {
+                return false;
+            }
+            return matchesWildcard(node.asText(), rule.pattern());
+        }
+        return false;
+    }
+
+    private String describeRule(String phase, EventSourceFilterRule rule) {
+        if ("event-type".equals(rule.type())) {
+            return phase + " event-type " + rule.pattern();
+        }
+        return phase + " payload " + rule.pointer() + " matched " + rule.pattern();
+    }
+
+    static boolean matchesWildcard(String value, String pattern) {
+        if (value == null || pattern == null) {
+            return false;
+        }
+        StringBuilder regex = new StringBuilder("^");
+        for (char c : pattern.toCharArray()) {
+            switch (c) {
+                case '*' -> regex.append(".*");
+                case '?' -> regex.append(".");
+                default -> regex.append(Pattern.quote(String.valueOf(c)));
+            }
+        }
+        regex.append("$");
+        return Pattern.compile(regex.toString()).matcher(value).matches();
+    }
+}
+```
+
+- [ ] **Step 6: Verify tests pass**
+
+```bash
+mvn test -pl core -Dtest=EventFilterEvaluatorTest
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/src/main/java/io/apitomy/axiom/core/filters/ \
+        core/src/test/java/io/apitomy/axiom/core/filters/
+git commit -m "feat(core): add EventFilterEvaluator with wildcard matching (#127)"
+```
+
+---
+
+### Task 3: Database Migration and Entity Update
+
+**Files:**
+- Create: `app/src/main/resources/db/migration/V34__add_event_source_filters.sql`
+- Modify: `core/src/main/java/io/apitomy/axiom/core/entities/EventSourceEntity.java`
+
+**Interfaces:**
+- Consumes: nothing
+- Produces: `EventSourceEntity.filters` field (String, JSON), used by Task 4 (REST layer,
+  PipelineOrchestrator)
+
+- [ ] **Step 1: Create migration V34**
+
+```sql
+-- Add filters column to event_source table
+ALTER TABLE event_source ADD COLUMN filters TEXT;
+
+-- Populate all existing event sources with default filter rules
+-- These defaults replace the hardcoded shouldSkipEvent() logic:
+--   *[bot] login suffix -> bot filter
+--   /* comment body -> slash command filter
+UPDATE event_source SET filters =
+    '{"include":[],"exclude":['
+    || '{"type":"payload","pointer":"/user/login","pattern":"*[bot]"},'
+    || '{"type":"payload","pointer":"/comment/user/login","pattern":"*[bot]"},'
+    || '{"type":"payload","pointer":"/comment/body","pattern":"/*"}'
+    || ']}';
+```
+
+- [ ] **Step 2: Add `filters` field to `EventSourceEntity`**
+
+In `EventSourceEntity.java`, add a new field after the `configuration` field:
+
+```java
+@Column(columnDefinition = "TEXT")
+public String filters;
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/resources/db/migration/V34__add_event_source_filters.sql \
+        core/src/main/java/io/apitomy/axiom/core/entities/EventSourceEntity.java
+git commit -m "feat(db): add filters column to event_source with defaults (#127)"
+```
+
+---
+
+### Task 4: Backend Integration (REST Layer + PipelineOrchestrator)
+
+**Files:**
+- Modify: `app/src/main/java/io/apitomy/axiom/app/rest/EventSourcesResourceImpl.java`
+- Modify: `app/src/main/java/io/apitomy/axiom/app/PipelineOrchestrator.java`
+
+**Interfaces:**
+- Consumes: `EventFilterEvaluator.evaluate()` from Task 2,
+  `EventSourceEntity.filters` from Task 3,
+  generated `EventSourceFilters`/`EventSourceFilterRule` beans from Task 1
+- Produces: filters round-trip through REST API; events filtered in the pipeline with
+  activity log entries showing matched rule detail
+
+- [ ] **Step 1: Update `applyFields()` in `EventSourcesResourceImpl`**
+
+Add filters serialization after the labels handling (around line 113):
+
+```java
+if (data.getFilters() != null) {
+    try {
+        entity.filters = objectMapper.writeValueAsString(data.getFilters());
+    } catch (Exception e) {
+        entity.filters = null;
+    }
+} else {
+    entity.filters = null;
+}
+```
+
+- [ ] **Step 2: Update `toBean()` in `EventSourcesResourceImpl`**
+
+Add filters deserialization after the labels line (around line 155):
+
+```java
+if (entity.filters != null) {
+    try {
+        bean.setFilters(objectMapper.readValue(entity.filters,
+                io.apitomy.axiom.api.beans.EventSourceFilters.class));
+    } catch (Exception e) {
+        // ignore parse errors
+    }
+}
+```
+
+- [ ] **Step 3: Update `createEventSource()` to apply default filters**
+
+In the `createEventSource()` method, after calling `applyFields(entity, data)`, add logic to
+set default filters if none were provided:
+
+```java
+if (entity.filters == null) {
+    try {
+        entity.filters = objectMapper.writeValueAsString(defaultFilters());
+    } catch (Exception e) {
+        entity.filters = null;
+    }
+}
+```
+
+Add a private helper method that builds the default filters object:
+
+```java
+private io.apitomy.axiom.api.beans.EventSourceFilters defaultFilters() {
+    io.apitomy.axiom.api.beans.EventSourceFilters filters = new io.apitomy.axiom.api.beans.EventSourceFilters();
+    filters.setInclude(List.of());
+
+    io.apitomy.axiom.api.beans.EventSourceFilterRule botRule = new io.apitomy.axiom.api.beans.EventSourceFilterRule();
+    botRule.setType(io.apitomy.axiom.api.beans.EventSourceFilterRule.Type.payload);
+    botRule.setPointer("/user/login");
+    botRule.setPattern("*[bot]");
+
+    io.apitomy.axiom.api.beans.EventSourceFilterRule commentBotRule = new io.apitomy.axiom.api.beans.EventSourceFilterRule();
+    commentBotRule.setType(io.apitomy.axiom.api.beans.EventSourceFilterRule.Type.payload);
+    commentBotRule.setPointer("/comment/user/login");
+    commentBotRule.setPattern("*[bot]");
+
+    io.apitomy.axiom.api.beans.EventSourceFilterRule slashRule = new io.apitomy.axiom.api.beans.EventSourceFilterRule();
+    slashRule.setType(io.apitomy.axiom.api.beans.EventSourceFilterRule.Type.payload);
+    slashRule.setPointer("/comment/body");
+    slashRule.setPattern("/*");
+
+    filters.setExclude(List.of(botRule, commentBotRule, slashRule));
+    return filters;
+}
+```
+
+Note: The exact generated bean class names and setter methods depend on the codegen output.
+Verify the generated `EventSourceFilterRule` and `EventSourceFilters` classes after Task 1's
+build step and adjust accordingly.
+
+- [ ] **Step 4: Replace `shouldSkipEvent()` in `PipelineOrchestrator`**
+
+Add an `@Inject` field at the top of `PipelineOrchestrator`:
+
+```java
+@Inject
+EventFilterEvaluator filterEvaluator;
+```
+
+Add the import:
+
+```java
+import io.apitomy.axiom.core.filters.EventFilterEvaluator;
+import io.apitomy.axiom.core.filters.EventSourceFilters;
+import io.apitomy.axiom.core.filters.FilterResult;
+```
+
+- [ ] **Step 5: Replace the pre-filter block in `processEvent()`**
+
+Replace the block at lines 174-183 (the `shouldSkipEvent` call and its handling) with:
+
+```java
+FilterResult filterResult = evaluateFilters(event);
+if (!filterResult.allowed()) {
+    LOG.infof("Pre-filtered event %d: %s", event.id, filterResult.matchedRule());
+    QuarkusTransaction.requiringNew().run(() -> {
+        logActivity(null, null, event.id, "event-pre-filtered",
+                "Event pre-filtered: " + event.eventType + " — " + filterResult.matchedRule());
+        markQueueEntry(queueEntryId, "completed");
+    });
+    return;
+}
+```
+
+Add a private `evaluateFilters` method:
+
+```java
+private FilterResult evaluateFilters(EventEntity event) {
+    if (event.eventSourceId == null) {
+        return FilterResult.ALLOWED;
+    }
+    EventSourceEntity source = EventSourceEntity.findById(event.eventSourceId);
+    if (source == null || source.filters == null) {
+        return FilterResult.ALLOWED;
+    }
+    try {
+        EventSourceFilters filters = objectMapper.readValue(source.filters, EventSourceFilters.class);
+        JsonNode payload = objectMapper.readTree(event.payload);
+        return filterEvaluator.evaluate(filters, event.eventType, payload);
+    } catch (Exception e) {
+        LOG.warnf("Failed to evaluate filters for event %d: %s", event.id, e.getMessage());
+        return FilterResult.ALLOWED;
+    }
+}
+```
+
+- [ ] **Step 6: Delete `shouldSkipEvent()` and `SLASH_COMMANDS`**
+
+Remove the `SLASH_COMMANDS` constant (lines 45-48) and the entire `shouldSkipEvent()` method
+(lines 110-144) from `PipelineOrchestrator`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/src/main/java/io/apitomy/axiom/app/rest/EventSourcesResourceImpl.java \
+        app/src/main/java/io/apitomy/axiom/app/PipelineOrchestrator.java
+git commit -m "feat(app): wire filter evaluator into REST layer and pipeline (#127)"
+```
+
+---
+
+### Task 5: Dry-Run Backend
+
+**Files:**
+- Create: `events/github/src/main/java/io/apitomy/axiom/events/github/GitHubEventClassifier.java`
+- Create: `events/github/src/main/java/io/apitomy/axiom/events/github/GitHubDryRunService.java`
+- Create: `events/jira/src/main/java/io/apitomy/axiom/events/jira/JiraEventClassifier.java`
+- Create: `events/jira/src/main/java/io/apitomy/axiom/events/jira/JiraDryRunService.java`
+- Create: `events/core/src/main/java/io/apitomy/axiom/events/core/DryRunEvent.java`
+- Modify: `events/github/src/main/java/io/apitomy/axiom/events/github/GitHubPoller.java`
+- Modify: `events/jira/src/main/java/io/apitomy/axiom/events/jira/JiraPoller.java`
+- Modify: `app/src/main/java/io/apitomy/axiom/app/rest/EventSourcesResourceImpl.java`
+
+**Interfaces:**
+- Consumes: `GitHubApiClient`, `JiraApiClient` (existing),
+  `EventFilterEvaluator.evaluate()` from Task 2
+- Produces: `POST /event-sources/filters/dry-run` endpoint returning
+  `FilterDryRunResponse`
+
+- [ ] **Step 1: Create `DryRunEvent` record in `events/core`**
+
+```java
+package io.apitomy.axiom.events.core;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Represents a single event produced during a dry-run evaluation.
+ *
+ * @param eventType the classified event type (e.g. "issue-created", "pr-merged")
+ * @param issueRef  the issue or PR reference (e.g. "owner/repo#42")
+ * @param summary   human-readable summary (e.g. issue title or comment author)
+ * @param payload   the wrapped event payload JSON
+ */
+public record DryRunEvent(String eventType, String issueRef, String summary, JsonNode payload) {
+}
+```
+
+- [ ] **Step 2: Create `GitHubEventClassifier`**
+
+Extract `determineIssueEventType`, `determinePrEventType`, all `wrap*AsWebhookPayload`
+methods, and `parseGitHubTimestamp` from `GitHubPoller` into a new static utility class:
+
+```java
+package io.apitomy.axiom.events.github;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+/**
+ * Classifies and wraps raw GitHub API responses into event types and
+ * webhook-like payloads. Shared by the poller and the dry-run service.
+ */
+public class GitHubEventClassifier {
+
+    private GitHubEventClassifier() {
+    }
+
+    /**
+     * Determines the event type for a GitHub issue based on timestamps.
+     */
+    public static String determineIssueEventType(JsonNode issue, Instant since) {
+        // Exact logic moved from GitHubPoller.determineIssueEventType()
+        String state = issue.path("state").asText("");
+        Instant createdAt = parseGitHubTimestamp(issue.path("created_at").asText(null));
+        Instant updatedAt = parseGitHubTimestamp(issue.path("updated_at").asText(null));
+        Instant closedAt = parseGitHubTimestamp(issue.path("closed_at").asText(null));
+
+        if (since == null) return null;
+        if (createdAt != null && createdAt.isAfter(since)) return "issue-created";
+        if ("closed".equals(state) && closedAt != null && closedAt.isAfter(since)) return "issue-closed";
+        if (updatedAt != null && updatedAt.isAfter(since)) {
+            if ("open".equals(state) && closedAt != null) return "issue-reopened";
+            return "issue-updated";
+        }
+        return null;
+    }
+
+    /**
+     * Determines the event type for a GitHub pull request based on timestamps.
+     */
+    public static String determinePrEventType(JsonNode pr, Instant since) {
+        // Exact logic moved from GitHubPoller.determinePrEventType()
+        String state = pr.path("state").asText("");
+        Instant createdAt = parseGitHubTimestamp(pr.path("created_at").asText(null));
+        Instant updatedAt = parseGitHubTimestamp(pr.path("updated_at").asText(null));
+        Instant closedAt = parseGitHubTimestamp(pr.path("closed_at").asText(null));
+        Instant mergedAt = parseGitHubTimestamp(pr.path("merged_at").asText(null));
+
+        if (since == null) return null;
+        if (createdAt != null && createdAt.isAfter(since)) return "pr-created";
+        if (mergedAt != null && mergedAt.isAfter(since)) return "pr-merged";
+        if ("closed".equals(state) && closedAt != null && closedAt.isAfter(since) && mergedAt == null)
+            return "pr-closed";
+        if (updatedAt != null && updatedAt.isAfter(since)) {
+            if ("open".equals(state) && closedAt != null) return "pr-reopened";
+            return "pr-updated";
+        }
+        return null;
+    }
+
+    /**
+     * Wraps a raw GitHub issue JSON as a webhook-like payload.
+     */
+    public static ObjectNode wrapIssue(ObjectMapper mapper, JsonNode issue, String eventType) {
+        // Logic moved from GitHubPoller.wrapIssueAsWebhookPayload()
+        String action = switch (eventType) {
+            case "issue-created" -> "opened";
+            case "issue-closed" -> "closed";
+            case "issue-reopened" -> "reopened";
+            default -> "edited";
+        };
+        ObjectNode node = mapper.createObjectNode();
+        node.put("action", action);
+        node.put("polled", true);
+        node.set("issue", issue);
+        return node;
+    }
+
+    /**
+     * Wraps a raw GitHub comment JSON as a webhook-like payload.
+     */
+    public static ObjectNode wrapComment(ObjectMapper mapper, JsonNode comment, int issueNumber) {
+        ObjectNode node = mapper.createObjectNode();
+        node.put("action", "created");
+        node.put("polled", true);
+        node.putObject("issue").put("number", issueNumber);
+        node.set("comment", comment);
+        return node;
+    }
+
+    /**
+     * Wraps a raw GitHub PR JSON as a webhook-like payload.
+     */
+    public static ObjectNode wrapPullRequest(ObjectMapper mapper, JsonNode pr, String eventType) {
+        String action = switch (eventType) {
+            case "pr-created" -> "opened";
+            case "pr-closed" -> "closed";
+            case "pr-merged" -> "closed";
+            case "pr-reopened" -> "reopened";
+            default -> "edited";
+        };
+        ObjectNode node = mapper.createObjectNode();
+        node.put("action", action);
+        node.put("polled", true);
+        node.set("pull_request", pr);
+        return node;
+    }
+
+    /**
+     * Wraps a raw GitHub review comment JSON as a webhook-like payload.
+     */
+    public static ObjectNode wrapReviewComment(ObjectMapper mapper, JsonNode comment, int prNumber) {
+        ObjectNode node = mapper.createObjectNode();
+        node.put("action", "created");
+        node.put("polled", true);
+        node.putObject("pull_request").put("number", prNumber);
+        node.set("comment", comment);
+        return node;
+    }
+
+    /**
+     * Parses a GitHub API timestamp string into an Instant.
+     */
+    public static Instant parseGitHubTimestamp(String timestamp) {
+        if (timestamp == null || timestamp.isBlank()) return null;
+        try {
+            return DateTimeFormatter.ISO_DATE_TIME.parse(timestamp, Instant::from);
+        } catch (DateTimeParseException e) {
+            return null;
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Update `GitHubPoller` to delegate to `GitHubEventClassifier`**
+
+Replace the private `determineIssueEventType`, `determinePrEventType`,
+`wrapIssueAsWebhookPayload`, `wrapCommentAsWebhookPayload`, `wrapPrAsWebhookPayload`,
+`wrapReviewCommentAsWebhookPayload`, and `parseGitHubTimestamp` methods with calls to the
+corresponding static methods on `GitHubEventClassifier`.
+
+For example, in `processIssues()`, change:
+```java
+String eventType = determineIssueEventType(issue, since);
+```
+to:
+```java
+String eventType = GitHubEventClassifier.determineIssueEventType(issue, since);
+```
+
+And:
+```java
+JsonNode wrappedPayload = wrapIssueAsWebhookPayload(issue, repoFullName, eventType);
+```
+to:
+```java
+JsonNode wrappedPayload = GitHubEventClassifier.wrapIssue(objectMapper, issue, eventType);
+```
+
+Apply the same pattern across all four `process*` methods. Then delete the now-unused private
+methods from `GitHubPoller`.
+
+Note: The existing `GitHubPollerPrEventTypeTest` directly calls `poller.determinePrEventType()`.
+Update it to call `GitHubEventClassifier.determinePrEventType()` instead and remove the
+`GitHubPoller` instance field.
+
+- [ ] **Step 4: Create `GitHubDryRunService`**
+
+```java
+package io.apitomy.axiom.events.github;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.apitomy.axiom.events.core.DryRunEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Fetches recent events from a GitHub repository and classifies them
+ * for dry-run filter evaluation. Does not ingest or persist anything.
+ */
+@ApplicationScoped
+public class GitHubDryRunService {
+
+    private static final Duration LOOKBACK = Duration.ofDays(7);
+
+    @Inject
+    GitHubApiClient apiClient;
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    /**
+     * Fetches recent events from the GitHub repository described by the
+     * configuration and classifies them into event types with payloads.
+     *
+     * @param owner  repository owner
+     * @param name   repository name
+     * @param token  authentication token
+     * @return list of classified events
+     */
+    public List<DryRunEvent> fetchRecentEvents(String owner, String name, String token) {
+        Instant since = Instant.now().minus(LOOKBACK);
+        List<DryRunEvent> events = new ArrayList<>();
+
+        var issueResult = apiClient.fetchIssuesUpdatedSince(owner, name, since, token);
+        if (issueResult.data() != null && issueResult.data().isArray()) {
+            for (JsonNode issue : issueResult.data()) {
+                if (issue.has("pull_request")) continue;
+                String eventType = GitHubEventClassifier.determineIssueEventType(issue, since);
+                if (eventType != null) {
+                    String ref = owner + "/" + name + "#" + issue.path("number").asInt();
+                    String summary = issue.path("title").asText("");
+                    ObjectNode payload = GitHubEventClassifier.wrapIssue(objectMapper, issue, eventType);
+                    events.add(new DryRunEvent(eventType, ref, summary, payload));
+                }
+            }
+        }
+
+        var commentResult = apiClient.fetchCommentsUpdatedSince(owner, name, since, token);
+        if (commentResult.data() != null && commentResult.data().isArray()) {
+            for (JsonNode comment : commentResult.data()) {
+                Instant createdAt = GitHubEventClassifier.parseGitHubTimestamp(
+                        comment.path("created_at").asText(null));
+                if (createdAt != null && createdAt.isAfter(since)) {
+                    String issueUrl = comment.path("issue_url").asText("");
+                    int issueNumber = extractIssueNumber(issueUrl);
+                    String ref = owner + "/" + name + "#" + issueNumber;
+                    String author = comment.path("user").path("login").asText("unknown");
+                    ObjectNode payload = GitHubEventClassifier.wrapComment(
+                            objectMapper, comment, issueNumber);
+                    events.add(new DryRunEvent("comment-added", ref,
+                            "Comment by " + author, payload));
+                }
+            }
+        }
+
+        var prResult = apiClient.fetchPullsUpdatedSince(owner, name, token);
+        if (prResult.data() != null && prResult.data().isArray()) {
+            for (JsonNode pr : prResult.data()) {
+                String eventType = GitHubEventClassifier.determinePrEventType(pr, since);
+                if (eventType != null) {
+                    String ref = owner + "/" + name + "#" + pr.path("number").asInt();
+                    String summary = pr.path("title").asText("");
+                    ObjectNode payload = GitHubEventClassifier.wrapPullRequest(
+                            objectMapper, pr, eventType);
+                    events.add(new DryRunEvent(eventType, ref, summary, payload));
+                }
+            }
+        }
+
+        var reviewResult = apiClient.fetchPullReviewCommentsUpdatedSince(
+                owner, name, since, token);
+        if (reviewResult.data() != null && reviewResult.data().isArray()) {
+            for (JsonNode comment : reviewResult.data()) {
+                Instant createdAt = GitHubEventClassifier.parseGitHubTimestamp(
+                        comment.path("created_at").asText(null));
+                if (createdAt != null && createdAt.isAfter(since)) {
+                    String prUrl = comment.path("pull_request_url").asText("");
+                    int prNumber = extractIssueNumber(prUrl);
+                    String ref = owner + "/" + name + "#" + prNumber;
+                    String author = comment.path("user").path("login").asText("unknown");
+                    ObjectNode payload = GitHubEventClassifier.wrapReviewComment(
+                            objectMapper, comment, prNumber);
+                    events.add(new DryRunEvent("pr-review-comment", ref,
+                            "Review comment by " + author, payload));
+                }
+            }
+        }
+
+        return events;
+    }
+
+    private int extractIssueNumber(String url) {
+        if (url == null || url.isBlank()) return 0;
+        int lastSlash = url.lastIndexOf('/');
+        if (lastSlash >= 0 && lastSlash < url.length() - 1) {
+            try {
+                return Integer.parseInt(url.substring(lastSlash + 1));
+            } catch (NumberFormatException e) {
+                return 0;
+            }
+        }
+        return 0;
+    }
+}
+```
+
+- [ ] **Step 5: Create `JiraEventClassifier`**
+
+Extract `determineEventType`, `buildIssuePayload`, `buildCommentPayload`, and
+`parseJiraTimestamp` from `JiraPoller` into a static utility class following the same pattern
+as `GitHubEventClassifier`. The methods should be:
+
+- `JiraEventClassifier.determineEventType(JsonNode fields, Instant since): String`
+- `JiraEventClassifier.buildIssuePayload(ObjectMapper, JsonNode issue, JsonNode fields,
+  String baseUrl, String eventType): ObjectNode`
+- `JiraEventClassifier.buildCommentPayload(ObjectMapper, JsonNode issue, JsonNode fields,
+  JsonNode comment, String baseUrl): ObjectNode`
+- `JiraEventClassifier.parseJiraTimestamp(String timestamp): Instant`
+
+- [ ] **Step 6: Update `JiraPoller` to delegate to `JiraEventClassifier`**
+
+Same pattern as Step 3 — replace private method calls with
+`JiraEventClassifier.methodName(...)` and delete the now-unused private methods.
+
+- [ ] **Step 7: Create `JiraDryRunService`**
+
+Follow the same pattern as `GitHubDryRunService`:
+
+```java
+package io.apitomy.axiom.events.jira;
+
+import io.apitomy.axiom.events.core.DryRunEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+// ... other imports
+
+@ApplicationScoped
+public class JiraDryRunService {
+
+    private static final Duration LOOKBACK = Duration.ofDays(7);
+
+    @Inject
+    JiraApiClient apiClient;
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    /**
+     * Fetches recent events from the Jira project described by the
+     * configuration and classifies them into event types with payloads.
+     *
+     * @param baseUrl  Jira base URL
+     * @param project  Jira project key
+     * @param credentials  authentication credentials
+     * @return list of classified events
+     */
+    public List<DryRunEvent> fetchRecentEvents(String baseUrl, String project,
+                                                String credentials) {
+        Instant since = Instant.now().minus(LOOKBACK);
+        List<DryRunEvent> events = new ArrayList<>();
+
+        var result = apiClient.fetchIssuesUpdatedSince(baseUrl, project, since, credentials);
+        if (result.data() != null) {
+            JsonNode issues = result.data().path("issues");
+            if (issues.isArray()) {
+                for (JsonNode issue : issues) {
+                    JsonNode fields = issue.path("fields");
+                    String key = issue.path("key").asText("");
+                    String summary = fields.path("summary").asText("");
+                    String eventType = JiraEventClassifier.determineEventType(fields, since);
+                    if (eventType != null) {
+                        ObjectNode payload = JiraEventClassifier.buildIssuePayload(
+                                objectMapper, issue, fields, baseUrl, eventType);
+                        events.add(new DryRunEvent(eventType, key, summary, payload));
+                    }
+                    // Check for new comments
+                    JsonNode comments = fields.path("comment").path("comments");
+                    if (comments.isArray()) {
+                        for (JsonNode comment : comments) {
+                            Instant commentCreated = JiraEventClassifier.parseJiraTimestamp(
+                                    comment.path("created").asText(null));
+                            if (commentCreated != null && commentCreated.isAfter(since)) {
+                                String author = comment.path("author")
+                                        .path("displayName").asText("unknown");
+                                ObjectNode payload = JiraEventClassifier.buildCommentPayload(
+                                        objectMapper, issue, fields, comment, baseUrl);
+                                events.add(new DryRunEvent("comment-added", key,
+                                        "Comment by " + author, payload));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return events;
+    }
+}
+```
+
+- [ ] **Step 8: Implement `dryRunFilters()` in `EventSourcesResourceImpl`**
+
+Add injected fields:
+
+```java
+@Inject
+GitHubDryRunService githubDryRunService;
+
+@Inject
+JiraDryRunService jiraDryRunService;
+
+@Inject
+EventFilterEvaluator filterEvaluator;
+```
+
+Add the imports for the core filter types and `DryRunEvent`.
+
+Implement the method (the generated interface will have the signature from the OpenAPI spec):
+
+```java
+@Override
+public FilterDryRunResponse dryRunFilters(FilterDryRunRequest request) {
+    // Convert API filter beans to core filter model
+    EventSourceFilters coreFilters = toCoreFilters(request.getFilters());
+
+    // Fetch recent events from the source
+    List<DryRunEvent> events = fetchDryRunEvents(request);
+
+    // Evaluate filters against each event
+    List<FilterDryRunResult> results = new ArrayList<>();
+    int allowed = 0;
+    int blocked = 0;
+
+    for (DryRunEvent event : events) {
+        FilterResult filterResult = filterEvaluator.evaluate(
+                coreFilters, event.eventType(), event.payload());
+        FilterDryRunResult result = new FilterDryRunResult();
+        result.setEventType(event.eventType());
+        result.setIssueRef(event.issueRef());
+        result.setSummary(event.summary());
+        result.setAllowed(filterResult.allowed());
+        result.setMatchedRule(filterResult.matchedRule());
+        results.add(result);
+        if (filterResult.allowed()) allowed++;
+        else blocked++;
+    }
+
+    FilterDryRunResponse response = new FilterDryRunResponse();
+    response.setResults(results);
+    response.setTotalEvaluated(events.size());
+    response.setTotalAllowed(allowed);
+    response.setTotalBlocked(blocked);
+    return response;
+}
+```
+
+Add the helper methods:
+
+```java
+private List<DryRunEvent> fetchDryRunEvents(FilterDryRunRequest request) {
+    String sourceType = request.getSourceType().value();
+    Map<String, Object> config = request.getConfiguration();
+    String token = resolveSecretValue(request.getSecretName());
+
+    if ("github".equals(sourceType)) {
+        String owner = String.valueOf(config.get("owner"));
+        String name = String.valueOf(config.get("name"));
+        return githubDryRunService.fetchRecentEvents(owner, name, token);
+    } else if ("jira".equals(sourceType)) {
+        String baseUrl = String.valueOf(config.get("baseUrl"));
+        String project = String.valueOf(config.get("project"));
+        return jiraDryRunService.fetchRecentEvents(baseUrl, project, token);
+    }
+    return List.of();
+}
+
+private EventSourceFilters toCoreFilters(
+        io.apitomy.axiom.api.beans.EventSourceFilters apiFilters) {
+    if (apiFilters == null) return EventSourceFilters.allowAll();
+    List<EventSourceFilterRule> include = apiFilters.getInclude() != null
+            ? apiFilters.getInclude().stream()
+                .map(r -> new EventSourceFilterRule(
+                        r.getType().value(), r.getPointer(), r.getPattern()))
+                .toList()
+            : List.of();
+    List<EventSourceFilterRule> exclude = apiFilters.getExclude() != null
+            ? apiFilters.getExclude().stream()
+                .map(r -> new EventSourceFilterRule(
+                        r.getType().value(), r.getPointer(), r.getPattern()))
+                .toList()
+            : List.of();
+    return new EventSourceFilters(include, exclude);
+}
+```
+
+Note: `resolveSecretValue()` should follow the same pattern the pollers use for resolving
+secrets. Check how `GitHubPoller.resolveToken()` works and replicate the logic, or extract
+it into a shared service if one doesn't already exist.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add events/core/src/main/java/io/apitomy/axiom/events/core/DryRunEvent.java \
+        events/github/src/main/java/io/apitomy/axiom/events/github/GitHubEventClassifier.java \
+        events/github/src/main/java/io/apitomy/axiom/events/github/GitHubDryRunService.java \
+        events/github/src/main/java/io/apitomy/axiom/events/github/GitHubPoller.java \
+        events/github/src/test/java/io/apitomy/axiom/events/github/GitHubPollerPrEventTypeTest.java \
+        events/jira/src/main/java/io/apitomy/axiom/events/jira/JiraEventClassifier.java \
+        events/jira/src/main/java/io/apitomy/axiom/events/jira/JiraDryRunService.java \
+        events/jira/src/main/java/io/apitomy/axiom/events/jira/JiraPoller.java \
+        app/src/main/java/io/apitomy/axiom/app/rest/EventSourcesResourceImpl.java
+git commit -m "feat(events): extract classifiers and implement dry-run endpoint (#127)"
+```
+
+---
+
+### Task 6: Frontend
+
+**Files:**
+- Modify: `ui/src/config/api.ts`
+- Modify: `ui/src/pages/EventSourceDetailPage.tsx`
+
+**Interfaces:**
+- Consumes: `GET /event-sources/{id}` returning `EventSource` with `filters` field,
+  `PUT /event-sources/{id}` accepting `filters`,
+  `POST /event-sources/filters/dry-run` endpoint
+- Produces: Filters tab UI with rule editing and dry-run preview
+
+- [ ] **Step 1: Add TypeScript filter types to `api.ts`**
+
+After the `EventSourceLog` interface (around line 847), add:
+
+```ts
+export interface EventSourceFilterRule {
+    type: "event-type" | "payload";
+    pointer?: string;
+    pattern: string;
+}
+
+export interface EventSourceFilters {
+    include: EventSourceFilterRule[];
+    exclude: EventSourceFilterRule[];
+}
+
+export interface FilterDryRunRequest {
+    sourceType: string;
+    configuration: Record<string, string>;
+    secretName?: string;
+    filters: EventSourceFilters;
+}
+
+export interface FilterDryRunResult {
+    eventType: string;
+    issueRef: string;
+    summary: string;
+    allowed: boolean;
+    matchedRule?: string;
+}
+
+export interface FilterDryRunResponse {
+    results: FilterDryRunResult[];
+    totalEvaluated: number;
+    totalAllowed: number;
+    totalBlocked: number;
+}
+```
+
+- [ ] **Step 2: Add `filters` to `EventSource` interface**
+
+Update the `EventSource` interface to include the filters field:
+
+```ts
+export interface EventSource {
+    id: number;
+    name: string;
+    description?: string;
+    sourceType: string;
+    enabled: boolean;
+    pollInterval?: number;
+    secretName?: string;
+    configuration?: Record<string, string>;
+    labels?: string[];
+    filters?: EventSourceFilters;
+}
+```
+
+- [ ] **Step 3: Add `dryRunFilters()` API function**
+
+After the existing event source API functions, add:
+
+```ts
+export async function dryRunFilters(request: FilterDryRunRequest): Promise<FilterDryRunResponse> {
+    const response = await fetch(`${API}/event-sources/filters/dry-run`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(request),
+    });
+    if (!response.ok) throw new Error(`Dry run failed: ${response.statusText}`);
+    return response.json();
+}
+```
+
+- [ ] **Step 4: Create the `FiltersTab` component**
+
+Add a new inline function component in `EventSourceDetailPage.tsx` (after the `LogsTab`
+component). This is the largest piece of frontend work. The component manages:
+
+- Local state for the edited filters (cloned from the source's filters on load)
+- Include and exclude rule tables
+- Add/edit/delete rule interactions
+- Dirty tracking and save
+- Dry-run preview
+
+```tsx
+function FiltersTab({ source, onSave }: {
+    source: EventSource;
+    onSave: (filters: EventSourceFilters) => Promise<void>;
+}) {
+    const [filters, setFilters] = useState<EventSourceFilters>(
+        source.filters ?? { include: [], exclude: [] }
+    );
+    const [dirty, setDirty] = useState(false);
+    const [saving, setSaving] = useState(false);
+    const [dryRunResults, setDryRunResults] = useState<FilterDryRunResponse | null>(null);
+    const [dryRunLoading, setDryRunLoading] = useState(false);
+
+    // State for the "add rule" form
+    const [addingTo, setAddingTo] = useState<"include" | "exclude" | null>(null);
+    const [newRuleType, setNewRuleType] = useState<"event-type" | "payload">("event-type");
+    const [newRulePointer, setNewRulePointer] = useState("");
+    const [newRulePattern, setNewRulePattern] = useState("");
+
+    const handleAddRule = (list: "include" | "exclude") => {
+        const rule: EventSourceFilterRule = {
+            type: newRuleType,
+            pattern: newRulePattern,
+            ...(newRuleType === "payload" ? { pointer: newRulePointer } : {}),
+        };
+        const updated = { ...filters };
+        updated[list] = [...updated[list], rule];
+        setFilters(updated);
+        setDirty(true);
+        setAddingTo(null);
+        setNewRuleType("event-type");
+        setNewRulePointer("");
+        setNewRulePattern("");
+    };
+
+    const handleDeleteRule = (list: "include" | "exclude", index: number) => {
+        const updated = { ...filters };
+        updated[list] = updated[list].filter((_, i) => i !== index);
+        setFilters(updated);
+        setDirty(true);
+    };
+
+    const handleSave = async () => {
+        setSaving(true);
+        try {
+            await onSave(filters);
+            setDirty(false);
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const handleDryRun = async () => {
+        setDryRunLoading(true);
+        try {
+            const request: FilterDryRunRequest = {
+                sourceType: source.sourceType,
+                configuration: source.configuration ?? {},
+                secretName: source.secretName,
+                filters,
+            };
+            const response = await dryRunFilters(request);
+            setDryRunResults(response);
+        } catch (e) {
+            console.error("Dry run failed:", e);
+        } finally {
+            setDryRunLoading(false);
+        }
+    };
+
+    // ... render logic below
+}
+```
+
+The render method should produce:
+- A page section header with "Save" button (disabled when not dirty)
+- **Include Rules** section: table of rules + "Add rule" button
+- **Exclude Rules** section: table of rules + "Add rule" button
+- When `addingTo` is set, show an inline form row with: type `FormSelect` (event-type /
+  payload), pointer `TextInput` (shown only when type=payload), pattern `TextInput`, and
+  Add/Cancel buttons
+- **Test Filters** button below the rule tables
+- When `dryRunResults` is set, show:
+  - Summary line: "N allowed, N blocked out of N events"
+  - Results table with columns: Result (green check / red X `Label`), Event Type, Reference,
+    Summary, Matched Rule
+
+Each rule table row has columns: Type, Pointer (blank for event-type), Pattern, and a Delete
+button (TrashIcon or similar).
+
+Use PatternFly components consistent with the existing page: `Card`, `CardBody`, `Table`,
+`Thead`, `Tbody`, `Tr`, `Th`, `Td`, `Button`, `FormSelect`, `TextInput`, `Label`.
+
+- [ ] **Step 5: Add the Filters tab to `EventSourceDetailPage`**
+
+In the `Tabs` section (around line 158), add the new tab between Info and Poll Logs:
+
+```tsx
+<Tab eventKey={1} title={<TabTitleText>Filters</TabTitleText>}>
+    <TabContent id="filters-tab">
+        {source && (
+            <FiltersTab
+                source={source}
+                onSave={async (filters) => {
+                    await updateEventSource(source.id, {
+                        ...source,
+                        filters,
+                    } as NewEventSource);
+                    loadData();
+                }}
+            />
+        )}
+    </TabContent>
+</Tab>
+```
+
+Update the existing Poll Logs tab `eventKey` from `1` to `2`, and update any references to
+`activeTab === 1` for the logs tab to `activeTab === 2`.
+
+Add the new imports at the top of the file:
+
+```ts
+import {
+    type EventSourceFilters,
+    type EventSourceFilterRule,
+    type FilterDryRunRequest,
+    type FilterDryRunResponse,
+    dryRunFilters,
+} from "../config/api";
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ui/src/config/api.ts ui/src/pages/EventSourceDetailPage.tsx
+git commit -m "feat(ui): add Filters tab with config editor and dry-run preview (#127)"
+```

--- a/docs/superpowers/specs/2026-08-07-event-source-filtering-design.md
+++ b/docs/superpowers/specs/2026-08-07-event-source-filtering-design.md
@@ -1,0 +1,312 @@
+# Event Source Filtering Design
+
+**GitHub Issue:** #127 — feat: user-configurable event source filtering
+**Date:** 2026-08-07
+
+## Summary
+
+Replace the hardcoded bot and slash-command pre-filters in `PipelineOrchestrator.shouldSkipEvent()`
+with a general-purpose, per-event-source filtering system. Users configure include/exclude filter
+rules on each event source. Filtering happens post-ingest, pre-Manager — events are in the DB but
+blocked before the AI Manager LLM call. A dry-run endpoint lets users preview filter behavior
+against live events fetched from the source API.
+
+## Filter Data Model
+
+### Filter rule
+
+Each filter rule has a **type**, an optional **JSON Pointer**, and a **glob pattern**:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | enum: `event-type`, `payload` | yes | What the rule matches against |
+| `pointer` | string (RFC 6901 JSON Pointer) | when type=`payload` | Path into the event payload |
+| `pattern` | string (glob) | yes | Glob pattern with `*` and `?` wildcards |
+
+- **`event-type` rules** match the glob against the event's `eventType` string (e.g. `issue-*`,
+  `pr-created`).
+- **`payload` rules** resolve the JSON Pointer against the event payload using
+  `JsonNode.at(pointer)`, then match the glob against the resulting text value.
+
+### Filter object
+
+```json
+{
+  "include": [<EventSourceFilterRule>, ...],
+  "exclude": [<EventSourceFilterRule>, ...]
+}
+```
+
+### Evaluation semantics
+
+1. **Include phase:** If `include` is empty, the event passes. If non-empty, the event must match
+   at least one include rule to pass.
+2. **Exclude phase:** If the event matches any exclude rule, it is blocked.
+3. **Missing pointer:** If a JSON Pointer resolves to a missing or null node, the rule does not
+   match (fails open).
+
+### Storage
+
+A new top-level `filters` field on `EventSource` and `NewEventSource`, stored as a `TEXT` column
+containing JSON on the `event_source` table. Separate from the `configuration` blob.
+
+### Default filters
+
+All event sources (new and existing via migration) get these defaults:
+
+```json
+{
+  "include": [],
+  "exclude": [
+    {"type": "payload", "pointer": "/user/login", "pattern": "*[bot]"},
+    {"type": "payload", "pointer": "/comment/user/login", "pattern": "*[bot]"},
+    {"type": "payload", "pointer": "/comment/body", "pattern": "/*"}
+  ]
+}
+```
+
+These replace the hardcoded `shouldSkipEvent()` logic:
+- Bot filter (`*[bot]` login suffix) covered by the first two rules (top-level user and comment
+  user).
+- Slash-command filter covered by the third rule (comment body starting with `/`).
+
+## OpenAPI Schema Changes
+
+### New schema definitions
+
+```json
+"EventSourceFilterRule": {
+  "required": ["type", "pattern"],
+  "properties": {
+    "type": {
+      "enum": ["event-type", "payload"],
+      "type": "string"
+    },
+    "pointer": {
+      "description": "JSON Pointer (RFC 6901) to the payload field. Required when type=payload.",
+      "type": "string"
+    },
+    "pattern": {
+      "description": "Glob pattern to match against (supports * and ? wildcards).",
+      "type": "string"
+    }
+  }
+}
+
+"EventSourceFilters": {
+  "properties": {
+    "include": {
+      "description": "Rules for events to include. Empty list means allow all.",
+      "type": "array",
+      "items": { "$ref": "#/components/schemas/EventSourceFilterRule" }
+    },
+    "exclude": {
+      "description": "Rules for events to exclude. Applied after include rules.",
+      "type": "array",
+      "items": { "$ref": "#/components/schemas/EventSourceFilterRule" }
+    }
+  }
+}
+```
+
+### Updated schemas
+
+Both `EventSource` and `NewEventSource` gain:
+
+```json
+"filters": { "$ref": "#/components/schemas/EventSourceFilters" }
+```
+
+### New endpoint schemas
+
+**Dry-run request:**
+
+```json
+"FilterDryRunRequest": {
+  "required": ["sourceType", "configuration", "filters"],
+  "properties": {
+    "sourceType": { "enum": ["github", "jira"], "type": "string" },
+    "configuration": { "type": "object", "additionalProperties": {} },
+    "secretName": { "type": "string" },
+    "filters": { "$ref": "#/components/schemas/EventSourceFilters" }
+  }
+}
+```
+
+**Dry-run response:**
+
+```json
+"FilterDryRunResponse": {
+  "properties": {
+    "results": {
+      "type": "array",
+      "items": { "$ref": "#/components/schemas/FilterDryRunResult" }
+    },
+    "totalEvaluated": { "type": "integer" },
+    "totalAllowed": { "type": "integer" },
+    "totalBlocked": { "type": "integer" }
+  }
+}
+
+"FilterDryRunResult": {
+  "properties": {
+    "eventType": { "type": "string" },
+    "issueRef": { "type": "string" },
+    "summary": { "type": "string" },
+    "allowed": { "type": "boolean" },
+    "matchedRule": { "type": "string" }
+  }
+}
+```
+
+### New endpoint
+
+```
+POST /api/event-sources/filters/dry-run
+```
+
+Request body: `FilterDryRunRequest`
+Response body: `FilterDryRunResponse`
+
+## Backend Design
+
+### EventFilterEvaluator
+
+New class in `core` module:
+
+```
+io.apitomy.axiom.core.filters.EventFilterEvaluator
+```
+
+**Public API:**
+
+```java
+public FilterResult evaluate(EventSourceFilters filters, String eventType, JsonNode payload);
+```
+
+**FilterResult record:**
+
+```java
+public record FilterResult(boolean allowed, String matchedRule) {}
+```
+
+- `allowed = true`, `matchedRule = null` — event passes.
+- `allowed = false`, `matchedRule = "exclude payload /user/login matched *[bot]"` — event blocked
+  with human-readable description of the matched rule.
+
+**Glob matching** uses a custom wildcard matcher that converts `*` and `?` to regex equivalents
+while treating all other characters as literal. This avoids `PathMatcher`'s interpretation of
+`[...]` as character classes — users write `*[bot]` to mean the literal string `[bot]`, not
+"one of b, o, t". No external library needed.
+
+### PipelineOrchestrator changes
+
+The `shouldSkipEvent()` method and `SLASH_COMMANDS` constant are deleted. The pre-filter check
+(lines 174-183) is replaced with:
+
+1. Load `EventSourceEntity` for `event.eventSourceId`.
+2. Deserialize `filters` JSON into `EventSourceFilters`.
+3. Parse `event.payload` into `JsonNode`.
+4. Call `EventFilterEvaluator.evaluate(filters, event.eventType, payload)`.
+5. If `!result.allowed`: log activity as `"event-pre-filtered"` with `result.matchedRule()` in
+   the summary, mark queue entry `"completed"`, return.
+6. If `allowed`: continue to Manager evaluation.
+
+If `filters` is null or empty, all events pass (backward compatible). If `event.eventSourceId`
+is null (no associated event source), filtering is skipped and the event passes through.
+
+### Dry-run endpoint implementation
+
+The dry-run endpoint needs to reuse poller fetch and event-type-determination logic without
+triggering ingestion. This requires extracting the fetch/classify logic from `GitHubPoller` and
+`JiraPoller` into reusable components that the dry-run resource can call.
+
+**Flow:**
+
+1. Resolve auth credentials from `secretName`.
+2. Fetch recent events from the source API using a recent time window (e.g. last 7 days).
+3. Classify each event using the same event-type determination logic the pollers use.
+4. Run `EventFilterEvaluator.evaluate()` on each event.
+5. Return results with summary counts. No DB writes.
+
+### Activity log enrichment
+
+The `"event-pre-filtered"` activity log entry summary is updated to include the matched rule
+detail:
+
+```
+Event pre-filtered: comment-added — exclude payload /comment/user/login matched *[bot]
+```
+
+This replaces the current format (`Event pre-filtered: comment-added — bot activity from
+dependabot[bot]`).
+
+## Database Migration (V34)
+
+```sql
+-- Add filters column to event_source
+ALTER TABLE event_source ADD COLUMN filters TEXT;
+
+-- Populate existing event sources with default filters
+UPDATE event_source SET filters = '{"include":[],"exclude":[
+  {"type":"payload","pointer":"/user/login","pattern":"*[bot]"},
+  {"type":"payload","pointer":"/comment/user/login","pattern":"*[bot]"},
+  {"type":"payload","pointer":"/comment/body","pattern":"/*"}
+]}';
+```
+
+## Frontend Design
+
+### New "Filters" tab on EventSourceDetailPage
+
+Tab order:
+- Tab 0: Info (existing)
+- Tab 1: Filters (new)
+- Tab 2: Poll Logs (existing, shifted from index 1)
+
+### Filter configuration section
+
+A card with two sub-sections — "Include Rules" and "Exclude Rules" — each containing a table:
+
+| Type | Pointer | Pattern | Actions |
+|------|---------|---------|---------|
+| `event-type` | — | `issue-*` | Edit / Delete |
+| `payload` | `/user/login` | `*[bot]` | Edit / Delete |
+
+- Pointer column is blank/disabled for `event-type` rules.
+- "Add rule" button opens an inline form: type dropdown (`event-type` or `payload`), pointer text
+  field (shown only for `payload` type), pattern text field.
+- "Save" button persists via `PUT /api/event-sources/{id}`.
+
+### Dry-run preview section
+
+Below the filter config, a "Test Filters" button:
+
+1. Calls `POST /api/event-sources/filters/dry-run` with the event source's configuration, auth,
+   and the currently edited (unsaved) filters.
+2. Displays results in a table:
+
+| Result | Event Type | Reference | Summary | Matched Rule |
+|--------|-----------|-----------|---------|-------------|
+| Allowed | `issue-created` | `#42` | Fix login bug | — |
+| Blocked | `comment-added` | `#99` | Comment by dependabot[bot] | `exclude /comment/user/login: *[bot]` |
+
+- Allowed rows: green check icon. Blocked rows: red X icon.
+- Summary counts above the table: "38 allowed, 12 blocked out of 50 events".
+- Preview uses the in-memory (unsaved) filter state so users can tweak and re-test before saving.
+
+## Observability
+
+- Each filtered event produces an `"event-pre-filtered"` activity log entry with the matched rule
+  in the summary. No changes to poll log schema.
+- Users can see filtered events in the activity log, filterable by entry type.
+
+## Scope Exclusions
+
+The following are explicitly deferred to future work:
+
+- Branch pattern filters (e.g. only PRs targeting `main`)
+- Label pattern filters
+- Filter Log tab (dedicated UI for filter history)
+- Array wildcard support in JSON Pointers
+- Regex value matching (glob only for now)

--- a/events/core/src/main/java/io/apitomy/axiom/events/core/DryRunEvent.java
+++ b/events/core/src/main/java/io/apitomy/axiom/events/core/DryRunEvent.java
@@ -1,0 +1,14 @@
+package io.apitomy.axiom.events.core;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Represents a single event produced during a dry-run evaluation.
+ *
+ * @param eventType the classified event type (e.g. "issue-created", "pr-merged")
+ * @param issueRef  the issue or PR reference (e.g. "owner/repo#42")
+ * @param summary   human-readable summary (e.g. issue title or comment author)
+ * @param payload   the wrapped event payload JSON
+ */
+public record DryRunEvent(String eventType, String issueRef, String summary, JsonNode payload) {
+}

--- a/events/github/src/main/java/io/apitomy/axiom/events/github/GitHubDryRunService.java
+++ b/events/github/src/main/java/io/apitomy/axiom/events/github/GitHubDryRunService.java
@@ -1,0 +1,123 @@
+package io.apitomy.axiom.events.github;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.apitomy.axiom.events.core.DryRunEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Fetches recent events from a GitHub repository and classifies them
+ * for dry-run filter evaluation. Does not ingest or persist anything.
+ */
+@ApplicationScoped
+public class GitHubDryRunService {
+
+    private static final Duration LOOKBACK = Duration.ofDays(7);
+
+    @Inject
+    GitHubApiClient apiClient;
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    /**
+     * Fetches recent events from the GitHub repository described by the
+     * configuration and classifies them into event types with payloads.
+     *
+     * @param owner  repository owner
+     * @param name   repository name
+     * @param token  authentication token
+     * @return list of classified events
+     */
+    public List<DryRunEvent> fetchRecentEvents(String owner, String name, String token) {
+        Instant since = Instant.now().minus(LOOKBACK);
+        List<DryRunEvent> events = new ArrayList<>();
+
+        var issueResult = apiClient.fetchIssuesUpdatedSince(owner, name, since, token);
+        if (issueResult.data() != null && issueResult.data().isArray()) {
+            for (JsonNode issue : issueResult.data()) {
+                if (issue.has("pull_request")) continue;
+                String eventType = GitHubEventClassifier.determineIssueEventType(issue, since);
+                if (eventType != null) {
+                    String ref = owner + "/" + name + "#" + issue.path("number").asInt();
+                    String summary = issue.path("title").asText("");
+                    ObjectNode payload = GitHubEventClassifier.wrapIssue(objectMapper, issue, eventType);
+                    events.add(new DryRunEvent(eventType, ref, summary, payload));
+                }
+            }
+        }
+
+        var commentResult = apiClient.fetchCommentsUpdatedSince(owner, name, since, token);
+        if (commentResult.data() != null && commentResult.data().isArray()) {
+            for (JsonNode comment : commentResult.data()) {
+                Instant createdAt = GitHubEventClassifier.parseGitHubTimestamp(
+                        comment.path("created_at").asText(null));
+                if (createdAt != null && createdAt.isAfter(since)) {
+                    String issueUrl = comment.path("issue_url").asText("");
+                    int issueNumber = extractIssueNumber(issueUrl);
+                    String ref = owner + "/" + name + "#" + issueNumber;
+                    String author = comment.path("user").path("login").asText("unknown");
+                    ObjectNode payload = GitHubEventClassifier.wrapComment(
+                            objectMapper, comment, issueNumber);
+                    events.add(new DryRunEvent("comment-added", ref,
+                            "Comment by " + author, payload));
+                }
+            }
+        }
+
+        var prResult = apiClient.fetchPullsUpdatedSince(owner, name, token);
+        if (prResult.data() != null && prResult.data().isArray()) {
+            for (JsonNode pr : prResult.data()) {
+                String eventType = GitHubEventClassifier.determinePrEventType(pr, since);
+                if (eventType != null) {
+                    String ref = owner + "/" + name + "#" + pr.path("number").asInt();
+                    String summary = pr.path("title").asText("");
+                    ObjectNode payload = GitHubEventClassifier.wrapPullRequest(
+                            objectMapper, pr, eventType);
+                    events.add(new DryRunEvent(eventType, ref, summary, payload));
+                }
+            }
+        }
+
+        var reviewResult = apiClient.fetchPullReviewCommentsUpdatedSince(
+                owner, name, since, token);
+        if (reviewResult.data() != null && reviewResult.data().isArray()) {
+            for (JsonNode comment : reviewResult.data()) {
+                Instant createdAt = GitHubEventClassifier.parseGitHubTimestamp(
+                        comment.path("created_at").asText(null));
+                if (createdAt != null && createdAt.isAfter(since)) {
+                    String prUrl = comment.path("pull_request_url").asText("");
+                    int prNumber = extractIssueNumber(prUrl);
+                    String ref = owner + "/" + name + "#" + prNumber;
+                    String author = comment.path("user").path("login").asText("unknown");
+                    ObjectNode payload = GitHubEventClassifier.wrapReviewComment(
+                            objectMapper, comment, prNumber);
+                    events.add(new DryRunEvent("pr-review-comment", ref,
+                            "Review comment by " + author, payload));
+                }
+            }
+        }
+
+        return events;
+    }
+
+    private int extractIssueNumber(String url) {
+        if (url == null || url.isBlank()) return 0;
+        int lastSlash = url.lastIndexOf('/');
+        if (lastSlash >= 0 && lastSlash < url.length() - 1) {
+            try {
+                return Integer.parseInt(url.substring(lastSlash + 1));
+            } catch (NumberFormatException e) {
+                return 0;
+            }
+        }
+        return 0;
+    }
+}

--- a/events/github/src/main/java/io/apitomy/axiom/events/github/GitHubEventClassifier.java
+++ b/events/github/src/main/java/io/apitomy/axiom/events/github/GitHubEventClassifier.java
@@ -1,0 +1,190 @@
+package io.apitomy.axiom.events.github;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+/**
+ * Classifies and wraps raw GitHub API responses into event types and
+ * webhook-like payloads. Shared by the poller and the dry-run service.
+ */
+public class GitHubEventClassifier {
+
+    private GitHubEventClassifier() {
+    }
+
+    /**
+     * Determines the event type for a GitHub issue based on timestamps.
+     *
+     * @param issue the issue JSON from the GitHub API
+     * @param since the timestamp to compare against
+     * @return the event type, or null if the issue is not relevant
+     */
+    public static String determineIssueEventType(JsonNode issue, Instant since) {
+        String state = issue.path("state").asText("");
+        Instant createdAt = parseGitHubTimestamp(issue.path("created_at").asText(null));
+        Instant updatedAt = parseGitHubTimestamp(issue.path("updated_at").asText(null));
+        Instant closedAt = parseGitHubTimestamp(issue.path("closed_at").asText(null));
+
+        if (since == null) {
+            return null;
+        }
+
+        if (createdAt != null && createdAt.isAfter(since)) {
+            return "issue-created";
+        }
+
+        if ("closed".equals(state) && closedAt != null && closedAt.isAfter(since)) {
+            return "issue-closed";
+        }
+
+        if (updatedAt != null && updatedAt.isAfter(since)) {
+            if ("open".equals(state) && closedAt != null) {
+                return "issue-reopened";
+            }
+            return "issue-updated";
+        }
+
+        return null;
+    }
+
+    /**
+     * Determines the event type for a GitHub pull request based on timestamps.
+     *
+     * @param pr the pull request JSON from the GitHub API
+     * @param since the timestamp to compare against
+     * @return the event type, or null if the PR is not relevant
+     */
+    public static String determinePrEventType(JsonNode pr, Instant since) {
+        String state = pr.path("state").asText("");
+        Instant createdAt = parseGitHubTimestamp(pr.path("created_at").asText(null));
+        Instant updatedAt = parseGitHubTimestamp(pr.path("updated_at").asText(null));
+        Instant closedAt = parseGitHubTimestamp(pr.path("closed_at").asText(null));
+        Instant mergedAt = parseGitHubTimestamp(pr.path("merged_at").asText(null));
+
+        if (since == null) {
+            return null;
+        }
+
+        if (createdAt != null && createdAt.isAfter(since)) {
+            return "pr-created";
+        }
+
+        if (mergedAt != null && mergedAt.isAfter(since)) {
+            return "pr-merged";
+        }
+
+        if ("closed".equals(state) && closedAt != null && closedAt.isAfter(since) && mergedAt == null) {
+            return "pr-closed";
+        }
+
+        if (updatedAt != null && updatedAt.isAfter(since)) {
+            if ("open".equals(state) && closedAt != null) {
+                return "pr-reopened";
+            }
+            return "pr-updated";
+        }
+
+        return null;
+    }
+
+    /**
+     * Wraps a raw GitHub issue JSON as a webhook-like payload.
+     *
+     * @param mapper the ObjectMapper for creating nodes
+     * @param issue the issue JSON
+     * @param eventType the classified event type
+     * @return the wrapped payload
+     */
+    public static ObjectNode wrapIssue(ObjectMapper mapper, JsonNode issue, String eventType) {
+        String action = switch (eventType) {
+            case "issue-created" -> "opened";
+            case "issue-closed" -> "closed";
+            case "issue-reopened" -> "reopened";
+            default -> "edited";
+        };
+        ObjectNode node = mapper.createObjectNode();
+        node.put("action", action);
+        node.put("polled", true);
+        node.set("issue", issue);
+        return node;
+    }
+
+    /**
+     * Wraps a raw GitHub comment JSON as a webhook-like payload.
+     *
+     * @param mapper the ObjectMapper for creating nodes
+     * @param comment the comment JSON
+     * @param issueNumber the issue number this comment belongs to
+     * @return the wrapped payload
+     */
+    public static ObjectNode wrapComment(ObjectMapper mapper, JsonNode comment, int issueNumber) {
+        ObjectNode node = mapper.createObjectNode();
+        node.put("action", "created");
+        node.put("polled", true);
+        node.putObject("issue").put("number", issueNumber);
+        node.set("comment", comment);
+        return node;
+    }
+
+    /**
+     * Wraps a raw GitHub PR JSON as a webhook-like payload.
+     *
+     * @param mapper the ObjectMapper for creating nodes
+     * @param pr the pull request JSON
+     * @param eventType the classified event type
+     * @return the wrapped payload
+     */
+    public static ObjectNode wrapPullRequest(ObjectMapper mapper, JsonNode pr, String eventType) {
+        String action = switch (eventType) {
+            case "pr-created" -> "opened";
+            case "pr-closed" -> "closed";
+            case "pr-merged" -> "closed";
+            case "pr-reopened" -> "reopened";
+            default -> "edited";
+        };
+        ObjectNode node = mapper.createObjectNode();
+        node.put("action", action);
+        node.put("polled", true);
+        node.set("pull_request", pr);
+        return node;
+    }
+
+    /**
+     * Wraps a raw GitHub review comment JSON as a webhook-like payload.
+     *
+     * @param mapper the ObjectMapper for creating nodes
+     * @param comment the review comment JSON
+     * @param prNumber the pull request number this comment belongs to
+     * @return the wrapped payload
+     */
+    public static ObjectNode wrapReviewComment(ObjectMapper mapper, JsonNode comment, int prNumber) {
+        ObjectNode node = mapper.createObjectNode();
+        node.put("action", "created");
+        node.put("polled", true);
+        node.putObject("pull_request").put("number", prNumber);
+        node.set("comment", comment);
+        return node;
+    }
+
+    /**
+     * Parses a GitHub API timestamp string into an Instant.
+     *
+     * @param timestamp the timestamp string in ISO 8601 format
+     * @return the parsed Instant, or null if parsing fails
+     */
+    public static Instant parseGitHubTimestamp(String timestamp) {
+        if (timestamp == null || timestamp.isBlank()) {
+            return null;
+        }
+        try {
+            return DateTimeFormatter.ISO_DATE_TIME.parse(timestamp, Instant::from);
+        } catch (DateTimeParseException e) {
+            return null;
+        }
+    }
+}

--- a/events/github/src/main/java/io/apitomy/axiom/events/github/GitHubPoller.java
+++ b/events/github/src/main/java/io/apitomy/axiom/events/github/GitHubPoller.java
@@ -225,15 +225,15 @@ public class GitHubPoller {
         for (JsonNode issue : result.data()) {
             if (issue.has("pull_request")) continue;
 
-            String eventType = determineIssueEventType(issue, since);
+            String eventType = GitHubEventClassifier.determineIssueEventType(issue, since);
             if (eventType == null) continue;
 
             int number = issue.path("number").asInt(0);
             String issueRef = repoFullName + "#" + number;
 
             try {
-                String payload = objectMapper.writeValueAsString(wrapIssueAsWebhookPayload(
-                        issue, repoFullName, eventType));
+                String payload = objectMapper.writeValueAsString(GitHubEventClassifier.wrapIssue(
+                        objectMapper, issue, eventType));
                 eventService.ingestEvent(eventSourceId, "github", eventType, issueRef, repoFullName, payload);
                 logLines.add("  " + eventType + ": " + issueRef + " — " + issue.path("title").asText(""));
                 count++;
@@ -263,7 +263,7 @@ public class GitHubPoller {
                 continue;
             }
 
-            Instant createdAt = parseGitHubTimestamp(comment.path("created_at").asText(null));
+            Instant createdAt = GitHubEventClassifier.parseGitHubTimestamp(comment.path("created_at").asText(null));
             if (since != null && createdAt != null && !createdAt.isAfter(since)) {
                 continue;
             }
@@ -271,8 +271,8 @@ public class GitHubPoller {
             String issueRef = repoFullName + "#" + issueNumber;
 
             try {
-                String payload = objectMapper.writeValueAsString(wrapCommentAsWebhookPayload(
-                        comment, repoFullName, issueNumber));
+                String payload = objectMapper.writeValueAsString(GitHubEventClassifier.wrapComment(
+                        objectMapper, comment, issueNumber));
                 eventService.ingestEvent(eventSourceId, "github", "comment-added", issueRef, repoFullName, payload);
                 String author = comment.path("user").path("login").asText("unknown");
                 logLines.add("  comment-added: " + issueRef + " by " + author);
@@ -298,20 +298,20 @@ public class GitHubPoller {
         String repoFullName = owner + "/" + name;
 
         for (JsonNode pr : result.data()) {
-            Instant updatedAt = parseGitHubTimestamp(pr.path("updated_at").asText(null));
+            Instant updatedAt = GitHubEventClassifier.parseGitHubTimestamp(pr.path("updated_at").asText(null));
             if (since != null && updatedAt != null && !updatedAt.isAfter(since)) {
                 continue;
             }
 
-            String eventType = determinePrEventType(pr, since);
+            String eventType = GitHubEventClassifier.determinePrEventType(pr, since);
             if (eventType == null) continue;
 
             int number = pr.path("number").asInt(0);
             String issueRef = repoFullName + "#" + number;
 
             try {
-                String payload = objectMapper.writeValueAsString(wrapPrAsWebhookPayload(
-                        pr, repoFullName, eventType));
+                String payload = objectMapper.writeValueAsString(GitHubEventClassifier.wrapPullRequest(
+                        objectMapper, pr, eventType));
                 eventService.ingestEvent(eventSourceId, "github", eventType, issueRef, repoFullName, payload);
                 logLines.add("  " + eventType + ": " + issueRef + " — " + pr.path("title").asText(""));
                 count++;
@@ -341,7 +341,7 @@ public class GitHubPoller {
                 continue;
             }
 
-            Instant createdAt = parseGitHubTimestamp(comment.path("created_at").asText(null));
+            Instant createdAt = GitHubEventClassifier.parseGitHubTimestamp(comment.path("created_at").asText(null));
             if (since != null && createdAt != null && !createdAt.isAfter(since)) {
                 continue;
             }
@@ -349,8 +349,8 @@ public class GitHubPoller {
             String issueRef = repoFullName + "#" + prNumber;
 
             try {
-                String payload = objectMapper.writeValueAsString(wrapReviewCommentAsWebhookPayload(
-                        comment, repoFullName, prNumber));
+                String payload = objectMapper.writeValueAsString(GitHubEventClassifier.wrapReviewComment(
+                        objectMapper, comment, prNumber));
                 eventService.ingestEvent(eventSourceId, "github", "pr-review-comment", issueRef, repoFullName, payload);
                 String author = comment.path("user").path("login").asText("unknown");
                 logLines.add("  pr-review-comment: " + issueRef + " by " + author);
@@ -364,144 +364,6 @@ public class GitHubPoller {
         return count;
     }
 
-    /**
-     * Determines the event type for an issue based on its state and timing.
-     */
-    private String determineIssueEventType(JsonNode issue, Instant since) {
-        String state = issue.path("state").asText("");
-        Instant createdAt = parseGitHubTimestamp(issue.path("created_at").asText(null));
-        Instant updatedAt = parseGitHubTimestamp(issue.path("updated_at").asText(null));
-        Instant closedAt = parseGitHubTimestamp(issue.path("closed_at").asText(null));
-
-        if (since == null) {
-            return null;
-        }
-
-        if (createdAt != null && createdAt.isAfter(since)) {
-            return "issue-created";
-        }
-
-        if ("closed".equals(state) && closedAt != null && closedAt.isAfter(since)) {
-            return "issue-closed";
-        }
-
-        if (updatedAt != null && updatedAt.isAfter(since)) {
-            if ("open".equals(state) && closedAt != null) {
-                return "issue-reopened";
-            }
-            return "issue-updated";
-        }
-
-        return null;
-    }
-
-    /**
-     * Determines the event type for a pull request based on its state and timing.
-     */
-    String determinePrEventType(JsonNode pr, Instant since) {
-        String state = pr.path("state").asText("");
-        Instant createdAt = parseGitHubTimestamp(pr.path("created_at").asText(null));
-        Instant updatedAt = parseGitHubTimestamp(pr.path("updated_at").asText(null));
-        Instant closedAt = parseGitHubTimestamp(pr.path("closed_at").asText(null));
-        Instant mergedAt = parseGitHubTimestamp(pr.path("merged_at").asText(null));
-
-        if (since == null) {
-            return null;
-        }
-
-        if (createdAt != null && createdAt.isAfter(since)) {
-            return "pr-created";
-        }
-
-        if (mergedAt != null && mergedAt.isAfter(since)) {
-            return "pr-merged";
-        }
-
-        if ("closed".equals(state) && closedAt != null && closedAt.isAfter(since) && mergedAt == null) {
-            return "pr-closed";
-        }
-
-        if (updatedAt != null && updatedAt.isAfter(since)) {
-            if ("open".equals(state) && closedAt != null) {
-                return "pr-reopened";
-            }
-            return "pr-updated";
-        }
-
-        return null;
-    }
-
-    /**
-     * Wraps a GitHub Issues API response into a structure resembling a webhook payload,
-     * so the downstream processing is consistent regardless of event source.
-     */
-    private JsonNode wrapIssueAsWebhookPayload(JsonNode issue, String repoFullName, String eventType) {
-        String action = switch (eventType) {
-            case "issue-created" -> "opened";
-            case "issue-closed" -> "closed";
-            case "issue-reopened" -> "reopened";
-            default -> "edited";
-        };
-        var node = objectMapper.createObjectNode();
-        node.put("action", action);
-        node.put("polled", true);
-        node.set("issue", issue);
-        return node;
-    }
-
-    /**
-     * Wraps a GitHub Comments API response into a structure resembling a webhook payload.
-     */
-    private JsonNode wrapCommentAsWebhookPayload(JsonNode comment, String repoFullName, int issueNumber) {
-        var node = objectMapper.createObjectNode();
-        node.put("action", "created");
-        node.put("polled", true);
-        node.putObject("issue").put("number", issueNumber);
-        node.set("comment", comment);
-        return node;
-    }
-
-    /**
-     * Wraps a GitHub Pulls API response into a structure resembling a webhook payload,
-     * so the downstream processing is consistent regardless of event source.
-     */
-    private JsonNode wrapPrAsWebhookPayload(JsonNode pr, String repoFullName, String eventType) {
-        String action = switch (eventType) {
-            case "pr-created" -> "opened";
-            case "pr-closed" -> "closed";
-            case "pr-merged" -> "closed";
-            case "pr-reopened" -> "reopened";
-            default -> "edited";
-        };
-        var node = objectMapper.createObjectNode();
-        node.put("action", action);
-        node.put("polled", true);
-        node.set("pull_request", pr);
-        return node;
-    }
-
-    /**
-     * Wraps a GitHub Pull Review Comments API response into a structure resembling a webhook payload.
-     */
-    private JsonNode wrapReviewCommentAsWebhookPayload(JsonNode comment, String repoFullName, int prNumber) {
-        var node = objectMapper.createObjectNode();
-        node.put("action", "created");
-        node.put("polled", true);
-        node.putObject("pull_request").put("number", prNumber);
-        node.set("comment", comment);
-        return node;
-    }
-
-    Instant parseGitHubTimestamp(String timestamp) {
-        if (timestamp == null || timestamp.isEmpty()) {
-            return null;
-        }
-        try {
-            return DateTimeFormatter.ISO_DATE_TIME.parse(timestamp, Instant::from);
-        } catch (Exception e) {
-            return null;
-        }
-    }
 
     private int extractIssueNumberFromUrl(String issueUrl) {
         if (issueUrl == null || issueUrl.isEmpty()) {

--- a/events/github/src/test/java/io/apitomy/axiom/events/github/GitHubPollerPrEventTypeTest.java
+++ b/events/github/src/test/java/io/apitomy/axiom/events/github/GitHubPollerPrEventTypeTest.java
@@ -9,12 +9,11 @@ import java.time.Instant;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Tests for PR event type determination logic in {@link GitHubPoller}.
+ * Tests for PR event type determination logic in {@link GitHubEventClassifier}.
  */
 class GitHubPollerPrEventTypeTest {
 
     private final ObjectMapper mapper = new ObjectMapper();
-    private final GitHubPoller poller = new GitHubPoller();
 
     private final Instant since = Instant.parse("2025-06-01T00:00:00Z");
     private static final String AFTER = "2025-06-02T00:00:00Z";
@@ -26,7 +25,7 @@ class GitHubPollerPrEventTypeTest {
         pr.put("state", "open");
         pr.put("created_at", AFTER);
         pr.put("updated_at", AFTER);
-        assertEquals("pr-created", poller.determinePrEventType(pr, since));
+        assertEquals("pr-created", GitHubEventClassifier.determinePrEventType(pr, since));
     }
 
     @Test
@@ -37,7 +36,7 @@ class GitHubPollerPrEventTypeTest {
         pr.put("updated_at", AFTER);
         pr.put("closed_at", AFTER);
         pr.put("merged_at", AFTER);
-        assertEquals("pr-merged", poller.determinePrEventType(pr, since));
+        assertEquals("pr-merged", GitHubEventClassifier.determinePrEventType(pr, since));
     }
 
     @Test
@@ -47,7 +46,7 @@ class GitHubPollerPrEventTypeTest {
         pr.put("created_at", BEFORE);
         pr.put("updated_at", AFTER);
         pr.put("closed_at", AFTER);
-        assertEquals("pr-closed", poller.determinePrEventType(pr, since));
+        assertEquals("pr-closed", GitHubEventClassifier.determinePrEventType(pr, since));
     }
 
     @Test
@@ -57,7 +56,7 @@ class GitHubPollerPrEventTypeTest {
         pr.put("created_at", BEFORE);
         pr.put("updated_at", AFTER);
         pr.put("closed_at", BEFORE);
-        assertEquals("pr-reopened", poller.determinePrEventType(pr, since));
+        assertEquals("pr-reopened", GitHubEventClassifier.determinePrEventType(pr, since));
     }
 
     @Test
@@ -66,7 +65,7 @@ class GitHubPollerPrEventTypeTest {
         pr.put("state", "open");
         pr.put("created_at", BEFORE);
         pr.put("updated_at", AFTER);
-        assertEquals("pr-updated", poller.determinePrEventType(pr, since));
+        assertEquals("pr-updated", GitHubEventClassifier.determinePrEventType(pr, since));
     }
 
     @Test
@@ -75,7 +74,7 @@ class GitHubPollerPrEventTypeTest {
         pr.put("state", "open");
         pr.put("created_at", BEFORE);
         pr.put("updated_at", BEFORE);
-        assertNull(poller.determinePrEventType(pr, since));
+        assertNull(GitHubEventClassifier.determinePrEventType(pr, since));
     }
 
     @Test
@@ -84,7 +83,7 @@ class GitHubPollerPrEventTypeTest {
         pr.put("state", "open");
         pr.put("created_at", AFTER);
         pr.put("updated_at", AFTER);
-        assertNull(poller.determinePrEventType(pr, null));
+        assertNull(GitHubEventClassifier.determinePrEventType(pr, null));
     }
 
     @Test
@@ -95,7 +94,7 @@ class GitHubPollerPrEventTypeTest {
         pr.put("updated_at", AFTER);
         pr.put("closed_at", AFTER);
         pr.put("merged_at", AFTER);
-        assertEquals("pr-merged", poller.determinePrEventType(pr, since));
+        assertEquals("pr-merged", GitHubEventClassifier.determinePrEventType(pr, since));
     }
 
     @Test
@@ -106,6 +105,6 @@ class GitHubPollerPrEventTypeTest {
         pr.put("updated_at", AFTER);
         pr.put("closed_at", AFTER);
         pr.put("merged_at", AFTER);
-        assertEquals("pr-created", poller.determinePrEventType(pr, since));
+        assertEquals("pr-created", GitHubEventClassifier.determinePrEventType(pr, since));
     }
 }

--- a/events/jira/src/main/java/io/apitomy/axiom/events/jira/JiraDryRunService.java
+++ b/events/jira/src/main/java/io/apitomy/axiom/events/jira/JiraDryRunService.java
@@ -1,0 +1,80 @@
+package io.apitomy.axiom.events.jira;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.apitomy.axiom.events.core.DryRunEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Fetches recent events from a Jira project and classifies them
+ * for dry-run filter evaluation. Does not ingest or persist anything.
+ */
+@ApplicationScoped
+public class JiraDryRunService {
+
+    private static final Duration LOOKBACK = Duration.ofDays(7);
+
+    @Inject
+    JiraApiClient apiClient;
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    /**
+     * Fetches recent events from the Jira project described by the
+     * configuration and classifies them into event types with payloads.
+     *
+     * @param baseUrl  Jira base URL
+     * @param project  Jira project key
+     * @param credentials  authentication credentials
+     * @return list of classified events
+     */
+    public List<DryRunEvent> fetchRecentEvents(String baseUrl, String project,
+                                                String credentials) {
+        Instant since = Instant.now().minus(LOOKBACK);
+        List<DryRunEvent> events = new ArrayList<>();
+
+        var result = apiClient.fetchIssuesUpdatedSince(baseUrl, project, since, credentials);
+        if (result.data() != null) {
+            JsonNode issues = result.data().path("issues");
+            if (issues.isArray()) {
+                for (JsonNode issue : issues) {
+                    JsonNode fields = issue.path("fields");
+                    String key = issue.path("key").asText("");
+                    String summary = fields.path("summary").asText("");
+                    String eventType = JiraEventClassifier.determineEventType(fields, since);
+                    if (eventType != null) {
+                        ObjectNode payload = JiraEventClassifier.buildIssuePayload(
+                                objectMapper, issue, fields, baseUrl, eventType);
+                        events.add(new DryRunEvent(eventType, key, summary, payload));
+                    }
+                    // Check for new comments
+                    JsonNode comments = fields.path("comment").path("comments");
+                    if (comments.isArray()) {
+                        for (JsonNode comment : comments) {
+                            Instant commentCreated = JiraEventClassifier.parseJiraTimestamp(
+                                    comment.path("created").asText(null));
+                            if (commentCreated != null && commentCreated.isAfter(since)) {
+                                String author = comment.path("author")
+                                        .path("displayName").asText("unknown");
+                                ObjectNode payload = JiraEventClassifier.buildCommentPayload(
+                                        objectMapper, issue, fields, comment, baseUrl);
+                                events.add(new DryRunEvent("comment-added", key,
+                                        "Comment by " + author, payload));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return events;
+    }
+}

--- a/events/jira/src/main/java/io/apitomy/axiom/events/jira/JiraEventClassifier.java
+++ b/events/jira/src/main/java/io/apitomy/axiom/events/jira/JiraEventClassifier.java
@@ -1,0 +1,165 @@
+package io.apitomy.axiom.events.jira;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Classifies and wraps raw Jira API responses into event types and
+ * normalized payloads. Shared by the poller and the dry-run service.
+ */
+public class JiraEventClassifier {
+
+    private static final Logger LOG = Logger.getLogger(JiraEventClassifier.class);
+
+    private JiraEventClassifier() {
+    }
+
+    /**
+     * Determines the event type based on issue field timestamps.
+     *
+     * @param fields the fields object from a Jira issue
+     * @param since the timestamp to compare against
+     * @return the event type, or null if the issue is not relevant
+     */
+    public static String determineEventType(JsonNode fields, Instant since) {
+        Instant createdAt = parseJiraTimestamp(fields.path("created").asText(null));
+        Instant updatedAt = parseJiraTimestamp(fields.path("updated").asText(null));
+
+        if (createdAt != null && createdAt.isAfter(since)) {
+            return "issue-created";
+        }
+
+        JsonNode resolution = fields.path("resolution");
+        JsonNode status = fields.path("status");
+        String statusCategory = status.path("statusCategory").path("key").asText("");
+
+        if ("done".equals(statusCategory) && updatedAt != null && updatedAt.isAfter(since)) {
+            return "issue-closed";
+        }
+
+        if (updatedAt != null && updatedAt.isAfter(since)) {
+            return "issue-updated";
+        }
+
+        return null;
+    }
+
+    /**
+     * Builds a normalized issue payload for consistency with other event sources.
+     *
+     * @param mapper the ObjectMapper for creating nodes
+     * @param issue the issue JSON from the Jira API
+     * @param fields the fields object from the issue
+     * @param baseUrl the Jira base URL
+     * @param eventType the classified event type
+     * @return the normalized payload
+     */
+    public static ObjectNode buildIssuePayload(ObjectMapper mapper, JsonNode issue,
+                                                JsonNode fields, String baseUrl, String eventType) {
+        String issueKey = issue.path("key").asText("");
+        String action = switch (eventType) {
+            case "issue-created" -> "created";
+            case "issue-closed" -> "closed";
+            case "issue-reopened" -> "reopened";
+            default -> "updated";
+        };
+
+        ObjectNode node = mapper.createObjectNode();
+        node.put("action", action);
+        node.put("polled", true);
+
+        ObjectNode issueNode = node.putObject("issue");
+        issueNode.put("key", issueKey);
+        issueNode.put("summary", fields.path("summary").asText(""));
+        issueNode.put("status", fields.path("status").path("name").asText(""));
+        issueNode.put("priority", fields.path("priority").path("name").asText(""));
+        issueNode.put("created", fields.path("created").asText(""));
+        issueNode.put("updated", fields.path("updated").asText(""));
+        issueNode.put("url", baseUrl + "/browse/" + issueKey);
+
+        JsonNode assignee = fields.path("assignee");
+        if (!assignee.isMissingNode() && !assignee.isNull()) {
+            issueNode.put("assignee", assignee.path("emailAddress")
+                    .asText(assignee.path("displayName").asText("")));
+        }
+
+        JsonNode reporter = fields.path("reporter");
+        if (!reporter.isMissingNode() && !reporter.isNull()) {
+            issueNode.put("reporter", reporter.path("emailAddress")
+                    .asText(reporter.path("displayName").asText("")));
+        }
+
+        JsonNode labels = fields.path("labels");
+        if (labels.isArray()) {
+            var labelsArray = issueNode.putArray("labels");
+            for (JsonNode label : labels) {
+                labelsArray.add(label.asText());
+            }
+        }
+
+        JsonNode resolution = fields.path("resolution");
+        if (!resolution.isMissingNode() && !resolution.isNull()) {
+            issueNode.put("resolution", resolution.path("name").asText(""));
+        }
+
+        return node;
+    }
+
+    /**
+     * Builds a normalized comment payload.
+     *
+     * @param mapper the ObjectMapper for creating nodes
+     * @param issue the issue JSON from the Jira API
+     * @param fields the fields object from the issue
+     * @param comment the comment JSON
+     * @param baseUrl the Jira base URL
+     * @return the normalized payload
+     */
+    public static ObjectNode buildCommentPayload(ObjectMapper mapper, JsonNode issue,
+                                                  JsonNode fields, JsonNode comment, String baseUrl) {
+        String issueKey = issue.path("key").asText("");
+        ObjectNode node = mapper.createObjectNode();
+        node.put("action", "commented");
+        node.put("polled", true);
+
+        ObjectNode issueNode = node.putObject("issue");
+        issueNode.put("key", issueKey);
+        issueNode.put("summary", fields.path("summary").asText(""));
+        issueNode.put("url", baseUrl + "/browse/" + issueKey);
+
+        ObjectNode commentNode = node.putObject("comment");
+        JsonNode author = comment.path("author");
+        commentNode.put("author", author.path("emailAddress")
+                .asText(author.path("displayName").asText("")));
+        commentNode.put("body", comment.path("body").asText(""));
+        commentNode.put("created", comment.path("created").asText(""));
+
+        return node;
+    }
+
+    /**
+     * Parses a Jira API timestamp string into an Instant.
+     *
+     * @param timestamp the timestamp string
+     * @return the parsed Instant, or null if parsing fails
+     */
+    public static Instant parseJiraTimestamp(String timestamp) {
+        if (timestamp == null || timestamp.isEmpty()) return null;
+        try {
+            return DateTimeFormatter.ISO_DATE_TIME.parse(timestamp, Instant::from);
+        } catch (Exception e) {
+            try {
+                return DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+                        .parse(timestamp, Instant::from);
+            } catch (Exception e2) {
+                LOG.tracef("Failed to parse Jira timestamp: %s", timestamp);
+                return null;
+            }
+        }
+    }
+}

--- a/events/jira/src/main/java/io/apitomy/axiom/events/jira/JiraPoller.java
+++ b/events/jira/src/main/java/io/apitomy/axiom/events/jira/JiraPoller.java
@@ -176,11 +176,11 @@ public class JiraPoller {
 
             JsonNode fields = issue.path("fields");
 
-            String eventType = determineEventType(fields, since);
+            String eventType = JiraEventClassifier.determineEventType(fields, since);
             if (eventType != null) {
                 try {
                     String payload = objectMapper.writeValueAsString(
-                            buildIssuePayload(issueKey, fields, baseUrl, eventType));
+                            JiraEventClassifier.buildIssuePayload(objectMapper, issue, fields, baseUrl, eventType));
                     eventService.ingestEvent(source.id, "jira", eventType,
                             issueKey, project, payload);
                     logLines.add("  " + eventType + ": " + issueKey + " — "
@@ -192,7 +192,7 @@ public class JiraPoller {
                 }
             }
 
-            int comments = ingestNewComments(source.id, issueKey, project,
+            int comments = ingestNewComments(source.id, issue, project,
                     fields, baseUrl, since, logLines);
             eventsIngested += comments;
         }
@@ -213,51 +213,27 @@ public class JiraPoller {
                 String.join("\n", logLines), eventsIngested);
     }
 
-    /**
-     * Determines the event type based on issue field timestamps.
-     */
-    private String determineEventType(JsonNode fields, Instant since) {
-        Instant createdAt = parseJiraTimestamp(fields.path("created").asText(null));
-        Instant updatedAt = parseJiraTimestamp(fields.path("updated").asText(null));
-
-        if (createdAt != null && createdAt.isAfter(since)) {
-            return "issue-created";
-        }
-
-        JsonNode resolution = fields.path("resolution");
-        JsonNode status = fields.path("status");
-        String statusCategory = status.path("statusCategory").path("key").asText("");
-
-        if ("done".equals(statusCategory) && updatedAt != null && updatedAt.isAfter(since)) {
-            return "issue-closed";
-        }
-
-        if (updatedAt != null && updatedAt.isAfter(since)) {
-            return "issue-updated";
-        }
-
-        return null;
-    }
 
     /**
      * Extracts new comments from an issue's comment field and ingests them as events.
      */
-    private int ingestNewComments(Long eventSourceId, String issueKey, String project,
+    private int ingestNewComments(Long eventSourceId, JsonNode issue, String project,
                                    JsonNode fields, String baseUrl, Instant since,
                                    List<String> logLines) {
+        String issueKey = issue.path("key").asText("");
         JsonNode commentNode = fields.path("comment").path("comments");
         if (!commentNode.isArray()) return 0;
 
         int count = 0;
         for (JsonNode comment : commentNode) {
-            Instant createdAt = parseJiraTimestamp(comment.path("created").asText(null));
+            Instant createdAt = JiraEventClassifier.parseJiraTimestamp(comment.path("created").asText(null));
             if (createdAt == null || !createdAt.isAfter(since)) {
                 continue;
             }
 
             try {
                 String payload = objectMapper.writeValueAsString(
-                        buildCommentPayload(issueKey, fields, comment, baseUrl));
+                        JiraEventClassifier.buildCommentPayload(objectMapper, issue, fields, comment, baseUrl));
                 eventService.ingestEvent(eventSourceId, "jira", "comment-added",
                         issueKey, project, payload);
                 String author = comment.path("author").path("displayName").asText("unknown");
@@ -271,97 +247,6 @@ public class JiraPoller {
         return count;
     }
 
-    /**
-     * Builds a normalized issue payload for consistency with other event sources.
-     */
-    private JsonNode buildIssuePayload(String issueKey, JsonNode fields,
-                                        String baseUrl, String eventType) {
-        String action = switch (eventType) {
-            case "issue-created" -> "created";
-            case "issue-closed" -> "closed";
-            case "issue-reopened" -> "reopened";
-            default -> "updated";
-        };
-
-        var node = objectMapper.createObjectNode();
-        node.put("action", action);
-        node.put("polled", true);
-
-        var issueNode = node.putObject("issue");
-        issueNode.put("key", issueKey);
-        issueNode.put("summary", fields.path("summary").asText(""));
-        issueNode.put("status", fields.path("status").path("name").asText(""));
-        issueNode.put("priority", fields.path("priority").path("name").asText(""));
-        issueNode.put("created", fields.path("created").asText(""));
-        issueNode.put("updated", fields.path("updated").asText(""));
-        issueNode.put("url", baseUrl + "/browse/" + issueKey);
-
-        JsonNode assignee = fields.path("assignee");
-        if (!assignee.isMissingNode() && !assignee.isNull()) {
-            issueNode.put("assignee", assignee.path("emailAddress")
-                    .asText(assignee.path("displayName").asText("")));
-        }
-
-        JsonNode reporter = fields.path("reporter");
-        if (!reporter.isMissingNode() && !reporter.isNull()) {
-            issueNode.put("reporter", reporter.path("emailAddress")
-                    .asText(reporter.path("displayName").asText("")));
-        }
-
-        JsonNode labels = fields.path("labels");
-        if (labels.isArray()) {
-            var labelsArray = issueNode.putArray("labels");
-            for (JsonNode label : labels) {
-                labelsArray.add(label.asText());
-            }
-        }
-
-        JsonNode resolution = fields.path("resolution");
-        if (!resolution.isMissingNode() && !resolution.isNull()) {
-            issueNode.put("resolution", resolution.path("name").asText(""));
-        }
-
-        return node;
-    }
-
-    /**
-     * Builds a normalized comment payload.
-     */
-    private JsonNode buildCommentPayload(String issueKey, JsonNode fields,
-                                          JsonNode comment, String baseUrl) {
-        var node = objectMapper.createObjectNode();
-        node.put("action", "commented");
-        node.put("polled", true);
-
-        var issueNode = node.putObject("issue");
-        issueNode.put("key", issueKey);
-        issueNode.put("summary", fields.path("summary").asText(""));
-        issueNode.put("url", baseUrl + "/browse/" + issueKey);
-
-        var commentNode = node.putObject("comment");
-        JsonNode author = comment.path("author");
-        commentNode.put("author", author.path("emailAddress")
-                .asText(author.path("displayName").asText("")));
-        commentNode.put("body", comment.path("body").asText(""));
-        commentNode.put("created", comment.path("created").asText(""));
-
-        return node;
-    }
-
-    private Instant parseJiraTimestamp(String timestamp) {
-        if (timestamp == null || timestamp.isEmpty()) return null;
-        try {
-            return DateTimeFormatter.ISO_DATE_TIME.parse(timestamp, Instant::from);
-        } catch (Exception e) {
-            try {
-                return DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
-                        .parse(timestamp, Instant::from);
-            } catch (Exception e2) {
-                LOG.tracef("Failed to parse Jira timestamp: %s", timestamp);
-                return null;
-            }
-        }
-    }
 
     @Transactional
     void updateLastPolledAt(Long sourceId, Instant polledAt) {

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -794,6 +794,7 @@ export interface EventSource {
     secretName?: string;
     configuration?: Record<string, string>;
     labels?: string[];
+    filters?: EventSourceFilters;
 }
 
 export type NewEventSource = Omit<EventSource, "id">;
@@ -835,6 +836,16 @@ export async function fetchEventSource(id: number): Promise<EventSource> {
     return response.json();
 }
 
+export async function dryRunFilters(request: FilterDryRunRequest): Promise<FilterDryRunResponse> {
+    const response = await fetch(`${API}/event-sources/filters/dry-run`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(request),
+    });
+    if (!response.ok) throw new Error(`Dry run failed: ${response.statusText}`);
+    return response.json();
+}
+
 export interface EventSourceLog {
     id: number;
     eventSourceId: number;
@@ -843,6 +854,39 @@ export interface EventSourceLog {
     detail?: string;
     eventsIngested?: number;
     createdOn: string;
+}
+
+export interface EventSourceFilterRule {
+    type: "event-type" | "payload";
+    pointer?: string;
+    pattern: string;
+}
+
+export interface EventSourceFilters {
+    include: EventSourceFilterRule[];
+    exclude: EventSourceFilterRule[];
+}
+
+export interface FilterDryRunRequest {
+    sourceType: string;
+    configuration: Record<string, string>;
+    secretName?: string;
+    filters: EventSourceFilters;
+}
+
+export interface FilterDryRunResult {
+    eventType: string;
+    issueRef: string;
+    summary: string;
+    allowed: boolean;
+    matchedRule?: string;
+}
+
+export interface FilterDryRunResponse {
+    results: FilterDryRunResult[];
+    totalEvaluated: number;
+    totalAllowed: number;
+    totalBlocked: number;
 }
 
 export async function fetchEventSourceLogs(

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -880,6 +880,7 @@ export interface FilterDryRunResult {
     summary: string;
     allowed: boolean;
     matchedRule?: string;
+    payload?: string;
 }
 
 export interface FilterDryRunResponse {

--- a/ui/src/pages/EventSourceDetailPage.tsx
+++ b/ui/src/pages/EventSourceDetailPage.tsx
@@ -33,16 +33,24 @@ import {
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import SaveIcon from "@patternfly/react-icons/dist/esm/icons/save-icon";
 import SyncAltIcon from "@patternfly/react-icons/dist/esm/icons/sync-alt-icon";
+import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
+import CheckCircleIcon from "@patternfly/react-icons/dist/esm/icons/check-circle-icon";
+import TimesCircleIcon from "@patternfly/react-icons/dist/esm/icons/times-circle-icon";
 import { EditLabelsModal } from "../components/EditLabelsModal";
 import { LabelDisplay } from "../components/LabelDisplay";
 import {
     type EventSource,
     type EventSourceLog,
+    type EventSourceFilters,
+    type EventSourceFilterRule,
+    type FilterDryRunRequest,
+    type FilterDryRunResponse,
     type Secret,
     fetchEventSource,
     updateEventSource,
     fetchEventSourceLogs,
     fetchSecrets,
+    dryRunFilters,
 } from "../config/api";
 
 export function EventSourceDetailPage() {
@@ -166,10 +174,27 @@ export function EventSourceDetailPage() {
                             onEditLabels={() => setIsLabelsOpen(true)} />
                     </TabContent>
                 </Tab>
-                <Tab eventKey={1} title={<TabTitleText>
+                <Tab eventKey={1} title={<TabTitleText>Filters</TabTitleText>}>
+                    <TabContent id="filters-tab" eventKey={1} activeKey={activeTab}
+                        style={{ marginTop: "24px" }}>
+                        {source && (
+                            <FiltersTab
+                                source={source}
+                                onSave={async (filters) => {
+                                    await updateEventSource(source.id, {
+                                        ...source,
+                                        filters,
+                                    });
+                                    loadData();
+                                }}
+                            />
+                        )}
+                    </TabContent>
+                </Tab>
+                <Tab eventKey={2} title={<TabTitleText>
                     Poll Logs{logs.length > 0 ? ` (${logs.length})` : ""}
                 </TabTitleText>}>
-                    <TabContent id="logs-tab" eventKey={1} activeKey={activeTab}
+                    <TabContent id="logs-tab" eventKey={2} activeKey={activeTab}
                         style={{ marginTop: "24px" }}>
                         <LogsTab logs={logs} totalCount={logsTotalCount}
                             page={logsPage} perPage={logsPerPage}
@@ -371,6 +396,226 @@ function LogsTab({ logs, totalCount, page, perPage, onPageChange, onPerPageChang
                     )}
                 </ModalBody>
             </Modal>
+        </div>
+    );
+}
+
+function FiltersTab({ source, onSave }: {
+    source: EventSource;
+    onSave: (filters: EventSourceFilters) => Promise<void>;
+}) {
+    const [filters, setFilters] = useState<EventSourceFilters>(
+        source.filters ?? { include: [], exclude: [] }
+    );
+    const [dirty, setDirty] = useState(false);
+    const [saving, setSaving] = useState(false);
+    const [dryRunResults, setDryRunResults] = useState<FilterDryRunResponse | null>(null);
+    const [dryRunLoading, setDryRunLoading] = useState(false);
+
+    // State for the "add rule" form
+    const [addingTo, setAddingTo] = useState<"include" | "exclude" | null>(null);
+    const [newRuleType, setNewRuleType] = useState<"event-type" | "payload">("event-type");
+    const [newRulePointer, setNewRulePointer] = useState("");
+    const [newRulePattern, setNewRulePattern] = useState("");
+
+    const handleAddRule = (list: "include" | "exclude") => {
+        const rule: EventSourceFilterRule = {
+            type: newRuleType,
+            pattern: newRulePattern,
+            ...(newRuleType === "payload" ? { pointer: newRulePointer } : {}),
+        };
+        const updated = { ...filters };
+        updated[list] = [...updated[list], rule];
+        setFilters(updated);
+        setDirty(true);
+        setAddingTo(null);
+        setNewRuleType("event-type");
+        setNewRulePointer("");
+        setNewRulePattern("");
+    };
+
+    const handleDeleteRule = (list: "include" | "exclude", index: number) => {
+        const updated = { ...filters };
+        updated[list] = updated[list].filter((_, i) => i !== index);
+        setFilters(updated);
+        setDirty(true);
+    };
+
+    const handleSave = async () => {
+        setSaving(true);
+        try {
+            await onSave(filters);
+            setDirty(false);
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const handleDryRun = async () => {
+        setDryRunLoading(true);
+        try {
+            const request: FilterDryRunRequest = {
+                sourceType: source.sourceType,
+                configuration: source.configuration ?? {},
+                secretName: source.secretName,
+                filters,
+            };
+            const response = await dryRunFilters(request);
+            setDryRunResults(response);
+        } catch (e) {
+            console.error("Dry run failed:", e);
+        } finally {
+            setDryRunLoading(false);
+        }
+    };
+
+    const renderRuleTable = (list: "include" | "exclude", rules: EventSourceFilterRule[]) => (
+        <div style={{ marginBottom: "24px" }}>
+            <Title headingLevel="h3" size="md" style={{ marginBottom: "12px" }}>
+                {list === "include" ? "Include Rules" : "Exclude Rules"}
+            </Title>
+            <Table aria-label={`${list} rules`} variant="compact">
+                <Thead>
+                    <Tr>
+                        <Th>Type</Th>
+                        <Th>Pointer</Th>
+                        <Th>Pattern</Th>
+                        <Th>Actions</Th>
+                    </Tr>
+                </Thead>
+                <Tbody>
+                    {rules.map((rule, index) => (
+                        <Tr key={index}>
+                            <Td>{rule.type}</Td>
+                            <Td>{rule.pointer ?? "—"}</Td>
+                            <Td><code>{rule.pattern}</code></Td>
+                            <Td>
+                                <Button variant="plain" aria-label="Delete rule"
+                                    onClick={() => handleDeleteRule(list, index)}>
+                                    <TrashIcon />
+                                </Button>
+                            </Td>
+                        </Tr>
+                    ))}
+                    {addingTo === list && (
+                        <Tr>
+                            <Td>
+                                <FormSelect value={newRuleType}
+                                    onChange={(_e, v) => setNewRuleType(v as "event-type" | "payload")}>
+                                    <FormSelectOption value="event-type" label="event-type" />
+                                    <FormSelectOption value="payload" label="payload" />
+                                </FormSelect>
+                            </Td>
+                            <Td>
+                                {newRuleType === "payload" ? (
+                                    <TextInput value={newRulePointer}
+                                        onChange={(_e, v) => setNewRulePointer(v)}
+                                        placeholder="/path/to/field" />
+                                ) : (
+                                    <span>—</span>
+                                )}
+                            </Td>
+                            <Td>
+                                <TextInput value={newRulePattern}
+                                    onChange={(_e, v) => setNewRulePattern(v)}
+                                    placeholder="^pattern.*" />
+                            </Td>
+                            <Td>
+                                <Button variant="primary" size="sm" style={{ marginRight: "8px" }}
+                                    isDisabled={!newRulePattern}
+                                    onClick={() => handleAddRule(list)}>
+                                    Add
+                                </Button>
+                                <Button variant="link" size="sm"
+                                    onClick={() => {
+                                        setAddingTo(null);
+                                        setNewRuleType("event-type");
+                                        setNewRulePointer("");
+                                        setNewRulePattern("");
+                                    }}>
+                                    Cancel
+                                </Button>
+                            </Td>
+                        </Tr>
+                    )}
+                </Tbody>
+            </Table>
+            {addingTo !== list && (
+                <Button variant="link" onClick={() => setAddingTo(list)}
+                    style={{ marginTop: "8px" }}>
+                    Add {list} rule
+                </Button>
+            )}
+        </div>
+    );
+
+    return (
+        <div>
+            <Flex justifyContent={{ default: "justifyContentSpaceBetween" }}
+                alignItems={{ default: "alignItemsCenter" }}
+                style={{ marginBottom: "16px" }}>
+                <FlexItem>
+                    <p className="axiom-text-subtle">
+                        Configure filter rules to control which events are processed. Include rules allow matching events; exclude rules block them.
+                    </p>
+                </FlexItem>
+                <FlexItem>
+                    <Button variant="primary" icon={<SaveIcon />} onClick={handleSave}
+                        isDisabled={!dirty || saving} isLoading={saving}>
+                        {saving ? "Saving..." : "Save"}
+                    </Button>
+                </FlexItem>
+            </Flex>
+
+            {renderRuleTable("include", filters.include)}
+            {renderRuleTable("exclude", filters.exclude)}
+
+            <div style={{ marginTop: "24px", marginBottom: "24px" }}>
+                <Button variant="secondary" onClick={handleDryRun}
+                    isLoading={dryRunLoading}
+                    isDisabled={dryRunLoading}>
+                    {dryRunLoading ? "Testing..." : "Test Filters"}
+                </Button>
+            </div>
+
+            {dryRunResults && (
+                <div style={{ marginTop: "24px" }}>
+                    <Title headingLevel="h3" size="md" style={{ marginBottom: "12px" }}>
+                        Test Results
+                    </Title>
+                    <p style={{ marginBottom: "12px" }}>
+                        <strong>{dryRunResults.totalAllowed} allowed</strong>, <strong>{dryRunResults.totalBlocked} blocked</strong> out of <strong>{dryRunResults.totalEvaluated}</strong> events
+                    </p>
+                    <Table aria-label="Filter test results" variant="compact">
+                        <Thead>
+                            <Tr>
+                                <Th>Result</Th>
+                                <Th>Event Type</Th>
+                                <Th>Reference</Th>
+                                <Th>Summary</Th>
+                                <Th>Matched Rule</Th>
+                            </Tr>
+                        </Thead>
+                        <Tbody>
+                            {dryRunResults.results.map((result, index) => (
+                                <Tr key={index}>
+                                    <Td>
+                                        <Label isCompact
+                                            color={result.allowed ? "green" : "red"}
+                                            icon={result.allowed ? <CheckCircleIcon /> : <TimesCircleIcon />}>
+                                            {result.allowed ? "Allowed" : "Blocked"}
+                                        </Label>
+                                    </Td>
+                                    <Td>{result.eventType}</Td>
+                                    <Td>{result.issueRef}</Td>
+                                    <Td>{result.summary}</Td>
+                                    <Td>{result.matchedRule ?? "—"}</Td>
+                                </Tr>
+                            ))}
+                        </Tbody>
+                    </Table>
+                </div>
+            )}
         </div>
     );
 }

--- a/ui/src/pages/EventSourceDetailPage.tsx
+++ b/ui/src/pages/EventSourceDetailPage.tsx
@@ -1,9 +1,12 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useParams, Link } from "react-router-dom";
 import {
     Breadcrumb,
     BreadcrumbItem,
     Button,
+    Card,
+    CardBody,
+    CardTitle,
     EmptyState,
     EmptyStateBody,
     Flex,
@@ -16,6 +19,10 @@ import {
     HelperTextItem,
     CodeBlock,
     CodeBlockCode,
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
     Label,
     Modal,
     ModalBody,
@@ -36,6 +43,8 @@ import SyncAltIcon from "@patternfly/react-icons/dist/esm/icons/sync-alt-icon";
 import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
 import CheckCircleIcon from "@patternfly/react-icons/dist/esm/icons/check-circle-icon";
 import TimesCircleIcon from "@patternfly/react-icons/dist/esm/icons/times-circle-icon";
+import { CodeEditor, Language } from "@patternfly/react-code-editor";
+import { useEffectiveTheme } from "../hooks/useTheme";
 import { EditLabelsModal } from "../components/EditLabelsModal";
 import { LabelDisplay } from "../components/LabelDisplay";
 import {
@@ -45,6 +54,7 @@ import {
     type EventSourceFilterRule,
     type FilterDryRunRequest,
     type FilterDryRunResponse,
+    type FilterDryRunResult,
     type Secret,
     fetchEventSource,
     updateEventSource,
@@ -59,6 +69,7 @@ export function EventSourceDetailPage() {
 
     const [source, setSource] = useState<EventSource | null>(null);
     const [form, setForm] = useState<Partial<EventSource>>({});
+    const [filters, setFilters] = useState<EventSourceFilters>({ include: [], exclude: [] });
     const [sourceUrl, setSourceUrl] = useState("");
     const [secrets, setSecrets] = useState<Secret[]>([]);
     const [logs, setLogs] = useState<EventSourceLog[]>([]);
@@ -87,6 +98,7 @@ export function EventSourceDetailPage() {
                     configuration: src.configuration,
                     labels: src.labels || [],
                 });
+                setFilters(src.filters ?? { include: [], exclude: [] });
                 setSourceUrl(buildUrlFromConfig(src));
                 setSecrets(secs);
                 setLogs(logResults.items);
@@ -105,10 +117,15 @@ export function EventSourceDetailPage() {
         setDirty(true);
     };
 
+    const updateFilters = (updated: EventSourceFilters) => {
+        setFilters(updated);
+        setDirty(true);
+    };
+
     const handleSave = () => {
         setSaving(true);
         const config = buildConfigFromUrl(form.sourceType || "", sourceUrl);
-        const data = { ...form, configuration: config } as EventSource;
+        const data = { ...form, configuration: config, filters } as EventSource;
         updateEventSource(id, data)
             .then((updated) => { setSource(updated); setDirty(false); })
             .catch(console.error)
@@ -180,13 +197,9 @@ export function EventSourceDetailPage() {
                         {source && (
                             <FiltersTab
                                 source={source}
-                                onSave={async (filters) => {
-                                    await updateEventSource(source.id, {
-                                        ...source,
-                                        filters,
-                                    });
-                                    loadData();
-                                }}
+                                filters={filters}
+                                onFiltersChange={updateFilters}
+                                isActive={activeTab === 1}
                             />
                         )}
                     </TabContent>
@@ -400,19 +413,17 @@ function LogsTab({ logs, totalCount, page, perPage, onPageChange, onPerPageChang
     );
 }
 
-function FiltersTab({ source, onSave }: {
+function FiltersTab({ source, filters, onFiltersChange, isActive }: {
     source: EventSource;
-    onSave: (filters: EventSourceFilters) => Promise<void>;
+    filters: EventSourceFilters;
+    onFiltersChange: (filters: EventSourceFilters) => void;
+    isActive: boolean;
 }) {
-    const [filters, setFilters] = useState<EventSourceFilters>(
-        source.filters ?? { include: [], exclude: [] }
-    );
-    const [dirty, setDirty] = useState(false);
-    const [saving, setSaving] = useState(false);
     const [dryRunResults, setDryRunResults] = useState<FilterDryRunResponse | null>(null);
     const [dryRunLoading, setDryRunLoading] = useState(false);
+    const [selectedResult, setSelectedResult] = useState<FilterDryRunResult | null>(null);
+    const prevActiveRef = useRef(false);
 
-    // State for the "add rule" form
     const [addingTo, setAddingTo] = useState<"include" | "exclude" | null>(null);
     const [newRuleType, setNewRuleType] = useState<"event-type" | "payload">("event-type");
     const [newRulePointer, setNewRulePointer] = useState("");
@@ -426,8 +437,7 @@ function FiltersTab({ source, onSave }: {
         };
         const updated = { ...filters };
         updated[list] = [...updated[list], rule];
-        setFilters(updated);
-        setDirty(true);
+        onFiltersChange(updated);
         setAddingTo(null);
         setNewRuleType("event-type");
         setNewRulePointer("");
@@ -437,21 +447,10 @@ function FiltersTab({ source, onSave }: {
     const handleDeleteRule = (list: "include" | "exclude", index: number) => {
         const updated = { ...filters };
         updated[list] = updated[list].filter((_, i) => i !== index);
-        setFilters(updated);
-        setDirty(true);
+        onFiltersChange(updated);
     };
 
-    const handleSave = async () => {
-        setSaving(true);
-        try {
-            await onSave(filters);
-            setDirty(false);
-        } finally {
-            setSaving(false);
-        }
-    };
-
-    const handleDryRun = async () => {
+    const handleDryRun = useCallback(async () => {
         setDryRunLoading(true);
         try {
             const request: FilterDryRunRequest = {
@@ -467,156 +466,281 @@ function FiltersTab({ source, onSave }: {
         } finally {
             setDryRunLoading(false);
         }
-    };
+    }, [source, filters]);
+
+    useEffect(() => {
+        if (isActive && !prevActiveRef.current) {
+            handleDryRun();
+        }
+        prevActiveRef.current = isActive;
+    }, [isActive, handleDryRun]);
+
+    useEffect(() => {
+        if (isActive) {
+            handleDryRun();
+        }
+    }, [filters]); // eslint-disable-line react-hooks/exhaustive-deps
 
     const renderRuleTable = (list: "include" | "exclude", rules: EventSourceFilterRule[]) => (
-        <div style={{ marginBottom: "24px" }}>
-            <Title headingLevel="h3" size="md" style={{ marginBottom: "12px" }}>
+        <Card style={{ marginBottom: "24px" }}>
+            <CardTitle>
                 {list === "include" ? "Include Rules" : "Exclude Rules"}
-            </Title>
-            <Table aria-label={`${list} rules`} variant="compact">
-                <Thead>
-                    <Tr>
-                        <Th>Type</Th>
-                        <Th>Pointer</Th>
-                        <Th>Pattern</Th>
-                        <Th>Actions</Th>
-                    </Tr>
-                </Thead>
-                <Tbody>
-                    {rules.map((rule, index) => (
-                        <Tr key={index}>
-                            <Td>{rule.type}</Td>
-                            <Td>{rule.pointer ?? "—"}</Td>
-                            <Td><code>{rule.pattern}</code></Td>
-                            <Td>
-                                <Button variant="plain" aria-label="Delete rule"
-                                    onClick={() => handleDeleteRule(list, index)}>
-                                    <TrashIcon />
-                                </Button>
-                            </Td>
-                        </Tr>
-                    ))}
-                    {addingTo === list && (
+            </CardTitle>
+            <CardBody>
+                <Table aria-label={`${list} rules`} variant="compact">
+                    <Thead>
                         <Tr>
-                            <Td>
-                                <FormSelect value={newRuleType}
-                                    onChange={(_e, v) => setNewRuleType(v as "event-type" | "payload")}>
-                                    <FormSelectOption value="event-type" label="event-type" />
-                                    <FormSelectOption value="payload" label="payload" />
-                                </FormSelect>
-                            </Td>
-                            <Td>
-                                {newRuleType === "payload" ? (
-                                    <TextInput value={newRulePointer}
-                                        onChange={(_e, v) => setNewRulePointer(v)}
-                                        placeholder="/path/to/field" />
-                                ) : (
-                                    <span>—</span>
-                                )}
-                            </Td>
-                            <Td>
-                                <TextInput value={newRulePattern}
-                                    onChange={(_e, v) => setNewRulePattern(v)}
-                                    placeholder="*[bot]" />
-                            </Td>
-                            <Td>
-                                <Button variant="primary" size="sm" style={{ marginRight: "8px" }}
-                                    isDisabled={!newRulePattern}
-                                    onClick={() => handleAddRule(list)}>
-                                    Add
-                                </Button>
-                                <Button variant="link" size="sm"
-                                    onClick={() => {
-                                        setAddingTo(null);
-                                        setNewRuleType("event-type");
-                                        setNewRulePointer("");
-                                        setNewRulePattern("");
-                                    }}>
-                                    Cancel
-                                </Button>
-                            </Td>
+                            <Th>Type</Th>
+                            <Th>Pointer</Th>
+                            <Th>Pattern</Th>
+                            <Th>Actions</Th>
                         </Tr>
-                    )}
-                </Tbody>
-            </Table>
-            {addingTo !== list && (
-                <Button variant="link" onClick={() => setAddingTo(list)}
-                    style={{ marginTop: "8px" }}>
-                    Add {list} rule
-                </Button>
-            )}
-        </div>
+                    </Thead>
+                    <Tbody>
+                        {rules.map((rule, index) => (
+                            <Tr key={index}>
+                                <Td>{rule.type}</Td>
+                                <Td>{rule.pointer ?? "—"}</Td>
+                                <Td><code>{rule.pattern}</code></Td>
+                                <Td>
+                                    <Button variant="plain" aria-label="Delete rule"
+                                        onClick={() => handleDeleteRule(list, index)}>
+                                        <TrashIcon />
+                                    </Button>
+                                </Td>
+                            </Tr>
+                        ))}
+                        {addingTo === list && (
+                            <Tr>
+                                <Td>
+                                    <FormSelect value={newRuleType}
+                                        onChange={(_e, v) => setNewRuleType(v as "event-type" | "payload")}>
+                                        <FormSelectOption value="event-type" label="event-type" />
+                                        <FormSelectOption value="payload" label="payload" />
+                                    </FormSelect>
+                                </Td>
+                                <Td>
+                                    {newRuleType === "payload" ? (
+                                        <TextInput value={newRulePointer}
+                                            onChange={(_e, v) => setNewRulePointer(v)}
+                                            placeholder="/path/to/field" />
+                                    ) : (
+                                        <span>—</span>
+                                    )}
+                                </Td>
+                                <Td>
+                                    <TextInput value={newRulePattern}
+                                        onChange={(_e, v) => setNewRulePattern(v)}
+                                        placeholder="*[bot]" />
+                                </Td>
+                                <Td>
+                                    <Button variant="primary" size="sm" style={{ marginRight: "8px" }}
+                                        isDisabled={!newRulePattern}
+                                        onClick={() => handleAddRule(list)}>
+                                        Add
+                                    </Button>
+                                    <Button variant="link" size="sm"
+                                        onClick={() => {
+                                            setAddingTo(null);
+                                            setNewRuleType("event-type");
+                                            setNewRulePointer("");
+                                            setNewRulePattern("");
+                                        }}>
+                                        Cancel
+                                    </Button>
+                                </Td>
+                            </Tr>
+                        )}
+                    </Tbody>
+                </Table>
+                {addingTo !== list && (
+                    <Button variant="link" onClick={() => setAddingTo(list)}
+                        style={{ marginTop: "8px" }}>
+                        Add {list} rule
+                    </Button>
+                )}
+            </CardBody>
+        </Card>
     );
 
     return (
-        <div>
-            <Flex justifyContent={{ default: "justifyContentSpaceBetween" }}
-                alignItems={{ default: "alignItemsCenter" }}
-                style={{ marginBottom: "16px" }}>
-                <FlexItem>
-                    <p className="axiom-text-subtle">
-                        Configure filter rules to control which events are processed. Include rules allow matching events; exclude rules block them.
-                    </p>
-                </FlexItem>
-                <FlexItem>
-                    <Button variant="primary" icon={<SaveIcon />} onClick={handleSave}
-                        isDisabled={!dirty || saving} isLoading={saving}>
-                        {saving ? "Saving..." : "Save"}
-                    </Button>
-                </FlexItem>
-            </Flex>
+        <Flex direction={{ default: "column", lg: "row" }}
+            alignItems={{ default: "alignItemsStretch" }}
+            style={{ gap: "24px" }}>
+            <FlexItem flex={{ default: "flex_1" }}>
+                <p className="axiom-text-subtle" style={{ marginBottom: "16px" }}>
+                    Configure filter rules to control which events are processed. Include rules
+                    allow matching events; exclude rules block them.
+                </p>
 
-            {renderRuleTable("include", filters.include)}
-            {renderRuleTable("exclude", filters.exclude)}
+                {renderRuleTable("include", filters.include)}
+                {renderRuleTable("exclude", filters.exclude)}
+            </FlexItem>
 
-            <div style={{ marginTop: "24px", marginBottom: "24px" }}>
-                <Button variant="secondary" onClick={handleDryRun}
-                    isLoading={dryRunLoading}
-                    isDisabled={dryRunLoading}>
-                    {dryRunLoading ? "Testing..." : "Test Filters"}
-                </Button>
-            </div>
+            <FlexItem flex={{ default: "flex_1" }}>
+                <Card>
+                    <CardTitle>
+                        <Flex justifyContent={{ default: "justifyContentSpaceBetween" }}
+                            alignItems={{ default: "alignItemsCenter" }}>
+                            <FlexItem>Matching Events Preview</FlexItem>
+                            <FlexItem>
+                                <Button variant="secondary" icon={<SyncAltIcon />}
+                                    onClick={handleDryRun}
+                                    isLoading={dryRunLoading}
+                                    isDisabled={dryRunLoading}>
+                                    Refresh
+                                </Button>
+                            </FlexItem>
+                        </Flex>
+                    </CardTitle>
+                    <CardBody>
+                        {!dryRunResults ? (
+                            <EmptyState>
+                                <EmptyStateBody>
+                                    Click "Refresh" to preview how the current rules would apply
+                                    to recent events.
+                                </EmptyStateBody>
+                            </EmptyState>
+                        ) : (
+                            <>
+                                <p style={{ marginBottom: "12px" }}>
+                                    <strong>{dryRunResults.totalAllowed} allowed</strong>,{" "}
+                                    <strong>{dryRunResults.totalBlocked} blocked</strong> out of{" "}
+                                    <strong>{dryRunResults.totalEvaluated}</strong> events
+                                </p>
+                                <div style={{ maxHeight: "60vh", overflow: "auto" }}>
+                                    <Table aria-label="Filter test results" variant="compact">
+                                        <Thead>
+                                            <Tr>
+                                                <Th>Result</Th>
+                                                <Th>Event Type</Th>
+                                                <Th>Reference</Th>
+                                                <Th>Summary</Th>
+                                                <Th>Matched Rule</Th>
+                                            </Tr>
+                                        </Thead>
+                                        <Tbody>
+                                            {dryRunResults.results.map((result, index) => (
+                                                <Tr key={index} isClickable
+                                                    onRowClick={() => setSelectedResult(result)}>
+                                                    <Td>
+                                                        <Label isCompact
+                                                            color={result.allowed ? "green" : "red"}
+                                                            icon={result.allowed
+                                                                ? <CheckCircleIcon />
+                                                                : <TimesCircleIcon />}>
+                                                            {result.allowed ? "Allowed" : "Blocked"}
+                                                        </Label>
+                                                    </Td>
+                                                    <Td>{result.eventType}</Td>
+                                                    <Td>{result.issueRef}</Td>
+                                                    <Td>{result.summary}</Td>
+                                                    <Td>{result.matchedRule ?? "—"}</Td>
+                                                </Tr>
+                                            ))}
+                                        </Tbody>
+                                    </Table>
+                                </div>
+                            </>
+                        )}
+                    </CardBody>
+                </Card>
+            </FlexItem>
 
-            {dryRunResults && (
-                <div style={{ marginTop: "24px" }}>
-                    <Title headingLevel="h3" size="md" style={{ marginBottom: "12px" }}>
-                        Test Results
-                    </Title>
-                    <p style={{ marginBottom: "12px" }}>
-                        <strong>{dryRunResults.totalAllowed} allowed</strong>, <strong>{dryRunResults.totalBlocked} blocked</strong> out of <strong>{dryRunResults.totalEvaluated}</strong> events
-                    </p>
-                    <Table aria-label="Filter test results" variant="compact">
-                        <Thead>
-                            <Tr>
-                                <Th>Result</Th>
-                                <Th>Event Type</Th>
-                                <Th>Reference</Th>
-                                <Th>Summary</Th>
-                                <Th>Matched Rule</Th>
-                            </Tr>
-                        </Thead>
-                        <Tbody>
-                            {dryRunResults.results.map((result, index) => (
-                                <Tr key={index}>
-                                    <Td>
-                                        <Label isCompact
-                                            color={result.allowed ? "green" : "red"}
-                                            icon={result.allowed ? <CheckCircleIcon /> : <TimesCircleIcon />}>
-                                            {result.allowed ? "Allowed" : "Blocked"}
-                                        </Label>
-                                    </Td>
-                                    <Td>{result.eventType}</Td>
-                                    <Td>{result.issueRef}</Td>
-                                    <Td>{result.summary}</Td>
-                                    <Td>{result.matchedRule ?? "—"}</Td>
-                                </Tr>
-                            ))}
-                        </Tbody>
-                    </Table>
-                </div>
-            )}
-        </div>
+            <DryRunEventDetailModal
+                result={selectedResult}
+                onClose={() => setSelectedResult(null)}
+            />
+        </Flex>
+    );
+}
+
+function DryRunEventDetailModal({ result, onClose }: {
+    result: FilterDryRunResult | null;
+    onClose: () => void;
+}) {
+    const effectiveTheme = useEffectiveTheme();
+    const formatPayload = (payload?: string): string => {
+        if (!payload) return "";
+        try {
+            return JSON.stringify(JSON.parse(payload), null, 2);
+        } catch {
+            return payload;
+        }
+    };
+
+    return (
+        <Modal isOpen={result !== null} onClose={onClose} variant="large"
+            aria-label="Event details">
+            <ModalHeader
+                title="Event Details"
+                description={result
+                    ? `${result.eventType} — ${result.issueRef}`
+                    : undefined}
+            />
+            <ModalBody>
+                {result && (
+                    <>
+                        <Card style={{ marginBottom: "8px" }}>
+                            <CardBody>
+                                <DescriptionList isHorizontal isCompact>
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm>Event Type</DescriptionListTerm>
+                                        <DescriptionListDescription>
+                                            {result.eventType}
+                                        </DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm>Reference</DescriptionListTerm>
+                                        <DescriptionListDescription>
+                                            {result.issueRef}
+                                        </DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm>Summary</DescriptionListTerm>
+                                        <DescriptionListDescription>
+                                            {result.summary}
+                                        </DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm>Result</DescriptionListTerm>
+                                        <DescriptionListDescription>
+                                            <Label isCompact
+                                                color={result.allowed ? "green" : "red"}
+                                                icon={result.allowed
+                                                    ? <CheckCircleIcon />
+                                                    : <TimesCircleIcon />}>
+                                                {result.allowed ? "Allowed" : "Blocked"}
+                                            </Label>
+                                        </DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                    {result.matchedRule && (
+                                        <DescriptionListGroup>
+                                            <DescriptionListTerm>Matched Rule</DescriptionListTerm>
+                                            <DescriptionListDescription>
+                                                {result.matchedRule}
+                                            </DescriptionListDescription>
+                                        </DescriptionListGroup>
+                                    )}
+                                </DescriptionList>
+                            </CardBody>
+                        </Card>
+
+                        <Title headingLevel="h4" size="md" style={{ marginBottom: "8px" }}>
+                            Payload
+                        </Title>
+                        <CodeEditor
+                            code={formatPayload(result.payload)}
+                            language={Language.json}
+                            isDarkTheme={effectiveTheme === "dark"}
+                            height="400px"
+                            isReadOnly
+                            isLineNumbersVisible
+                        />
+                    </>
+                )}
+            </ModalBody>
+        </Modal>
     );
 }
 

--- a/ui/src/pages/EventSourceDetailPage.tsx
+++ b/ui/src/pages/EventSourceDetailPage.tsx
@@ -518,7 +518,7 @@ function FiltersTab({ source, onSave }: {
                             <Td>
                                 <TextInput value={newRulePattern}
                                     onChange={(_e, v) => setNewRulePattern(v)}
-                                    placeholder="^pattern.*" />
+                                    placeholder="*[bot]" />
                             </Td>
                             <Td>
                                 <Button variant="primary" size="sm" style={{ marginRight: "8px" }}


### PR DESCRIPTION
Fixes #127

## Summary

- **Configurable filters:** Per-event-source include/exclude filter rules stored as a new `filters` JSON column on `event_source`. Supports two rule types: `event-type` (glob against the event type string) and `payload` (JSON Pointer + glob against a payload field value).
- **Replaces hardcoded logic:** Removes `shouldSkipEvent()` and `SLASH_COMMANDS` from `PipelineOrchestrator`. The old bot and slash-command filters are migrated into default filter rules via DB migration V34, applied to all existing and new event sources.
- **Dry-run endpoint:** `POST /api/event-sources/filters/dry-run` fetches live events from the source API (GitHub/Jira), classifies them using extracted poller logic, and evaluates proposed filters — letting users preview what would be allowed or blocked before saving.
- **Frontend Filters tab:** New tab on the event source detail page with include/exclude rule tables, inline add/delete, save, and a "Test Filters" button that shows dry-run results with green/red allowed/blocked labels and summary counts.

## Changes

| Area | What changed |
|------|-------------|
| OpenAPI | Added `EventSourceFilterRule`, `EventSourceFilters`, `FilterDryRunRequest/Response/Result` schemas; `filters` on `EventSource`/`NewEventSource`; dry-run endpoint |
| Core | `EventFilterEvaluator` with wildcard matching (17 unit tests), filter model records |
| DB | V34 migration: `filters TEXT` column with default exclude rules |
| App | REST serialization, `PipelineOrchestrator` filter integration, dry-run endpoint implementation |
| Events | Extracted `GitHubEventClassifier`/`JiraEventClassifier` from pollers; `GitHubDryRunService`/`JiraDryRunService` |
| UI | TypeScript filter types, `dryRunFilters()` API call, `FiltersTab` component |

## Test plan

- [ ] Build passes (`build.sh`) — 282 tests, 0 failures
- [ ] UI builds (`npm run build`) — TypeScript + Vite clean
- [ ] Create new event source — verify default filters are populated
- [ ] Edit filters via Filters tab — verify save round-trips correctly
- [ ] Test Filters dry-run — verify live events are fetched and filter verdicts displayed
- [ ] Trigger event ingestion — verify filtered events show `event-pre-filtered` in activity log with matched rule detail
- [ ] Verify bot events blocked by default `*[bot]` rules
- [ ] Verify slash-command comments blocked by default `/*` rule