### PR TITLE
feat: label-based action type filtering for Manager (#167)

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/ImportExportService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ImportExportService.java
@@ -309,6 +309,12 @@ public class ImportExportService {
             entity.maxSteps = item.has("maxSteps") ? item.path("maxSteps").asInt() : null;
             entity.maxBudgetUsd = item.has("maxBudgetUsd") ? item.path("maxBudgetUsd").asDouble() : null;
             entity.environment = jsonOrNull(item, "environment");
+            JsonNode labelsNode = item.path("labels");
+            if (labelsNode.isArray()) {
+                for (JsonNode l : labelsNode) {
+                    entity.labels.add(l.asText());
+                }
+            }
             entity.persist();
             count++;
         }
@@ -438,6 +444,13 @@ public class ImportExportService {
             entity.maxSteps = item.has("maxSteps") ? item.path("maxSteps").asInt() : null;
             entity.maxBudgetUsd = item.has("maxBudgetUsd") ? item.path("maxBudgetUsd").asDouble() : null;
             entity.environment = jsonOrNull(item, "environment");
+            entity.labels.clear();
+            JsonNode labelsNode = item.path("labels");
+            if (labelsNode.isArray()) {
+                for (JsonNode l : labelsNode) {
+                    entity.labels.add(l.asText());
+                }
+            }
             entity.persist();
             if (isNew) created++;
             else updated++;
@@ -600,6 +613,10 @@ public class ImportExportService {
         if (e.maxSteps != null) n.put("maxSteps", e.maxSteps);
         if (e.maxBudgetUsd != null) n.put("maxBudgetUsd", e.maxBudgetUsd);
         putIfNotNull(n, "environment", e.environment);
+        if (e.labels != null && !e.labels.isEmpty()) {
+            var labelsArr = n.putArray("labels");
+            e.labels.forEach(labelsArr::add);
+        }
         return n;
     }
 

--- a/app/src/main/java/io/apitomy/axiom/app/rest/ActionResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/ActionResourceImpl.java
@@ -186,6 +186,10 @@ public class ActionResourceImpl implements ActionResource {
         entity.maxBudgetUsd = data.getMaxBudgetUsd();
         entity.emitsEvent = data.getEmitsEvent() != null ? data.getEmitsEvent() : false;
         entity.environment = environmentToJson(data.getEnvironment());
+        entity.labels.clear();
+        if (data.getLabels() != null) {
+            entity.labels.addAll(data.getLabels());
+        }
     }
 
     private ActionTypeEntity findOrThrow(long id) {
@@ -217,6 +221,7 @@ public class ActionResourceImpl implements ActionResource {
         actionType.setMaxBudgetUsd(entity.maxBudgetUsd);
         actionType.setEmitsEvent(entity.emitsEvent);
         actionType.setEnvironment(jsonToEnvironment(entity.environment));
+        actionType.setLabels(entity.labels);
         return actionType;
     }
 

--- a/app/src/main/resources/db/migration/V35__add_action_type_labels.sql
+++ b/app/src/main/resources/db/migration/V35__add_action_type_labels.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS action_type_label (
+    action_type_id BIGINT NOT NULL,
+    label VARCHAR(255) NOT NULL,
+    UNIQUE (action_type_id, label),
+    FOREIGN KEY (action_type_id) REFERENCES action_type(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_action_type_label ON action_type_label(label, action_type_id);

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -4868,6 +4868,13 @@
             "format": "double",
             "description": "Maximum budget in USD for this action type. When empty, the global default is used.",
             "type": "number"
+          },
+          "labels": {
+            "description": "Free-form labels for categorization",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },
@@ -4942,6 +4949,13 @@
             "format": "double",
             "description": "Maximum budget in USD for this action type. When empty, the global default is used.",
             "type": "number"
+          },
+          "labels": {
+            "description": "Free-form labels for categorization",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },

--- a/core/src/main/java/io/apitomy/axiom/core/entities/ActionTypeEntity.java
+++ b/core/src/main/java/io/apitomy/axiom/core/entities/ActionTypeEntity.java
@@ -1,9 +1,16 @@
 package io.apitomy.axiom.core.entities;
 
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Table;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Defines a kind of work that can be performed within the system.
@@ -82,4 +89,9 @@ public class ActionTypeEntity extends PanacheEntity {
 
     @Column(name = "emits_event", nullable = false)
     public boolean emitsEvent;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "action_type_label", joinColumns = @JoinColumn(name = "action_type_id"))
+    @Column(name = "label")
+    public List<String> labels = new ArrayList<>();
 }

--- a/manager/src/main/java/io/apitomy/axiom/manager/ManagerService.java
+++ b/manager/src/main/java/io/apitomy/axiom/manager/ManagerService.java
@@ -214,7 +214,8 @@ public class ManagerService {
         if (actionTypes == null || actionTypes.isEmpty()) {
             return actionTypes;
         }
-        Set<String> eventLabels = new HashSet<>(eventSourceLabels);
+        Set<String> eventLabels = eventSourceLabels != null
+                ? new HashSet<>(eventSourceLabels) : Collections.emptySet();
         return actionTypes.stream()
                 .filter(at -> at.labels == null || at.labels.isEmpty()
                         || eventLabels.containsAll(at.labels))

--- a/manager/src/main/java/io/apitomy/axiom/manager/ManagerService.java
+++ b/manager/src/main/java/io/apitomy/axiom/manager/ManagerService.java
@@ -9,6 +9,7 @@ import io.apitomy.axiom.core.entities.ActivityLogEntity;
 import io.apitomy.axiom.core.entities.AiUsageEntity;
 import io.apitomy.axiom.core.entities.ActorEntity;
 import io.apitomy.axiom.core.entities.EventEntity;
+import io.apitomy.axiom.core.entities.EventSourceEntity;
 import io.apitomy.axiom.core.entities.ManagerConfigEntity;
 import io.apitomy.axiom.core.entities.ProjectEntity;
 import io.apitomy.axiom.core.entities.TaskEntity;
@@ -24,8 +25,10 @@ import org.jboss.logging.Logger;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Service that invokes the AI Manager to evaluate events and produce decisions.
@@ -87,6 +90,17 @@ public class ManagerService {
         // Load context (short transaction — releases connection before AI call)
         EvalContext ctx = QuarkusTransaction.requiringNew().call(() -> {
             List<ActionTypeEntity> actionTypes = ActionTypeEntity.list("managerTriggerable", true);
+
+            // Filter action types by label compatibility with the event source
+            List<String> eventSourceLabels = Collections.emptyList();
+            if (event.eventSourceId != null) {
+                EventSourceEntity eventSource = EventSourceEntity.findById(event.eventSourceId);
+                if (eventSource != null && eventSource.labels != null) {
+                    eventSourceLabels = eventSource.labels;
+                }
+            }
+            actionTypes = filterByLabels(actionTypes, eventSourceLabels);
+
             List<ActorEntity> actors = ActorEntity.listAll();
 
             ProjectEntity project = null;
@@ -183,6 +197,28 @@ public class ManagerService {
             completeEvalNode(evalNodeId, "failed", null);
             return Collections.emptyList();
         }
+    }
+
+    /**
+     * Filters action types by label compatibility with the event's source labels.
+     * Action types with no labels are always included (backwards-compatible).
+     * Action types with labels are included only if their labels are a subset
+     * of the event source labels.
+     *
+     * @param actionTypes the candidate action types
+     * @param eventSourceLabels the labels from the event's source
+     * @return the filtered list
+     */
+    static List<ActionTypeEntity> filterByLabels(List<ActionTypeEntity> actionTypes,
+                                                  List<String> eventSourceLabels) {
+        if (actionTypes == null || actionTypes.isEmpty()) {
+            return actionTypes;
+        }
+        Set<String> eventLabels = new HashSet<>(eventSourceLabels);
+        return actionTypes.stream()
+                .filter(at -> at.labels == null || at.labels.isEmpty()
+                        || eventLabels.containsAll(at.labels))
+                .toList();
     }
 
     /**

--- a/manager/src/test/java/io/apitomy/axiom/manager/ManagerServiceLabelFilterTest.java
+++ b/manager/src/test/java/io/apitomy/axiom/manager/ManagerServiceLabelFilterTest.java
@@ -1,0 +1,105 @@
+package io.apitomy.axiom.manager;
+
+import io.apitomy.axiom.core.entities.ActionTypeEntity;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for ManagerService's label-based action type filtering logic.
+ */
+class ManagerServiceLabelFilterTest {
+
+    @Test
+    void testNoLabelsOnActionTypeAlwaysIncluded() {
+        ActionTypeEntity at = makeActionType("deploy", List.of());
+        List<ActionTypeEntity> result = ManagerService.filterByLabels(List.of(at), List.of("team-a"));
+        assertEquals(1, result.size());
+        assertEquals("deploy", result.get(0).name);
+    }
+
+    @Test
+    void testNullLabelsOnActionTypeAlwaysIncluded() {
+        ActionTypeEntity at = makeActionType("deploy", null);
+        List<ActionTypeEntity> result = ManagerService.filterByLabels(List.of(at), List.of("team-a"));
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void testNoLabelsOnActionTypeNoLabelsOnEvent() {
+        ActionTypeEntity at = makeActionType("deploy", List.of());
+        List<ActionTypeEntity> result = ManagerService.filterByLabels(List.of(at), Collections.emptyList());
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void testActionTypeLabelsSubsetOfEventLabels() {
+        ActionTypeEntity at = makeActionType("deploy", List.of("team-a"));
+        List<ActionTypeEntity> result = ManagerService.filterByLabels(
+                List.of(at), List.of("team-a", "team-b", "prod"));
+        assertEquals(1, result.size());
+        assertEquals("deploy", result.get(0).name);
+    }
+
+    @Test
+    void testActionTypeLabelsExactMatchEventLabels() {
+        ActionTypeEntity at = makeActionType("deploy", List.of("team-a", "prod"));
+        List<ActionTypeEntity> result = ManagerService.filterByLabels(
+                List.of(at), List.of("team-a", "prod"));
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void testActionTypeLabelsNotSubsetExcluded() {
+        ActionTypeEntity at = makeActionType("deploy", List.of("team-a", "prod"));
+        List<ActionTypeEntity> result = ManagerService.filterByLabels(
+                List.of(at), List.of("team-b"));
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testActionTypeLabelsNoEventLabelsExcluded() {
+        ActionTypeEntity at = makeActionType("deploy", List.of("team-a"));
+        List<ActionTypeEntity> result = ManagerService.filterByLabels(
+                List.of(at), Collections.emptyList());
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testMixedActionTypesFilteredCorrectly() {
+        ActionTypeEntity noLabels = makeActionType("analyze", List.of());
+        ActionTypeEntity matching = makeActionType("deploy", List.of("team-a"));
+        ActionTypeEntity nonMatching = makeActionType("review", List.of("team-b"));
+
+        List<ActionTypeEntity> result = ManagerService.filterByLabels(
+                List.of(noLabels, matching, nonMatching), List.of("team-a", "prod"));
+
+        assertEquals(2, result.size());
+        assertEquals("analyze", result.get(0).name);
+        assertEquals("deploy", result.get(1).name);
+    }
+
+    @Test
+    void testEmptyActionTypeListReturnsEmpty() {
+        List<ActionTypeEntity> result = ManagerService.filterByLabels(
+                Collections.emptyList(), List.of("team-a"));
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testNullActionTypeListReturnsNull() {
+        List<ActionTypeEntity> result = ManagerService.filterByLabels(null, List.of("team-a"));
+        assertNull(result);
+    }
+
+    private ActionTypeEntity makeActionType(String name, List<String> labels) {
+        ActionTypeEntity entity = new ActionTypeEntity();
+        entity.name = name;
+        entity.labels = labels != null ? new ArrayList<>(labels) : null;
+        return entity;
+    }
+}

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -337,6 +337,7 @@ export interface ActionType {
     maxBudgetUsd?: number;
     emitsEvent: boolean;
     environment?: Record<string, string>;
+    labels?: string[];
 }
 
 export type NewActionType = Omit<ActionType, "id">;

--- a/ui/src/pages/ActionTypeDetailPage.tsx
+++ b/ui/src/pages/ActionTypeDetailPage.tsx
@@ -26,7 +26,9 @@ import {
 } from "@patternfly/react-core";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import { registerPlaceholderCompletions, ACTION_TYPE_PLACEHOLDERS } from "../components/PlaceholderCompletionProvider";
+import { EditLabelsModal } from "../components/EditLabelsModal";
 import { EnvironmentTab } from "../components/EnvironmentTab";
+import { LabelDisplay } from "../components/LabelDisplay";
 import { ToolListEditor } from "../components/ToolListEditor";
 import { ScriptAiModal } from "../components/ScriptAiModal";
 import { ActionTypeAiModal } from "../components/ActionTypeAiModal";
@@ -61,6 +63,7 @@ export function ActionTypeDetailPage() {
     const [dirty, setDirty] = useState(false);
     const [activeTab, setActiveTab] = useState(0);
     const [aiModalOpen, setAiModalOpen] = useState(false);
+    const [isLabelsOpen, setIsLabelsOpen] = useState(false);
     const [availableModels, setAvailableModels] = useState<string[]>([]);
     const [availableEngines, setAvailableEngines] = useState<string[]>([]);
     const [validationMessages, setValidationMessages] = useState<ToolValidationMessage[]>([]);
@@ -108,6 +111,7 @@ export function ActionTypeDetailPage() {
                     engine: at.engine,
                     maxSteps: at.maxSteps,
                     maxBudgetUsd: at.maxBudgetUsd,
+                    labels: at.labels || [],
                 });
                 setTools(at.allowedTools || []);
                 setEnvVars(at.environment || {});
@@ -233,7 +237,7 @@ export function ActionTypeDetailPage() {
             <Tabs activeKey={activeTab} onSelect={(_e, k) => setActiveTab(k as number)}>
                 <Tab eventKey={0} title={<TabTitleText>Info</TabTitleText>}>
                     <TabContent id="info-tab" eventKey={0} activeKey={activeTab} style={{ marginTop: "24px" }}>
-                        <InfoTab form={form} updateForm={updateForm} availableModels={availableModels} availableEngines={availableEngines} />
+                        <InfoTab form={form} updateForm={updateForm} availableModels={availableModels} availableEngines={availableEngines} onEditLabels={() => setIsLabelsOpen(true)} />
                     </TabContent>
                 </Tab>
                 {form.executionMode === "actor" && (
@@ -342,15 +346,25 @@ export function ActionTypeDetailPage() {
                     onClose={() => setAiModalOpen(false)}
                 />
             )}
+
+            <EditLabelsModal
+                isOpen={isLabelsOpen}
+                labels={form.labels || []}
+                onSave={async (labels) => {
+                    updateForm({ labels });
+                }}
+                onClose={() => setIsLabelsOpen(false)}
+            />
         </PageSection>
     );
 }
 
-function InfoTab({ form, updateForm, availableModels, availableEngines }: {
+function InfoTab({ form, updateForm, availableModels, availableEngines, onEditLabels }: {
     form: NewActionType;
     updateForm: (updates: Partial<NewActionType>) => void;
     availableModels: string[];
     availableEngines: string[];
+    onEditLabels: () => void;
 }) {
     return (
         <Form style={{ maxWidth: "600px" }}>
@@ -369,6 +383,9 @@ function InfoTab({ form, updateForm, availableModels, availableEngines }: {
                     onChange={(_e, v) => updateForm({ description: v })}
                     rows={3}
                 />
+            </FormGroup>
+            <FormGroup label="Labels" fieldId="labels">
+                <LabelDisplay labels={form.labels || []} onEdit={onEditLabels} />
             </FormGroup>
             <FormGroup label="Execution Mode" isRequired fieldId="executionMode">
                 <FormSelect


### PR DESCRIPTION
## Summary

- Add a `labels` field to action types (same model as event source labels) with full CRUD support
  across OpenAPI spec, entity, REST API, import/export, and UI.
- Filter candidate action types in the Manager by label compatibility with the event source:
  action types with no labels are always included (backwards-compatible); action types with labels
  are included only if their labels are a subset of the event's source labels.
- Add unit tests for the label filtering logic covering all matching scenarios.

## Related Issue

Fixes #167

## Test Plan

- [ ] Run `mvn install` to regenerate API beans and verify all tests pass
- [ ] Start the app and navigate to an Action Type detail page — verify the Labels section
      appears in the Info tab
- [ ] Add, edit, and remove labels via the modal — verify they persist after save and page refresh
- [ ] Create two event sources with different labels (e.g. `team-a`, `team-b`)
- [ ] Create action types with labels matching one source but not the other
- [ ] Trigger events from each source and verify the Manager only considers label-compatible
      action types (check activity logs or debug endpoint)
- [ ] Verify action types with no labels are still considered for all events (backwards compat)
- [ ] Test import/export round-trip with action type labels