### PR TITLE
Add refresh button to Dashboard page

### DIFF
--- a/ui/src/pages/DashboardViewPage.tsx
+++ b/ui/src/pages/DashboardViewPage.tsx
@@ -23,6 +23,7 @@ import PencilAltIcon from "@patternfly/react-icons/dist/esm/icons/pencil-alt-ico
 import PlusCircleIcon from "@patternfly/react-icons/dist/esm/icons/plus-circle-icon";
 import SaveIcon from "@patternfly/react-icons/dist/esm/icons/save-icon";
 import StarIcon from "@patternfly/react-icons/dist/esm/icons/star-icon";
+import SyncAltIcon from "@patternfly/react-icons/dist/esm/icons/sync-alt-icon";
 import TimesIcon from "@patternfly/react-icons/dist/esm/icons/times-icon";
 import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
 import {
@@ -62,6 +63,7 @@ export function DashboardViewPage() {
 
     const [addWidgetOpen, setAddWidgetOpen] = useState(false);
     const [deleteOpen, setDeleteOpen] = useState(false);
+    const [refreshKey, setRefreshKey] = useState(0);
 
     const load = useCallback(() => {
         if (!dashboardId) return;
@@ -268,6 +270,13 @@ export function DashboardViewPage() {
                             </>
                         ) : (
                             <>
+                                <FlexItem>
+                                    <Button variant="plain"
+                                            aria-label="Refresh"
+                                            onClick={() => setRefreshKey(k => k + 1)}>
+                                        <SyncAltIcon />
+                                    </Button>
+                                </FlexItem>
                                 {!dashboard.isDefault && (
                                     <FlexItem>
                                         <Button variant="secondary" icon={<StarIcon />}
@@ -331,6 +340,7 @@ export function DashboardViewPage() {
                     {activeWidgets.map(w => (
                         <div key={w.id}>
                             <WidgetCard
+                                key={refreshKey}
                                 widgetType={w.type}
                                 config={w.config}
                                 labels={activeLabels}


### PR DESCRIPTION
## Summary

Adds a refresh button to the Dashboard view page that triggers all widgets to reload their data without a full browser page reload.

## Changes

- Added a refresh button (using `SyncAltIcon`) to the Dashboard view page toolbar, visible when not in edit mode
- The button uses a React key-based remount strategy: clicking it increments a `refreshKey` counter that is applied as a `key` prop on each `WidgetCard`, causing React to unmount and remount all widget components — which in turn re-triggers their `useEffect` data-fetching hooks
- Button style (`variant="plain"`, `aria-label="Refresh"`) is consistent with refresh buttons on other pages like ProjectDetailPage

## Files Modified

- `ui/src/pages/DashboardViewPage.tsx`

Fixes #177