### PR TITLE
feat: show filter status (allowed/blocked) on Events log page

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/PipelineOrchestrator.java
+++ b/app/src/main/java/io/apitomy/axiom/app/PipelineOrchestrator.java
@@ -160,12 +160,25 @@ public class PipelineOrchestrator {
         if (!filterResult.allowed()) {
             LOG.infof("Pre-filtered event %d: %s", event.id, filterResult.matchedRule());
             QuarkusTransaction.requiringNew().run(() -> {
+                EventEntity managed = EventEntity.findById(eventId);
+                if (managed != null) {
+                    managed.filterStatus = "blocked";
+                    managed.filterMatchedRule = filterResult.matchedRule();
+                }
                 logActivity(null, null, event.id, "event-pre-filtered",
                         "Event pre-filtered: " + event.eventType + " — " + filterResult.matchedRule());
                 markQueueEntry(queueEntryId, "completed");
             });
             return;
         }
+
+        // Mark event as allowed through filters
+        QuarkusTransaction.requiringNew().run(() -> {
+            EventEntity managed = EventEntity.findById(eventId);
+            if (managed != null) {
+                managed.filterStatus = "allowed";
+            }
+        });
 
         // Trace creation (TraceService manages its own transactions)
         TraceContext traceCtx = null;

--- a/app/src/main/java/io/apitomy/axiom/app/rest/EventsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/EventsResourceImpl.java
@@ -43,7 +43,8 @@ public class EventsResourceImpl implements EventsResource {
     @Override
     public EventSearchResults listEvents(BigInteger page, BigInteger limit,
                                           String filterSource, String filterEventType,
-                                          String filterRepository, String filterLabels) {
+                                          String filterRepository, String filterLabels,
+                                          String filterFilterStatus) {
         int pageNum = page != null ? page.intValue() : 1;
         int pageSize = limit != null ? limit.intValue() : 20;
 
@@ -70,6 +71,10 @@ public class EventsResourceImpl implements EventsResource {
                     + " GROUP BY es.id HAVING COUNT(DISTINCT esl) = :labelCount)");
             params.put("labels", labels);
             params.put("labelCount", (long) labels.size());
+        }
+        if (filterFilterStatus != null && !filterFilterStatus.isBlank()) {
+            hql.append(" and filterStatus = :filterStatus");
+            params.put("filterStatus", filterFilterStatus);
         }
 
         long totalCount = EventEntity.count(hql.toString(), params);
@@ -174,6 +179,8 @@ public class EventsResourceImpl implements EventsResource {
         if (entity.traceId != null) {
             event.setTraceId(entity.traceId);
         }
+        event.setFilterStatus(entity.filterStatus);
+        event.setFilterMatchedRule(entity.filterMatchedRule);
         return event;
     }
 }

--- a/app/src/main/resources/db/migration/V39__add_event_filter_status.sql
+++ b/app/src/main/resources/db/migration/V39__add_event_filter_status.sql
@@ -1,0 +1,2 @@
+ALTER TABLE event ADD COLUMN filter_status VARCHAR(16);
+ALTER TABLE event ADD COLUMN filter_matched_rule VARCHAR(512);

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -1862,6 +1862,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "filterFilterStatus",
+            "in": "query",
+            "description": "Filter by filter status (allowed or blocked)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -5493,23 +5502,23 @@
         "type": "object",
         "properties": {
           "closedProjectRetentionDays": {
-            "description": "Number of days to retain closed projects before automatic deletion.",
             "format": "int32",
+            "description": "Number of days to retain closed projects before automatic deletion.",
             "type": "integer"
           },
           "traceRetentionDays": {
-            "description": "Number of days to retain execution traces before automatic deletion.",
             "format": "int32",
+            "description": "Number of days to retain execution traces before automatic deletion.",
             "type": "integer"
           },
           "eventRetentionDays": {
-            "description": "Number of days to retain ingested events before automatic deletion.",
             "format": "int32",
+            "description": "Number of days to retain ingested events before automatic deletion.",
             "type": "integer"
           },
           "eventSourceLogRetentionDays": {
-            "description": "Number of days to retain event source poll logs before automatic deletion.",
             "format": "int32",
+            "description": "Number of days to retain event source poll logs before automatic deletion.",
             "type": "integer"
           }
         }
@@ -5669,6 +5678,14 @@
             "items": {
               "type": "string"
             }
+          },
+          "filterStatus": {
+            "description": "Filter evaluation result: allowed, blocked, or null for legacy events",
+            "type": "string"
+          },
+          "filterMatchedRule": {
+            "description": "Description of the filter rule that blocked the event, if applicable",
+            "type": "string"
           }
         }
       },

--- a/core/src/main/java/io/apitomy/axiom/core/entities/EventEntity.java
+++ b/core/src/main/java/io/apitomy/axiom/core/entities/EventEntity.java
@@ -44,4 +44,10 @@ public class EventEntity extends PanacheEntity {
 
     @Column(name = "received_at", nullable = false)
     public Instant receivedAt;
+
+    @Column(name = "filter_status")
+    public String filterStatus;
+
+    @Column(name = "filter_matched_rule")
+    public String filterMatchedRule;
 }

--- a/ui/src/components/EventDetailModal.tsx
+++ b/ui/src/components/EventDetailModal.tsx
@@ -86,6 +86,25 @@ export function EventDetailModal({ event, onClose }: EventDetailModalProps) {
                                             </DescriptionListDescription>
                                         </DescriptionListGroup>
                                     )}
+                                    {event.filterStatus && (
+                                        <DescriptionListGroup>
+                                            <DescriptionListTerm>Filter Status</DescriptionListTerm>
+                                            <DescriptionListDescription>
+                                                <Label isCompact
+                                                    color={event.filterStatus === "allowed" ? "green" : "red"}>
+                                                    {event.filterStatus}
+                                                </Label>
+                                            </DescriptionListDescription>
+                                        </DescriptionListGroup>
+                                    )}
+                                    {event.filterMatchedRule && (
+                                        <DescriptionListGroup>
+                                            <DescriptionListTerm>Matched Rule</DescriptionListTerm>
+                                            <DescriptionListDescription>
+                                                {event.filterMatchedRule}
+                                            </DescriptionListDescription>
+                                        </DescriptionListGroup>
+                                    )}
                                 </DescriptionList>
                             </CardBody>
                         </Card>

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -1236,6 +1236,8 @@ export interface AxiomEvent {
     receivedAt: string;
     traceId?: string;
     labels?: string[];
+    filterStatus?: string;
+    filterMatchedRule?: string;
 }
 
 export async function fetchEvent(id: number): Promise<AxiomEvent> {
@@ -1253,7 +1255,7 @@ export async function fetchProjectEvents(projectId: number): Promise<AxiomEvent[
 export async function fetchEvents(
     page = 1, limit = 20,
     filterSource?: string, filterEventType?: string, filterRepository?: string,
-    filterLabels?: string
+    filterLabels?: string, filterFilterStatus?: string
 ): Promise<SearchResults<AxiomEvent>> {
     const params = new URLSearchParams();
     params.set("page", String(page));
@@ -1262,6 +1264,7 @@ export async function fetchEvents(
     if (filterEventType) params.set("filterEventType", filterEventType);
     if (filterRepository) params.set("filterRepository", filterRepository);
     if (filterLabels) params.set("filterLabels", filterLabels);
+    if (filterFilterStatus) params.set("filterFilterStatus", filterFilterStatus);
     const response = await fetch(`${API}/events?${params}`);
     if (!response.ok) throw new Error(`Failed to fetch events: ${response.status}`);
     return response.json();

--- a/ui/src/pages/EventsPage.tsx
+++ b/ui/src/pages/EventsPage.tsx
@@ -30,11 +30,17 @@ const SOURCE_COLORS: Record<string, "blue" | "green" | "orange" | "grey"> = {
     internal: "orange",
 };
 
+const FILTER_STATUS_COLORS: Record<string, "green" | "red" | "grey"> = {
+    allowed: "green",
+    blocked: "red",
+};
+
 const FILTER_TYPES: ChipFilterType[] = [
     { value: "source", label: "Source", testId: "event-filter-source" },
     { value: "eventType", label: "Event Type", testId: "event-filter-eventType" },
     { value: "repository", label: "Repository", testId: "event-filter-repository" },
     { value: "labels", label: "Labels", testId: "event-filter-labels" },
+    { value: "filterStatus", label: "Filter Status", testId: "event-filter-filterStatus" },
 ];
 
 export function EventsPage() {
@@ -57,6 +63,7 @@ export function EventsPage() {
         .filter((f) => f.filterBy.value === "labels")
         .map((f) => f.filterValue)
         .join(",");
+    const filterFilterStatus = filters.find((f) => f.filterBy.value === "filterStatus")?.filterValue;
     const isFiltered = filters.length > 0;
 
     const loadData = useCallback(() => {
@@ -66,7 +73,8 @@ export function EventsPage() {
             filterSource || undefined,
             filterEventType || undefined,
             filterRepository || undefined,
-            filterLabels || undefined
+            filterLabels || undefined,
+            filterFilterStatus || undefined
         )
             .then((results) => {
                 setEvents(results.items);
@@ -74,7 +82,7 @@ export function EventsPage() {
             })
             .catch(console.error)
             .finally(() => setLoading(false));
-    }, [page, perPage, filterSource, filterEventType, filterRepository, filterLabels]);
+    }, [page, perPage, filterSource, filterEventType, filterRepository, filterLabels, filterFilterStatus]);
 
     useEffect(() => { loadData(); }, [loadData]);
 
@@ -176,6 +184,7 @@ export function EventsPage() {
                                 <Th>#</Th>
                                 <Th>Time</Th>
                                 <Th>Source</Th>
+                                <Th>Filter</Th>
                                 <Th>Labels</Th>
                                 <Th>Event Type</Th>
                                 <Th>Repository</Th>
@@ -203,6 +212,22 @@ export function EventsPage() {
                                             }}>
                                             {event.source}
                                         </Label>
+                                    </Td>
+                                    <Td>
+                                        {event.filterStatus ? (
+                                            <Label isCompact
+                                                color={FILTER_STATUS_COLORS[event.filterStatus] || "grey"}
+                                                style={{ cursor: "pointer" }}
+                                                onClick={(e) => {
+                                                    e.stopPropagation();
+                                                    const statusType = FILTER_TYPES.find((t) => t.value === "filterStatus")!;
+                                                    onAddFilterCriteria({ filterBy: statusType, filterValue: event.filterStatus! });
+                                                }}>
+                                                {event.filterStatus}
+                                            </Label>
+                                        ) : (
+                                            <Label isCompact color="grey">—</Label>
+                                        )}
                                     </Td>
                                     <Td>
                                         {event.labels && event.labels.length > 0


### PR DESCRIPTION
## Summary

- Add `filter_status` and `filter_matched_rule` columns to the `event` table (V39 migration)
- Set filter status on `EventEntity` in `PipelineOrchestrator.processEvent()` after filter evaluation — `"blocked"` with matched rule description, or `"allowed"`
- Update OpenAPI spec with `filterStatus` and `filterMatchedRule` properties on the `Event` schema, plus a `filterFilterStatus` query parameter on `GET /events`
- Add filter status badge column (green/red/grey) to the Events table on the frontend, with a chip filter toggle for allowed/blocked
- Show filter status and matched rule in the `EventDetailModal`

Fixes #180