### PR TITLE
feat: add filtering to action types and event sources pages

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/rest/ActionResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/ActionResourceImpl.java
@@ -2,6 +2,7 @@ package io.apitomy.axiom.app.rest;
 
 import io.apitomy.axiom.api.ActionResource;
 import io.apitomy.axiom.api.beans.ActionType;
+import io.apitomy.axiom.api.beans.ActionTypeSearchResults;
 import io.apitomy.axiom.api.beans.NewActionType;
 import io.apitomy.axiom.api.beans.ReportAiEditRequest;
 import io.apitomy.axiom.api.beans.ReportAiEditResponse;
@@ -19,6 +20,7 @@ import io.apitomy.axiom.core.entities.SecretEntity;
 import io.apitomy.axiom.core.entities.ToolDefinitionEntity;
 import io.apitomy.axiom.core.entities.ToolsetEntity;
 import io.apitomy.axiom.core.services.ActionTypeValidator;
+import io.quarkus.panache.common.Page;
 import io.quarkus.panache.common.Sort;
 import io.smallrye.common.annotation.RunOnVirtualThread;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -28,6 +30,8 @@ import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 
 import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -52,11 +56,47 @@ public class ActionResourceImpl implements ActionResource {
      * {@inheritDoc}
      */
     @Override
-    public List<ActionType> listActionTypes() {
-        return ActionTypeEntity.<ActionTypeEntity>listAll(Sort.ascending("name"))
-                .stream()
-                .map(this::toBean)
-                .toList();
+    public ActionTypeSearchResults listActionTypes(BigInteger page, BigInteger limit,
+                                                   String filterName, String filterMode,
+                                                   String filterLabels) {
+        int pageNum = page != null ? page.intValue() : 1;
+        int pageSize = limit != null ? limit.intValue() : 20;
+
+        StringBuilder hql = new StringBuilder("1=1");
+        Map<String, Object> params = new HashMap<>();
+
+        if (filterName != null && !filterName.isBlank()) {
+            hql.append(" and (lower(name) like :name or lower(description) like :name)");
+            params.put("name", "%" + filterName.toLowerCase() + "%");
+        }
+
+        if (filterMode != null && !filterMode.isBlank()) {
+            hql.append(" and executionMode = :mode");
+            params.put("mode", filterMode.toLowerCase());
+        }
+
+        if (filterLabels != null && !filterLabels.isBlank()) {
+            List<String> labels = Arrays.stream(filterLabels.split(","))
+                    .map(String::trim).filter(s -> !s.isEmpty()).toList();
+            hql.append(" and id in (SELECT a.id FROM ActionTypeEntity a"
+                    + " JOIN a.labels al WHERE al IN :labels"
+                    + " GROUP BY a.id HAVING COUNT(DISTINCT al) = :labelCount)");
+            params.put("labels", labels);
+            params.put("labelCount", (long) labels.size());
+        }
+
+        long totalCount = ActionTypeEntity.count(hql.toString(), params);
+        List<ActionType> items = ActionTypeEntity.<ActionTypeEntity>find(
+                        hql.toString(), Sort.ascending("name"), params)
+                .page(Page.of(pageNum - 1, pageSize))
+                .list().stream().map(this::toBean).toList();
+
+        ActionTypeSearchResults results = new ActionTypeSearchResults();
+        results.setItems(items);
+        results.setTotalCount(totalCount);
+        results.setPage(pageNum);
+        results.setLimit(pageSize);
+        return results;
     }
 
     /**

--- a/app/src/main/java/io/apitomy/axiom/app/rest/EventSourcesResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/EventSourcesResourceImpl.java
@@ -6,6 +6,7 @@ import io.apitomy.axiom.api.EventResource;
 import io.apitomy.axiom.api.beans.EventSource;
 import io.apitomy.axiom.api.beans.EventSourceLog;
 import io.apitomy.axiom.api.beans.EventSourceLogSearchResults;
+import io.apitomy.axiom.api.beans.EventSourceSearchResults;
 import io.apitomy.axiom.api.beans.FilterDryRunRequest;
 import io.apitomy.axiom.api.beans.FilterDryRunResponse;
 import io.apitomy.axiom.api.beans.FilterDryRunResult;
@@ -32,8 +33,10 @@ import org.jboss.logging.Logger;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -65,12 +68,47 @@ public class EventSourcesResourceImpl implements EventResource {
      * {@inheritDoc}
      */
     @Override
-    public List<EventSource> listEventSources() {
-        return EventSourceEntity.<EventSourceEntity>listAll()
-                .stream()
-                .sorted(Comparator.comparing(e -> e.name))
-                .map(this::toBean)
-                .toList();
+    public EventSourceSearchResults listEventSources(BigInteger page, BigInteger limit,
+                                                     String filterName, String filterType,
+                                                     String filterLabels) {
+        int pageNum = page != null ? page.intValue() : 1;
+        int pageSize = limit != null ? limit.intValue() : 20;
+
+        StringBuilder hql = new StringBuilder("1=1");
+        Map<String, Object> params = new HashMap<>();
+
+        if (filterName != null && !filterName.isBlank()) {
+            hql.append(" and (lower(name) like :name or lower(description) like :name)");
+            params.put("name", "%" + filterName.toLowerCase() + "%");
+        }
+
+        if (filterType != null && !filterType.isBlank()) {
+            hql.append(" and sourceType = :sourceType");
+            params.put("sourceType", filterType.toLowerCase());
+        }
+
+        if (filterLabels != null && !filterLabels.isBlank()) {
+            List<String> labels = Arrays.stream(filterLabels.split(","))
+                    .map(String::trim).filter(s -> !s.isEmpty()).toList();
+            hql.append(" and id in (SELECT e.id FROM EventSourceEntity e"
+                    + " JOIN e.labels el WHERE el IN :labels"
+                    + " GROUP BY e.id HAVING COUNT(DISTINCT el) = :labelCount)");
+            params.put("labels", labels);
+            params.put("labelCount", (long) labels.size());
+        }
+
+        long totalCount = EventSourceEntity.count(hql.toString(), params);
+        List<EventSource> items = EventSourceEntity.<EventSourceEntity>find(
+                        hql.toString(), Sort.ascending("name"), params)
+                .page(Page.of(pageNum - 1, pageSize))
+                .list().stream().map(this::toBean).toList();
+
+        EventSourceSearchResults results = new EventSourceSearchResults();
+        results.setItems(items);
+        results.setTotalCount(totalCount);
+        results.setPage(pageNum);
+        results.setLimit(pageSize);
+        return results;
     }
 
     /**

--- a/app/src/test/java/io/apitomy/axiom/app/ActionResourceTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/ActionResourceTest.java
@@ -23,8 +23,8 @@ class ActionResourceTest {
             .then()
                 .statusCode(200)
                 .contentType(ContentType.JSON)
-                .body("$.size()", greaterThanOrEqualTo(2))
-                .body("name", hasItems("auto-tag", "close-project"));
+                .body("items.size()", greaterThanOrEqualTo(2))
+                .body("items.name", hasItems("auto-tag", "close-project"));
     }
 
     @Test
@@ -34,7 +34,7 @@ class ActionResourceTest {
                 .get(ACTION_TYPES_PATH)
             .then()
                 .statusCode(200)
-                .extract().path("find { it.name == 'auto-tag' }.id");
+                .extract().path("items.find { it.name == 'auto-tag' }.id");
 
         given()
             .when()
@@ -54,7 +54,7 @@ class ActionResourceTest {
                 .get(ACTION_TYPES_PATH)
             .then()
                 .statusCode(200)
-                .extract().path("find { it.name == 'close-project' }.id");
+                .extract().path("items.find { it.name == 'close-project' }.id");
 
         given()
             .when()

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -782,11 +782,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ActionTypeSearchResults",
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ActionType"
-                  }
+                  "$ref": "#/components/schemas/ActionTypeSearchResults"
                 }
               }
             }
@@ -1014,11 +1010,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/EventSourceSearchResults",
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/EventSource"
-                  }
+                  "$ref": "#/components/schemas/EventSourceSearchResults"
                 }
               }
             }

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -729,12 +729,60 @@
         ],
         "summary": "List all action types",
         "operationId": "listActionTypes",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number (1-indexed)",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Items per page",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "filterName",
+            "in": "query",
+            "description": "Filter by name or description (substring match)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filterMode",
+            "in": "query",
+            "description": "Filter by execution mode (actor or script)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filterLabels",
+            "in": "query",
+            "description": "Filter by labels (comma-separated, AND logic)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "List of action types",
             "content": {
               "application/json": {
                 "schema": {
+                  "$ref": "#/components/schemas/ActionTypeSearchResults",
                   "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/ActionType"
@@ -914,11 +962,59 @@
         ],
         "summary": "List all event sources",
         "operationId": "listEventSources",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number (1-indexed)",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Items per page",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "filterName",
+            "in": "query",
+            "description": "Filter by name or description (substring match)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filterType",
+            "in": "query",
+            "description": "Filter by source type (github or jira)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filterLabels",
+            "in": "query",
+            "description": "Filter by labels (comma-separated, AND logic)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
               "application/json": {
                 "schema": {
+                  "$ref": "#/components/schemas/EventSourceSearchResults",
                   "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/EventSource"
@@ -7622,6 +7718,48 @@
           "payload": {
             "description": "The raw event payload JSON",
             "type": "string"
+          }
+        }
+      },
+      "ActionTypeSearchResults": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ActionType"
+            }
+          },
+          "totalCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "page": {
+            "type": "integer"
+          },
+          "limit": {
+            "type": "integer"
+          }
+        }
+      },
+      "EventSourceSearchResults": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EventSource"
+            }
+          },
+          "totalCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "page": {
+            "type": "integer"
+          },
+          "limit": {
+            "type": "integer"
           }
         }
       }

--- a/ui/src/components/dashboards/widgets/ActionTypesWidget.tsx
+++ b/ui/src/components/dashboards/widgets/ActionTypesWidget.tsx
@@ -12,10 +12,10 @@ function ActionTypesWidget({ config, labels }: WidgetProps) {
 
     useEffect(() => {
         let cancelled = false;
-        fetchActionTypes()
-            .then(all => {
+        fetchActionTypes(1, 1000)
+            .then(results => {
                 if (cancelled) return;
-                let filtered = all;
+                let filtered = results.items;
                 if (labels.length > 0) {
                     // Subset logic: include action types with no labels,
                     // or whose labels are a subset of the dashboard's labels.

--- a/ui/src/components/dashboards/widgets/ActionTypesWidget.tsx
+++ b/ui/src/components/dashboards/widgets/ActionTypesWidget.tsx
@@ -19,7 +19,7 @@ function ActionTypesWidget({ config, labels }: WidgetProps) {
                 if (labels.length > 0) {
                     // Subset logic: include action types with no labels,
                     // or whose labels are a subset of the dashboard's labels.
-                    filtered = all.filter(at =>
+                    filtered = filtered.filter(at =>
                         !at.labels || at.labels.length === 0
                         || at.labels.every(l => labels.includes(l))
                     );

--- a/ui/src/components/dashboards/widgets/EventSourceHealthWidget.tsx
+++ b/ui/src/components/dashboards/widgets/EventSourceHealthWidget.tsx
@@ -11,9 +11,10 @@ function EventSourceHealthWidget({ labels }: WidgetProps) {
 
     useEffect(() => {
         let cancelled = false;
-        fetchEventSources()
-            .then(all => {
+        fetchEventSources(1, 1000)
+            .then(results => {
                 if (cancelled) return;
+                const all = results.items;
                 if (labels.length > 0) {
                     setSources(all.filter(s =>
                         s.labels?.some((l: string) => labels.includes(l))

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -344,8 +344,16 @@ export interface ActionType {
 
 export type NewActionType = Omit<ActionType, "id">;
 
-export async function fetchActionTypes(): Promise<ActionType[]> {
-    const response = await fetch(`${API}/action-types`);
+export async function fetchActionTypes(
+    page = 1, limit = 20, filterName?: string, filterMode?: string, filterLabels?: string
+): Promise<SearchResults<ActionType>> {
+    const params = new URLSearchParams();
+    params.set("page", String(page));
+    params.set("limit", String(limit));
+    if (filterName) params.set("filterName", filterName);
+    if (filterMode) params.set("filterMode", filterMode);
+    if (filterLabels) params.set("filterLabels", filterLabels);
+    const response = await fetch(`${API}/action-types?${params}`);
     if (!response.ok) throw new Error(`Failed to fetch action types: ${response.status}`);
     return response.json();
 }
@@ -802,8 +810,16 @@ export interface EventSource {
 
 export type NewEventSource = Omit<EventSource, "id">;
 
-export async function fetchEventSources(): Promise<EventSource[]> {
-    const response = await fetch(`${API}/event-sources`);
+export async function fetchEventSources(
+    page = 1, limit = 20, filterName?: string, filterType?: string, filterLabels?: string
+): Promise<SearchResults<EventSource>> {
+    const params = new URLSearchParams();
+    params.set("page", String(page));
+    params.set("limit", String(limit));
+    if (filterName) params.set("filterName", filterName);
+    if (filterType) params.set("filterType", filterType);
+    if (filterLabels) params.set("filterLabels", filterLabels);
+    const response = await fetch(`${API}/event-sources?${params}`);
     if (!response.ok) throw new Error(`Failed to fetch event sources: ${response.status}`);
     return response.json();
 }

--- a/ui/src/pages/ActionTypesPage.tsx
+++ b/ui/src/pages/ActionTypesPage.tsx
@@ -16,12 +16,23 @@ import {
     ModalFooter,
     ModalHeader,
     PageSection,
+    Pagination,
     TextInput,
     Title,
+    Toolbar,
+    ToolbarContent,
+    ToolbarItem,
 } from "@patternfly/react-core";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import PlusCircleIcon from "@patternfly/react-icons/dist/esm/icons/plus-circle-icon";
+import SyncAltIcon from "@patternfly/react-icons/dist/esm/icons/sync-alt-icon";
 import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
+import {
+    type ChipFilterCriteria,
+    type ChipFilterType,
+    ChipFilterInput,
+    FilterChips,
+} from "@apitomy/common-ui-components";
 import {
     type ActionType,
     type NewActionType,
@@ -33,21 +44,89 @@ import { BooleanStatusIcon } from "../components/BooleanStatusIcon";
 import { ColoredLabel } from "../components/ColoredLabel";
 import { ConfirmDeleteModal } from "../components/ConfirmDeleteModal";
 
+const FILTER_TYPES: ChipFilterType[] = [
+    { value: "name", label: "Name", testId: "action-type-filter-name" },
+    { value: "mode", label: "Mode", testId: "action-type-filter-mode" },
+    { value: "labels", label: "Labels", testId: "action-type-filter-labels" },
+];
+
 export function ActionTypesPage() {
     const navigate = useNavigate();
     const [actionTypes, setActionTypes] = useState<ActionType[]>([]);
+    const [totalCount, setTotalCount] = useState(0);
     const [loading, setLoading] = useState(true);
     const [isCreateOpen, setIsCreateOpen] = useState(false);
     const [deleteTarget, setDeleteTarget] = useState<number | null>(null);
     const [newName, setNewName] = useState("");
     const [newMode, setNewMode] = useState("actor");
 
+    const [filters, setFilters] = useState<ChipFilterCriteria[]>([]);
+    const [page, setPage] = useState(1);
+    const [perPage, setPerPage] = useState(20);
+
+    const filterName = filters.find((f) => f.filterBy.value === "name")?.filterValue;
+    const filterMode = filters.find((f) => f.filterBy.value === "mode")?.filterValue;
+    const filterLabels = filters
+        .filter((f) => f.filterBy.value === "labels")
+        .map((f) => f.filterValue)
+        .join(",");
+    const isFiltered = filters.length > 0;
+
     const load = useCallback(() => {
         setLoading(true);
-        fetchActionTypes().then(setActionTypes).catch(console.error).finally(() => setLoading(false));
-    }, []);
+        fetchActionTypes(page, perPage, filterName || undefined, filterMode || undefined, filterLabels || undefined)
+            .then((results) => {
+                setActionTypes(results.items);
+                setTotalCount(results.totalCount);
+            })
+            .catch(console.error)
+            .finally(() => setLoading(false));
+    }, [page, perPage, filterName, filterMode, filterLabels]);
 
     useEffect(() => { load(); }, [load]);
+
+    const onAddFilterCriteria = (criteria: ChipFilterCriteria) => {
+        if (!criteria.filterValue) return;
+        const updated = filters.filter((f) =>
+            !(f.filterBy.value === criteria.filterBy.value && f.filterValue === criteria.filterValue));
+        if (criteria.filterBy.value === "name" || criteria.filterBy.value === "mode") {
+            const withoutSame = updated.filter((f) => f.filterBy.value !== criteria.filterBy.value);
+            withoutSame.push(criteria);
+            setFilters(withoutSame);
+        } else {
+            updated.push(criteria);
+            setFilters(updated);
+        }
+        setPage(1);
+    };
+
+    const onRemoveFilterCriteria = (criteria: ChipFilterCriteria) => {
+        setFilters(filters.filter((f) =>
+            !(f.filterBy.value === criteria.filterBy.value && f.filterValue === criteria.filterValue)));
+        setPage(1);
+    };
+
+    const onClearAllFilters = () => {
+        setFilters([]);
+        setPage(1);
+    };
+
+    const addLabelFilter = (label: string) => {
+        const already = filters.some((f) => f.filterBy.value === "labels" && f.filterValue === label);
+        if (!already) {
+            const labelType = FILTER_TYPES.find((t) => t.value === "labels")!;
+            setFilters([...filters, { filterBy: labelType, filterValue: label }]);
+            setPage(1);
+        }
+    };
+
+    const addModeFilter = (mode: string) => {
+        const modeType = FILTER_TYPES.find((t) => t.value === "mode")!;
+        const withoutMode = filters.filter((f) => f.filterBy.value !== "mode");
+        withoutMode.push({ filterBy: modeType, filterValue: mode });
+        setFilters(withoutMode);
+        setPage(1);
+    };
 
     const handleCreate = () => {
         const data: NewActionType = {
@@ -93,11 +172,52 @@ export function ActionTypesPage() {
                 </FlexItem>
             </Flex>
 
-            <div style={{ marginTop: "16px" }}>
+            <Toolbar style={{ marginTop: "16px" }}>
+                <ToolbarContent>
+                    <ToolbarItem>
+                        <ChipFilterInput
+                            filterTypes={FILTER_TYPES}
+                            onAddCriteria={onAddFilterCriteria} />
+                    </ToolbarItem>
+                    <ToolbarItem>
+                        <Button variant="control" aria-label="Refresh" onClick={load}>
+                            <SyncAltIcon />
+                        </Button>
+                    </ToolbarItem>
+                    <ToolbarItem variant="pagination" align={{ default: "alignEnd" }}>
+                        <Pagination
+                            itemCount={totalCount}
+                            perPage={perPage}
+                            page={page}
+                            onSetPage={(_e, p) => setPage(p)}
+                            onPerPageSelect={(_e, pp) => { setPerPage(pp); setPage(1); }}
+                            isCompact
+                        />
+                    </ToolbarItem>
+                </ToolbarContent>
+            </Toolbar>
+            {isFiltered && (
+                <Toolbar>
+                    <ToolbarContent>
+                        <ToolbarItem>
+                            <FilterChips
+                                criteria={filters}
+                                onClearAllCriteria={onClearAllFilters}
+                                onRemoveCriteria={onRemoveFilterCriteria} />
+                        </ToolbarItem>
+                    </ToolbarContent>
+                </Toolbar>
+            )}
+
+            <div>
                 {loading ? (
                     <EmptyState><EmptyStateBody>Loading...</EmptyStateBody></EmptyState>
                 ) : actionTypes.length === 0 ? (
-                    <EmptyState><EmptyStateBody>No action types.</EmptyStateBody></EmptyState>
+                    <EmptyState><EmptyStateBody>
+                        {isFiltered
+                            ? "No action types match the current filters."
+                            : "No action types defined."}
+                    </EmptyStateBody></EmptyState>
                 ) : (
                     <Table aria-label="Action Types" variant="compact">
                         <Thead>
@@ -121,14 +241,24 @@ export function ActionTypesPage() {
                                 >
                                     <Td>{at.name}</Td>
                                     <Td>
-                                        <Label isCompact color={at.executionMode === "actor" ? "blue" : "orange"}>
+                                        <Label isCompact
+                                            color={at.executionMode === "actor" ? "blue" : "orange"}
+                                            style={{ cursor: "pointer" }}
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                addModeFilter(at.executionMode);
+                                            }}>
                                             {at.executionMode}
                                         </Label>
                                     </Td>
                                     <Td>
                                         {at.labels?.map((label) => (
                                             <ColoredLabel key={label} isCompact
-                                                style={{ marginRight: "4px" }}>
+                                                style={{ marginRight: "4px", cursor: "pointer" }}
+                                                onClick={(e) => {
+                                                    e.stopPropagation();
+                                                    addLabelFilter(label);
+                                                }}>
                                                 {label}
                                             </ColoredLabel>
                                         ))}
@@ -155,7 +285,6 @@ export function ActionTypesPage() {
                 Delete this action type?
             </ConfirmDeleteModal>
 
-            {/* Simple create modal — just name and mode, then navigate to detail page */}
             <Modal isOpen={isCreateOpen} onClose={() => setIsCreateOpen(false)} variant="small">
                 <ModalHeader title="Create Action Type" />
                 <ModalBody>

--- a/ui/src/pages/ActorDetailPage.tsx
+++ b/ui/src/pages/ActorDetailPage.tsx
@@ -281,7 +281,7 @@ function CapabilitiesTab({ capabilities, onAdd, onRemove }: {
     const [actionTypes, setActionTypes] = useState<ActionType[]>([]);
 
     useEffect(() => {
-        fetchActionTypes().then(setActionTypes).catch(console.error);
+        fetchActionTypes(1, 1000).then((r) => setActionTypes(r.items)).catch(console.error);
     }, []);
 
     const suggestions: TypeaheadAddSuggestion[] = actionTypes.map((at) => ({

--- a/ui/src/pages/ConfigurationPacksPage.tsx
+++ b/ui/src/pages/ConfigurationPacksPage.tsx
@@ -84,7 +84,7 @@ export function ConfigurationPacksPage() {
     const loadData = useCallback(() => {
         setLoading(true);
         Promise.all([
-            fetchActionTypes(),
+            fetchActionTypes(1, 1000),
             fetchTools(1, 1000),
             fetchToolsets(),
             fetchMcpServers(),
@@ -92,7 +92,7 @@ export function ConfigurationPacksPage() {
             fetchAssistantTemplates(),
         ])
             .then(([at, t, ts, mcp, rd, st]) => {
-                setActionTypes(at);
+                setActionTypes(at.items);
                 setTools(t.items);
                 setToolsets(ts);
                 setMcpServers(mcp);

--- a/ui/src/pages/EventSourcesPage.tsx
+++ b/ui/src/pages/EventSourcesPage.tsx
@@ -12,18 +12,30 @@ import {
     HelperText,
     HelperTextItem,
     FormSelectOption,
+    Label,
     Modal,
     ModalBody,
     ModalFooter,
     ModalHeader,
     PageSection,
+    Pagination,
     Switch,
     TextInput,
     Title,
+    Toolbar,
+    ToolbarContent,
+    ToolbarItem,
 } from "@patternfly/react-core";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import PlusCircleIcon from "@patternfly/react-icons/dist/esm/icons/plus-circle-icon";
+import SyncAltIcon from "@patternfly/react-icons/dist/esm/icons/sync-alt-icon";
 import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
+import {
+    type ChipFilterCriteria,
+    type ChipFilterType,
+    ChipFilterInput,
+    FilterChips,
+} from "@apitomy/common-ui-components";
 import { BooleanStatusIcon } from "../components/BooleanStatusIcon";
 import { ColoredLabel } from "../components/ColoredLabel";
 import { LabelInput } from "../components/LabelInput";
@@ -39,9 +51,16 @@ import {
 } from "../config/api";
 import { ConfirmDeleteModal } from "../components/ConfirmDeleteModal";
 
+const FILTER_TYPES: ChipFilterType[] = [
+    { value: "name", label: "Name", testId: "event-source-filter-name" },
+    { value: "type", label: "Type", testId: "event-source-filter-type" },
+    { value: "labels", label: "Labels", testId: "event-source-filter-labels" },
+];
+
 export function EventSourcesPage() {
     const navigate = useNavigate();
     const [sources, setSources] = useState<EventSource[]>([]);
+    const [totalCount, setTotalCount] = useState(0);
     const [loading, setLoading] = useState(true);
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [editing, setEditing] = useState<EventSource | null>(null);
@@ -59,13 +78,74 @@ export function EventSourcesPage() {
     // Jira-specific fields
     const [jiraUrl, setJiraUrl] = useState("");
 
+    const [filters, setFilters] = useState<ChipFilterCriteria[]>([]);
+    const [page, setPage] = useState(1);
+    const [perPage, setPerPage] = useState(20);
+
+    const filterName = filters.find((f) => f.filterBy.value === "name")?.filterValue;
+    const filterType = filters.find((f) => f.filterBy.value === "type")?.filterValue;
+    const filterLabels = filters
+        .filter((f) => f.filterBy.value === "labels")
+        .map((f) => f.filterValue)
+        .join(",");
+    const isFiltered = filters.length > 0;
+
     const load = useCallback(() => {
         setLoading(true);
-        fetchEventSources().then(setSources).catch(console.error).finally(() => setLoading(false));
-    }, []);
+        fetchEventSources(page, perPage, filterName || undefined, filterType || undefined, filterLabels || undefined)
+            .then((results) => {
+                setSources(results.items);
+                setTotalCount(results.totalCount);
+            })
+            .catch(console.error)
+            .finally(() => setLoading(false));
+    }, [page, perPage, filterName, filterType, filterLabels]);
 
     useEffect(() => { load(); }, [load]);
     useEffect(() => { fetchSecrets().then(setSecrets).catch(console.error); }, []);
+
+    const onAddFilterCriteria = (criteria: ChipFilterCriteria) => {
+        if (!criteria.filterValue) return;
+        const updated = filters.filter((f) =>
+            !(f.filterBy.value === criteria.filterBy.value && f.filterValue === criteria.filterValue));
+        if (criteria.filterBy.value === "name" || criteria.filterBy.value === "type") {
+            const withoutSame = updated.filter((f) => f.filterBy.value !== criteria.filterBy.value);
+            withoutSame.push(criteria);
+            setFilters(withoutSame);
+        } else {
+            updated.push(criteria);
+            setFilters(updated);
+        }
+        setPage(1);
+    };
+
+    const onRemoveFilterCriteria = (criteria: ChipFilterCriteria) => {
+        setFilters(filters.filter((f) =>
+            !(f.filterBy.value === criteria.filterBy.value && f.filterValue === criteria.filterValue)));
+        setPage(1);
+    };
+
+    const onClearAllFilters = () => {
+        setFilters([]);
+        setPage(1);
+    };
+
+    const addLabelFilter = (label: string) => {
+        const already = filters.some((f) => f.filterBy.value === "labels" && f.filterValue === label);
+        if (!already) {
+            const labelType = FILTER_TYPES.find((t) => t.value === "labels")!;
+            setFilters([...filters, { filterBy: labelType, filterValue: label }]);
+            setPage(1);
+        }
+    };
+
+    const addTypeFilter = (type: string) => {
+        const typeFilterType = FILTER_TYPES.find((t) => t.value === "type")!;
+        const withoutType = filters.filter((f) => f.filterBy.value !== "type");
+        withoutType.push({ filterBy: typeFilterType, filterValue: type });
+        setFilters(withoutType);
+        setPage(1);
+    };
 
     const parseGitHubUrl = (url: string): { owner: string; name: string; instance: string } | null => {
         try {
@@ -84,8 +164,6 @@ export function EventSourcesPage() {
             const trimmed = url.replace(/\/+$/, "");
             const parsed = new URL(trimmed);
             const parts = parsed.pathname.split("/").filter(Boolean);
-            // Find "projects" anywhere in the path and take the next segment as the key
-            // Supports: /projects/KEY, /browse/KEY, /jira/software/c/projects/KEY/...
             const idx = parts.findIndex((p) => p === "projects" || p === "browse");
             if (idx >= 0 && idx + 1 < parts.length) {
                 return { baseUrl: parsed.origin, project: parts[idx + 1] };
@@ -177,12 +255,53 @@ export function EventSourcesPage() {
                 </FlexItem>
             </Flex>
 
-            <div style={{ marginTop: "16px" }}>
+            <Toolbar style={{ marginTop: "16px" }}>
+                <ToolbarContent>
+                    <ToolbarItem>
+                        <ChipFilterInput
+                            filterTypes={FILTER_TYPES}
+                            onAddCriteria={onAddFilterCriteria} />
+                    </ToolbarItem>
+                    <ToolbarItem>
+                        <Button variant="control" aria-label="Refresh" onClick={load}>
+                            <SyncAltIcon />
+                        </Button>
+                    </ToolbarItem>
+                    <ToolbarItem variant="pagination" align={{ default: "alignEnd" }}>
+                        <Pagination
+                            itemCount={totalCount}
+                            perPage={perPage}
+                            page={page}
+                            onSetPage={(_e, p) => setPage(p)}
+                            onPerPageSelect={(_e, pp) => { setPerPage(pp); setPage(1); }}
+                            isCompact
+                        />
+                    </ToolbarItem>
+                </ToolbarContent>
+            </Toolbar>
+            {isFiltered && (
+                <Toolbar>
+                    <ToolbarContent>
+                        <ToolbarItem>
+                            <FilterChips
+                                criteria={filters}
+                                onClearAllCriteria={onClearAllFilters}
+                                onRemoveCriteria={onRemoveFilterCriteria} />
+                        </ToolbarItem>
+                    </ToolbarContent>
+                </Toolbar>
+            )}
+
+            <div>
                 {loading ? (
                     <EmptyState><EmptyStateBody>Loading...</EmptyStateBody></EmptyState>
                 ) : sources.length === 0 ? (
                     <EmptyState>
-                        <EmptyStateBody>No event sources configured.</EmptyStateBody>
+                        <EmptyStateBody>
+                            {isFiltered
+                                ? "No event sources match the current filters."
+                                : "No event sources configured."}
+                        </EmptyStateBody>
                     </EmptyState>
                 ) : (
                     <Table aria-label="Event Sources" variant="compact">
@@ -201,12 +320,25 @@ export function EventSourcesPage() {
                             {sources.map((s) => (
                                 <Tr key={s.id} isClickable onRowClick={() => navigate(`/event-sources/${s.id}`)}>
                                     <Td>{s.name}</Td>
-                                    <Td>{s.sourceType}</Td>
+                                    <Td>
+                                        <Label isCompact
+                                            style={{ cursor: "pointer" }}
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                addTypeFilter(s.sourceType);
+                                            }}>
+                                            {s.sourceType}
+                                        </Label>
+                                    </Td>
                                     <Td><code>{describeSource(s)}</code></Td>
                                     <Td>
                                         {s.labels?.map((label) => (
                                             <ColoredLabel key={label} isCompact
-                                                style={{ marginRight: "4px" }}>
+                                                style={{ marginRight: "4px", cursor: "pointer" }}
+                                                onClick={(e) => {
+                                                    e.stopPropagation();
+                                                    addLabelFilter(label);
+                                                }}>
                                                 {label}
                                             </ColoredLabel>
                                         ))}

--- a/ui/src/pages/ProjectDetailPage.tsx
+++ b/ui/src/pages/ProjectDetailPage.tsx
@@ -138,9 +138,9 @@ export function ProjectDetailPage() {
     }, [loadData]);
 
     const openActionModal = () => {
-        fetchActionTypes()
-            .then((types) => {
-                const triggerable = types.filter(
+        fetchActionTypes(1, 1000)
+            .then((results) => {
+                const triggerable = results.items.filter(
                     (t) => t.userTriggerable
                 );
                 setActionTypes(triggerable);


### PR DESCRIPTION
## Summary

- Adds server-side filtering and pagination to the **Action Types** page (Name, Mode, Labels) and **Event Sources** page (Name, Type, Labels), matching the existing pattern from the Tools page.
- Updates the OpenAPI spec with new query parameters, search results schemas (`ActionTypeSearchResults`, `EventSourceSearchResults`), and updated response types.
- Backend `ActionResourceImpl` and `EventSourcesResourceImpl` now build dynamic HQL queries with pagination support.
- Frontend `fetchActionTypes` / `fetchEventSources` updated to pass filter/pagination params and return `SearchResults<T>`.
- All other consumers (`ActionTypesWidget`, `EventSourceHealthWidget`, `ProjectDetailPage`, `ActorDetailPage`, `ConfigurationPacksPage`) updated for the new return type.
- Labels and mode/type badges in table rows are clickable to add as filter criteria.

## Test plan

- [ ] Verify Action Types page loads with pagination and no filters applied
- [ ] Filter by Name — confirm substring match on name/description
- [ ] Filter by Mode — click a mode badge or type in filter input, confirm only matching mode shown
- [ ] Filter by Labels — click label chips or type in filter, confirm AND logic for multiple labels
- [ ] Clear individual filter chips and "Clear all" button work correctly
- [ ] Verify Event Sources page has the same filtering behavior (Name, Type, Labels)
- [ ] Verify dashboard widgets (ActionTypesWidget, EventSourceHealthWidget) still render correctly
- [ ] Verify ProjectDetailPage action modal and ActorDetailPage action type typeahead still work
- [ ] Verify ConfigurationPacksPage still loads action types correctly