### PR TITLE
feat: capture raw NDJSON event logs for AI Assistant sessions

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSession.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSession.java
@@ -7,9 +7,12 @@ import io.apitomy.axiom.app.assistant.AssistantEventParser.SseEvent;
 import org.jboss.logging.Logger;
 
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -40,6 +43,7 @@ public class AssistantSession {
 
     private static final Logger LOG = Logger.getLogger(AssistantSession.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String RAW_EVENTS_FILE = "raw-events.jsonl";
 
     /** Possible session states. */
     public enum Status { STARTING, RUNNING, STOPPED, ERROR }
@@ -71,6 +75,7 @@ public class AssistantSession {
     private final Object eventLock = new Object();
     private final CopyOnWriteArrayList<AutoApprovalRule> autoApprovalRules = new CopyOnWriteArrayList<>();
     private volatile boolean allowAll;
+    private volatile BufferedWriter rawEventsWriter;
     private final Long projectId;
     private final String projectName;
 
@@ -137,6 +142,15 @@ public class AssistantSession {
 
         process = pb.start();
         stdin = process.getOutputStream();
+
+        try {
+            rawEventsWriter = new BufferedWriter(new OutputStreamWriter(
+                    new FileOutputStream(sessionDirectory.resolve(RAW_EVENTS_FILE).toFile()),
+                    StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            LOG.warnf(e, "Failed to open raw events log for session %s; raw logging disabled", id);
+            rawEventsWriter = null;
+        }
 
         // Read stdout (NDJSON) on a virtual thread
         Thread.ofVirtual().name("assistant-stdout-" + id).start(this::readStdout);
@@ -323,6 +337,8 @@ public class AssistantSession {
     public void destroy() {
         LOG.infof("Destroying assistant session %s", id);
         status = Status.STOPPED;
+        closeQuietly(rawEventsWriter);
+        rawEventsWriter = null;
         if (process != null && process.isAlive()) {
             process.destroyForcibly();
         }
@@ -371,6 +387,15 @@ public class AssistantSession {
      */
     public Path getSessionDirectory() {
         return sessionDirectory;
+    }
+
+    /**
+     * Returns the path to the raw NDJSON event log file.
+     *
+     * @return the raw events log file path
+     */
+    public Path getRawEventsFile() {
+        return sessionDirectory.resolve(RAW_EVENTS_FILE);
     }
 
     public Path getWorkingDirectory() {
@@ -532,39 +557,74 @@ public class AssistantSession {
         }
     }
 
+    private void writeRawEvent(String line) {
+        BufferedWriter writer = rawEventsWriter;
+        if (writer == null) {
+            return;
+        }
+        try {
+            writer.write("{\"ts\":\"");
+            writer.write(Instant.now().toString());
+            writer.write("\",\"raw\":");
+            writer.write(line);
+            writer.write("}");
+            writer.newLine();
+            writer.flush();
+        } catch (IOException e) {
+            LOG.warnf(e, "Failed to write raw event for session %s; disabling raw logging", id);
+            rawEventsWriter = null;
+            closeQuietly(writer);
+        }
+    }
+
+    private static void closeQuietly(AutoCloseable closeable) {
+        if (closeable != null) {
+            try {
+                closeable.close();
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
     private void readStdout() {
-        try (BufferedReader reader = new BufferedReader(
-                new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
-            String line;
-            while ((line = reader.readLine()) != null) {
-                List<SseEvent> events = parser.parse(line);
-                for (SseEvent event : events) {
-                    if (handleAutoApproval(event)) {
-                        continue;
-                    }
-                    if ("turn_complete".equals(event.type())) {
-                        accumulateCost(event);
-                    }
-                    synchronized (eventLock) {
-                        if ("conversation_reset".equals(event.type())) {
-                            eventHistory.clear();
+        try {
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    writeRawEvent(line);
+                    List<SseEvent> events = parser.parse(line);
+                    for (SseEvent event : events) {
+                        if (handleAutoApproval(event)) {
+                            continue;
                         }
-                        eventHistory.add(event);
-                        lastActivityAt = Instant.now();
-                        for (Consumer<SseEvent> listener : listeners) {
-                            try {
-                                listener.accept(event);
-                            } catch (Exception e) {
-                                LOG.warnf(e, "SSE listener error in session %s", id);
+                        if ("turn_complete".equals(event.type())) {
+                            accumulateCost(event);
+                        }
+                        synchronized (eventLock) {
+                            if ("conversation_reset".equals(event.type())) {
+                                eventHistory.clear();
+                            }
+                            eventHistory.add(event);
+                            lastActivityAt = Instant.now();
+                            for (Consumer<SseEvent> listener : listeners) {
+                                try {
+                                    listener.accept(event);
+                                } catch (Exception e) {
+                                    LOG.warnf(e, "SSE listener error in session %s", id);
+                                }
                             }
                         }
                     }
                 }
+            } catch (IOException e) {
+                if (status == Status.RUNNING) {
+                    LOG.warnf("Error reading stdout for session %s: %s", id, e.getMessage());
+                }
             }
-        } catch (IOException e) {
-            if (status == Status.RUNNING) {
-                LOG.warnf("Error reading stdout for session %s: %s", id, e.getMessage());
-            }
+        } finally {
+            closeQuietly(rawEventsWriter);
+            rawEventsWriter = null;
         }
     }
 

--- a/app/src/main/java/io/apitomy/axiom/app/rest/AssistantResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/AssistantResourceImpl.java
@@ -37,7 +37,6 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.StreamingOutput;
 import jakarta.ws.rs.sse.OutboundSseEvent;
 import jakarta.ws.rs.sse.Sse;
 import jakarta.ws.rs.sse.SseEventSink;
@@ -303,25 +302,7 @@ public class AssistantResourceImpl implements AssistantResource {
     /** {@inheritDoc} */
     @Override
     public String getAssistantSessionRawEvents(String sessionId) {
-        // Overridden below with streaming file download.
-        requireSession(sessionId);
-        return "";
-    }
-
-    /**
-     * Downloads the raw NDJSON event log file for an assistant session.
-     * The file is streamed directly from disk to avoid loading large logs
-     * into memory.
-     */
-    @GET
-    @Path("/sessions/{sessionId}/raw-events")
-    @Produces(MediaType.TEXT_PLAIN)
-    public Response getAssistantSessionRawEventsStream(
-            @PathParam("sessionId") String sessionId) {
-        AssistantSession session = sessionManager.getSession(sessionId);
-        if (session == null) {
-            throw new WebApplicationException("Session not found: " + sessionId, 404);
-        }
+        AssistantSession session = requireSession(sessionId);
 
         java.nio.file.Path rawEventsFile = session.getRawEventsFile();
         if (!java.nio.file.Files.exists(rawEventsFile)) {
@@ -329,13 +310,12 @@ public class AssistantResourceImpl implements AssistantResource {
                     "No raw events log available for session: " + sessionId, 404);
         }
 
-        StreamingOutput stream = output -> {
-            try (var input = java.nio.file.Files.newInputStream(rawEventsFile)) {
-                input.transferTo(output);
-            }
-        };
-
-        return Response.ok(stream, MediaType.TEXT_PLAIN).build();
+        try {
+            return java.nio.file.Files.readString(rawEventsFile, java.nio.charset.StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new WebApplicationException(
+                    "Failed to read raw events log: " + e.getMessage(), 500);
+        }
     }
 
     /** {@inheritDoc} */

--- a/app/src/main/java/io/apitomy/axiom/app/rest/AssistantResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/AssistantResourceImpl.java
@@ -37,12 +37,15 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.StreamingOutput;
 import jakarta.ws.rs.sse.OutboundSseEvent;
 import jakarta.ws.rs.sse.Sse;
 import jakarta.ws.rs.sse.SseEventSink;
 import org.jboss.logging.Logger;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -297,6 +300,44 @@ public class AssistantResourceImpl implements AssistantResource {
         json.append("]");
 
         return Response.ok(json.toString(), MediaType.APPLICATION_JSON).build();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getAssistantSessionRawEvents(String sessionId) {
+        // Overridden below with streaming file download.
+        requireSession(sessionId);
+        return "";
+    }
+
+    /**
+     * Downloads the raw NDJSON event log file for an assistant session.
+     * The file is streamed directly from disk to avoid loading large logs
+     * into memory.
+     */
+    @GET
+    @Path("/sessions/{sessionId}/raw-events")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response getAssistantSessionRawEventsStream(
+            @PathParam("sessionId") String sessionId) {
+        AssistantSession session = sessionManager.getSession(sessionId);
+        if (session == null) {
+            throw new WebApplicationException("Session not found: " + sessionId, 404);
+        }
+
+        Path rawEventsFile = session.getRawEventsFile();
+        if (!Files.exists(rawEventsFile)) {
+            throw new WebApplicationException(
+                    "No raw events log available for session: " + sessionId, 404);
+        }
+
+        StreamingOutput stream = output -> {
+            try (var input = Files.newInputStream(rawEventsFile)) {
+                input.transferTo(output);
+            }
+        };
+
+        return Response.ok(stream, MediaType.TEXT_PLAIN).build();
     }
 
     /** {@inheritDoc} */

--- a/app/src/main/java/io/apitomy/axiom/app/rest/AssistantResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/AssistantResourceImpl.java
@@ -44,8 +44,6 @@ import jakarta.ws.rs.sse.SseEventSink;
 import org.jboss.logging.Logger;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -325,14 +323,14 @@ public class AssistantResourceImpl implements AssistantResource {
             throw new WebApplicationException("Session not found: " + sessionId, 404);
         }
 
-        Path rawEventsFile = session.getRawEventsFile();
-        if (!Files.exists(rawEventsFile)) {
+        java.nio.file.Path rawEventsFile = session.getRawEventsFile();
+        if (!java.nio.file.Files.exists(rawEventsFile)) {
             throw new WebApplicationException(
                     "No raw events log available for session: " + sessionId, 404);
         }
 
         StreamingOutput stream = output -> {
-            try (var input = Files.newInputStream(rawEventsFile)) {
+            try (var input = java.nio.file.Files.newInputStream(rawEventsFile)) {
                 input.transferTo(output);
             }
         };

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -4900,6 +4900,42 @@
           }
         }
       }
+    },
+    "/assistant/sessions/{sessionId}/raw-events": {
+      "get": {
+        "tags": [
+          "assistant"
+        ],
+        "summary": "Get the raw NDJSON event log for an assistant session",
+        "description": "Returns the raw NDJSON event log captured from the Claude Code subprocess stdout. Each line is a JSON object with a 'ts' (ISO-8601 timestamp) field and a 'raw' field containing the original NDJSON event. The log is available while the session exists and is deleted when the session is destroyed.",
+        "operationId": "getAssistantSessionRawEvents",
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "description": "The assistant session ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The raw NDJSON event log",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Session not found or no raw events log available"
+          }
+        }
+      }
     }
   },
   "components": {


### PR DESCRIPTION
## Summary

Fixes #199

- Writes every raw NDJSON line from Claude Code's stdout to a timestamped log file
  (`~/.axiom/assistant/sessions/<sessionId>/raw-events.jsonl`) during interactive sessions.
  Each line is wrapped as `{"ts":"<ISO-8601>","raw":{...original...}}`.
- Adds `GET /api/v1/assistant/sessions/{sessionId}/raw-events` endpoint to download the log,
  using `StreamingOutput` to avoid loading large files into memory.
- The log file is automatically cleaned up when the session directory is deleted
  (no additional retention logic needed).

## Changes

- **`openapi.json`** — New `getAssistantSessionRawEvents` operation with `text/plain` response
- **`AssistantSession.java`** — Opens a `BufferedWriter` on session start, writes each raw line
  before parsing in `readStdout()`, closes the writer on session end/destroy
- **`AssistantResourceImpl.java`** — Interface stub + custom streaming overload that serves the
  log file via `StreamingOutput`

## Test plan

- [ ] Run `mvn install` to regenerate the `AssistantResource` interface and verify compilation
- [ ] Start the app, create an AI Assistant session, send a message
- [ ] Verify `raw-events.jsonl` is created in the session directory with timestamped NDJSON lines
- [ ] Call `GET /api/v1/assistant/sessions/{sessionId}/raw-events` and verify the log is returned
- [ ] Delete the session and verify the log file is cleaned up with the directory