### PR TITLE
fix: sync SDK tool validator with all 22 implemented tools

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/SeedDataInitializer.java
+++ b/app/src/main/java/io/apitomy/axiom/app/SeedDataInitializer.java
@@ -1,5 +1,6 @@
 package io.apitomy.axiom.app;
 
+import io.apitomy.axiom.core.SdkToolNames;
 import io.apitomy.axiom.core.entities.ActionTypeEntity;
 
 import java.time.Instant;
@@ -192,19 +193,7 @@ public class SeedDataInitializer {
         }
         seedToolset("Axiom SDK",
                 "Built-in Axiom SDK tools for programmatic interaction with Axiom from AI agents",
-                String.join(",",
-                        "mcp__axiom-sdk__axiom_fire_event",
-                        "mcp__axiom-sdk__axiom_list_projects",
-                        "mcp__axiom-sdk__axiom_get_project",
-                        "mcp__axiom-sdk__axiom_create_task",
-                        "mcp__axiom-sdk__axiom_get_task_status",
-                        "mcp__axiom-sdk__axiom_add_thread_entry",
-                        "mcp__axiom-sdk__axiom_close_project",
-                        "mcp__axiom-sdk__axiom_reopen_project",
-                        "mcp__axiom-sdk__axiom_add_project_label",
-                        "mcp__axiom-sdk__axiom_remove_project_label",
-                        "mcp__axiom-sdk__axiom_list_tools",
-                        "mcp__axiom-sdk__axiom_list_report_definitions"));
+                SdkToolNames.ALL_CSV);
         LOG.info("Created 'Axiom SDK' toolset");
     }
 

--- a/app/src/main/java/io/apitomy/axiom/app/rest/ActionResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/ActionResourceImpl.java
@@ -203,8 +203,18 @@ public class ActionResourceImpl implements ActionResource {
                 "mcp__axiom-sdk__axiom_reopen_project",
                 "mcp__axiom-sdk__axiom_add_project_label",
                 "mcp__axiom-sdk__axiom_remove_project_label",
+                "mcp__axiom-sdk__axiom_add_report_label",
+                "mcp__axiom-sdk__axiom_remove_report_label",
                 "mcp__axiom-sdk__axiom_list_tools",
-                "mcp__axiom-sdk__axiom_list_report_definitions"
+                "mcp__axiom-sdk__axiom_list_report_definitions",
+                "mcp__axiom-sdk__axiom_list_reports",
+                "mcp__axiom-sdk__axiom_get_project_thread",
+                "mcp__axiom-sdk__axiom_list_action_types",
+                "mcp__axiom-sdk__axiom_list_actors",
+                "mcp__axiom-sdk__axiom_update_project",
+                "mcp__axiom-sdk__axiom_list_events",
+                "mcp__axiom-sdk__axiom_respond_to_task",
+                "mcp__axiom-sdk__axiom_get_activity_log"
         );
         return new ActionTypeValidator.KnownNames(secrets, tools, toolsets, sdkTools);
     }

--- a/app/src/main/java/io/apitomy/axiom/app/rest/ActionResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/ActionResourceImpl.java
@@ -15,6 +15,7 @@ import io.apitomy.axiom.app.ActionTypeAiService;
 import io.apitomy.axiom.app.ScriptAiService;
 import io.apitomy.axiom.api.beans.ToolValidationResult;
 import io.apitomy.axiom.api.beans.ToolValidationMessage;
+import io.apitomy.axiom.core.SdkToolNames;
 import io.apitomy.axiom.core.entities.ActionTypeEntity;
 import io.apitomy.axiom.core.entities.SecretEntity;
 import io.apitomy.axiom.core.entities.ToolDefinitionEntity;
@@ -192,30 +193,7 @@ public class ActionResourceImpl implements ActionResource {
         Set<String> toolsets = ToolsetEntity.<ToolsetEntity>listAll().stream()
                 .map(t -> t.name)
                 .collect(java.util.stream.Collectors.toSet());
-        Set<String> sdkTools = Set.of(
-                "mcp__axiom-sdk__axiom_fire_event",
-                "mcp__axiom-sdk__axiom_list_projects",
-                "mcp__axiom-sdk__axiom_get_project",
-                "mcp__axiom-sdk__axiom_create_task",
-                "mcp__axiom-sdk__axiom_get_task_status",
-                "mcp__axiom-sdk__axiom_add_thread_entry",
-                "mcp__axiom-sdk__axiom_close_project",
-                "mcp__axiom-sdk__axiom_reopen_project",
-                "mcp__axiom-sdk__axiom_add_project_label",
-                "mcp__axiom-sdk__axiom_remove_project_label",
-                "mcp__axiom-sdk__axiom_add_report_label",
-                "mcp__axiom-sdk__axiom_remove_report_label",
-                "mcp__axiom-sdk__axiom_list_tools",
-                "mcp__axiom-sdk__axiom_list_report_definitions",
-                "mcp__axiom-sdk__axiom_list_reports",
-                "mcp__axiom-sdk__axiom_get_project_thread",
-                "mcp__axiom-sdk__axiom_list_action_types",
-                "mcp__axiom-sdk__axiom_list_actors",
-                "mcp__axiom-sdk__axiom_update_project",
-                "mcp__axiom-sdk__axiom_list_events",
-                "mcp__axiom-sdk__axiom_respond_to_task",
-                "mcp__axiom-sdk__axiom_get_activity_log"
-        );
+        Set<String> sdkTools = SdkToolNames.ALL;
         return new ActionTypeValidator.KnownNames(secrets, tools, toolsets, sdkTools);
     }
 

--- a/app/src/main/java/io/apitomy/axiom/app/rest/ReportsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/ReportsResourceImpl.java
@@ -15,6 +15,7 @@ import io.apitomy.axiom.api.beans.Environment;
 import io.apitomy.axiom.app.ReportAiService;
 import io.apitomy.axiom.app.ReportQueueConsumer;
 import io.apitomy.axiom.app.ReportScheduler;
+import io.apitomy.axiom.core.SdkToolNames;
 import io.apitomy.axiom.core.entities.ReportDefinitionEntity;
 import io.apitomy.axiom.core.entities.ReportEntity;
 import io.apitomy.axiom.core.entities.SecretEntity;
@@ -322,20 +323,7 @@ public class ReportsResourceImpl implements ReportsResource {
         Set<String> toolsets = ToolsetEntity.<ToolsetEntity>listAll().stream()
                 .map(t -> t.name)
                 .collect(java.util.stream.Collectors.toSet());
-        Set<String> sdkTools = Set.of(
-                "mcp__axiom-sdk__axiom_fire_event",
-                "mcp__axiom-sdk__axiom_list_projects",
-                "mcp__axiom-sdk__axiom_get_project",
-                "mcp__axiom-sdk__axiom_create_task",
-                "mcp__axiom-sdk__axiom_get_task_status",
-                "mcp__axiom-sdk__axiom_add_thread_entry",
-                "mcp__axiom-sdk__axiom_close_project",
-                "mcp__axiom-sdk__axiom_reopen_project",
-                "mcp__axiom-sdk__axiom_add_project_label",
-                "mcp__axiom-sdk__axiom_remove_project_label",
-                "mcp__axiom-sdk__axiom_list_tools",
-                "mcp__axiom-sdk__axiom_list_report_definitions"
-        );
+        Set<String> sdkTools = SdkToolNames.ALL;
         return new ReportDefinitionValidator.KnownNames(secrets, tools, toolsets, sdkTools);
     }
 

--- a/app/src/main/java/io/apitomy/axiom/app/rest/ScheduledJobsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/ScheduledJobsResourceImpl.java
@@ -296,8 +296,18 @@ public class ScheduledJobsResourceImpl implements ScheduledResource {
                 "mcp__axiom-sdk__axiom_reopen_project",
                 "mcp__axiom-sdk__axiom_add_project_label",
                 "mcp__axiom-sdk__axiom_remove_project_label",
+                "mcp__axiom-sdk__axiom_add_report_label",
+                "mcp__axiom-sdk__axiom_remove_report_label",
                 "mcp__axiom-sdk__axiom_list_tools",
-                "mcp__axiom-sdk__axiom_list_report_definitions"
+                "mcp__axiom-sdk__axiom_list_report_definitions",
+                "mcp__axiom-sdk__axiom_list_reports",
+                "mcp__axiom-sdk__axiom_get_project_thread",
+                "mcp__axiom-sdk__axiom_list_action_types",
+                "mcp__axiom-sdk__axiom_list_actors",
+                "mcp__axiom-sdk__axiom_update_project",
+                "mcp__axiom-sdk__axiom_list_events",
+                "mcp__axiom-sdk__axiom_respond_to_task",
+                "mcp__axiom-sdk__axiom_get_activity_log"
         );
         return new ScheduledJobValidator.KnownNames(secrets, tools, toolsets, sdkTools);
     }

--- a/app/src/main/java/io/apitomy/axiom/app/rest/ScheduledJobsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/ScheduledJobsResourceImpl.java
@@ -10,6 +10,7 @@ import io.apitomy.axiom.api.beans.ToolValidationMessage;
 import io.apitomy.axiom.api.beans.ToolValidationResult;
 import io.apitomy.axiom.app.ScheduledJobQueueConsumer;
 import io.apitomy.axiom.app.ScheduledJobScheduler;
+import io.apitomy.axiom.core.SdkToolNames;
 import io.apitomy.axiom.core.entities.ScheduledJobEntity;
 import io.apitomy.axiom.core.entities.ScheduledJobRunEntity;
 import io.apitomy.axiom.core.entities.SecretEntity;
@@ -285,30 +286,7 @@ public class ScheduledJobsResourceImpl implements ScheduledResource {
         Set<String> toolsets = ToolsetEntity.<ToolsetEntity>listAll().stream()
                 .map(t -> t.name)
                 .collect(java.util.stream.Collectors.toSet());
-        Set<String> sdkTools = Set.of(
-                "mcp__axiom-sdk__axiom_fire_event",
-                "mcp__axiom-sdk__axiom_list_projects",
-                "mcp__axiom-sdk__axiom_get_project",
-                "mcp__axiom-sdk__axiom_create_task",
-                "mcp__axiom-sdk__axiom_get_task_status",
-                "mcp__axiom-sdk__axiom_add_thread_entry",
-                "mcp__axiom-sdk__axiom_close_project",
-                "mcp__axiom-sdk__axiom_reopen_project",
-                "mcp__axiom-sdk__axiom_add_project_label",
-                "mcp__axiom-sdk__axiom_remove_project_label",
-                "mcp__axiom-sdk__axiom_add_report_label",
-                "mcp__axiom-sdk__axiom_remove_report_label",
-                "mcp__axiom-sdk__axiom_list_tools",
-                "mcp__axiom-sdk__axiom_list_report_definitions",
-                "mcp__axiom-sdk__axiom_list_reports",
-                "mcp__axiom-sdk__axiom_get_project_thread",
-                "mcp__axiom-sdk__axiom_list_action_types",
-                "mcp__axiom-sdk__axiom_list_actors",
-                "mcp__axiom-sdk__axiom_update_project",
-                "mcp__axiom-sdk__axiom_list_events",
-                "mcp__axiom-sdk__axiom_respond_to_task",
-                "mcp__axiom-sdk__axiom_get_activity_log"
-        );
+        Set<String> sdkTools = SdkToolNames.ALL;
         return new ScheduledJobValidator.KnownNames(secrets, tools, toolsets, sdkTools);
     }
 

--- a/core/src/main/java/io/apitomy/axiom/core/SdkToolNames.java
+++ b/core/src/main/java/io/apitomy/axiom/core/SdkToolNames.java
@@ -1,0 +1,45 @@
+package io.apitomy.axiom.core;
+
+import java.util.Set;
+
+/**
+ * Canonical set of all SDK tool names exposed by the Axiom MCP SDK server.
+ * This must stay in sync with the SDK_TOOLS array in sdk-server.js.
+ */
+public final class SdkToolNames {
+
+    private static final String PREFIX = "mcp__axiom-sdk__";
+
+    /** All SDK tool names, fully qualified with the MCP server prefix. */
+    public static final Set<String> ALL = Set.of(
+            PREFIX + "axiom_fire_event",
+            PREFIX + "axiom_list_projects",
+            PREFIX + "axiom_get_project",
+            PREFIX + "axiom_create_task",
+            PREFIX + "axiom_get_task_status",
+            PREFIX + "axiom_add_thread_entry",
+            PREFIX + "axiom_close_project",
+            PREFIX + "axiom_reopen_project",
+            PREFIX + "axiom_add_project_label",
+            PREFIX + "axiom_remove_project_label",
+            PREFIX + "axiom_add_report_label",
+            PREFIX + "axiom_remove_report_label",
+            PREFIX + "axiom_list_tools",
+            PREFIX + "axiom_list_report_definitions",
+            PREFIX + "axiom_list_reports",
+            PREFIX + "axiom_get_project_thread",
+            PREFIX + "axiom_list_action_types",
+            PREFIX + "axiom_list_actors",
+            PREFIX + "axiom_update_project",
+            PREFIX + "axiom_list_events",
+            PREFIX + "axiom_respond_to_task",
+            PREFIX + "axiom_get_activity_log",
+            PREFIX + "axiom_update_project_body"
+    );
+
+    /** All SDK tool names as a comma-separated string. */
+    public static final String ALL_CSV = String.join(",", ALL);
+
+    private SdkToolNames() {
+    }
+}

--- a/ui/src/components/AddToolInput.tsx
+++ b/ui/src/components/AddToolInput.tsx
@@ -8,6 +8,7 @@ import {
 } from "../config/api";
 import { TypeaheadAddInput, type TypeaheadAddSuggestion } from "./TypeaheadAddInput";
 import { BrowseToolsModal } from "./BrowseToolsModal";
+import { SDK_TOOL_VALUES } from "../config/sdkTools";
 
 /**
  * Well-known Claude Code built-in tools available for autocomplete.
@@ -44,23 +45,6 @@ const BUILTIN_TOOLS = [
     "Bash(mkdir *)",
     "Bash(cp *)",
     "Bash(mv *)",
-];
-
-const AXIOM_SDK_TOOLS = [
-    "mcp__axiom-sdk__axiom_fire_event",
-    "mcp__axiom-sdk__axiom_list_projects",
-    "mcp__axiom-sdk__axiom_get_project",
-    "mcp__axiom-sdk__axiom_create_task",
-    "mcp__axiom-sdk__axiom_get_task_status",
-    "mcp__axiom-sdk__axiom_add_thread_entry",
-    "mcp__axiom-sdk__axiom_close_project",
-    "mcp__axiom-sdk__axiom_reopen_project",
-    "mcp__axiom-sdk__axiom_add_project_label",
-    "mcp__axiom-sdk__axiom_remove_project_label",
-    "mcp__axiom-sdk__axiom_list_tools",
-    "mcp__axiom-sdk__axiom_list_report_definitions",
-    "mcp__axiom-sdk__axiom_update_project",
-    "mcp__axiom-sdk__axiom_update_project_body",
 ];
 
 const TOOLSET_STYLE: React.CSSProperties = {
@@ -117,7 +101,7 @@ export function AddToolInput({
         customTools.forEach((t) =>
             items.push({ value: `mcp__axiom-tools__${t.name}`, style: MCP_STYLE }));
 
-        AXIOM_SDK_TOOLS.forEach((t) =>
+        SDK_TOOL_VALUES.forEach((t) =>
             items.push({ value: t, style: MCP_STYLE }));
 
         mcpServers.forEach((s) =>

--- a/ui/src/components/BrowseToolsModal.tsx
+++ b/ui/src/components/BrowseToolsModal.tsx
@@ -16,6 +16,7 @@ import {
     type Toolset,
     type ToolDefinition,
 } from "../config/api";
+import { SDK_TOOLS as SDK_TOOL_ENTRIES } from "../config/sdkTools";
 
 interface ToolEntry {
     value: string;
@@ -24,22 +25,7 @@ interface ToolEntry {
     category: "toolset" | "custom" | "sdk";
 }
 
-const SDK_TOOLS: ToolEntry[] = [
-    { value: "mcp__axiom-sdk__axiom_fire_event", label: "axiom_fire_event", description: "Fire a new event into Axiom for processing by the Manager", category: "sdk" },
-    { value: "mcp__axiom-sdk__axiom_list_projects", label: "axiom_list_projects", description: "List existing Axiom projects with optional filtering", category: "sdk" },
-    { value: "mcp__axiom-sdk__axiom_get_project", label: "axiom_get_project", description: "Get details of a specific Axiom project", category: "sdk" },
-    { value: "mcp__axiom-sdk__axiom_create_task", label: "axiom_create_task", description: "Create a new task on an Axiom project", category: "sdk" },
-    { value: "mcp__axiom-sdk__axiom_get_task_status", label: "axiom_get_task_status", description: "Get the status and details of a specific task", category: "sdk" },
-    { value: "mcp__axiom-sdk__axiom_add_thread_entry", label: "axiom_add_thread_entry", description: "Post an update or message to a project's conversation thread", category: "sdk" },
-    { value: "mcp__axiom-sdk__axiom_close_project", label: "axiom_close_project", description: "Close (complete) an Axiom project", category: "sdk" },
-    { value: "mcp__axiom-sdk__axiom_reopen_project", label: "axiom_reopen_project", description: "Reopen a previously closed Axiom project", category: "sdk" },
-    { value: "mcp__axiom-sdk__axiom_add_project_label", label: "axiom_add_project_label", description: "Add a label to an Axiom project", category: "sdk" },
-    { value: "mcp__axiom-sdk__axiom_remove_project_label", label: "axiom_remove_project_label", description: "Remove a label from an Axiom project", category: "sdk" },
-    { value: "mcp__axiom-sdk__axiom_list_tools", label: "axiom_list_tools", description: "List all custom tool definitions configured in Axiom", category: "sdk" },
-    { value: "mcp__axiom-sdk__axiom_list_report_definitions", label: "axiom_list_report_definitions", description: "List all report definitions configured in Axiom", category: "sdk" },
-    { value: "mcp__axiom-sdk__axiom_update_project", label: "axiom_update_project", description: "Update an Axiom project's metadata such as name, body, or labels", category: "sdk" },
-    { value: "mcp__axiom-sdk__axiom_update_project_body", label: "axiom_update_project_body", description: "Update an Axiom project's body with markdown content", category: "sdk" },
-];
+const SDK_TOOLS: ToolEntry[] = SDK_TOOL_ENTRIES.map(t => ({ ...t, category: "sdk" as const }));
 
 interface BrowseToolsModalProps {
     isOpen: boolean;

--- a/ui/src/config/sdkTools.ts
+++ b/ui/src/config/sdkTools.ts
@@ -1,0 +1,40 @@
+const PREFIX = "mcp__axiom-sdk__";
+
+interface SdkToolEntry {
+    value: string;
+    label: string;
+    description: string;
+}
+
+/**
+ * Canonical list of all SDK tools exposed by the Axiom MCP SDK server.
+ * Must stay in sync with the SDK_TOOLS array in sdk-server.js.
+ */
+export const SDK_TOOLS: SdkToolEntry[] = [
+    { value: PREFIX + "axiom_fire_event", label: "axiom_fire_event", description: "Fire a new event into Axiom for processing by the Manager" },
+    { value: PREFIX + "axiom_list_projects", label: "axiom_list_projects", description: "List existing Axiom projects with optional filtering" },
+    { value: PREFIX + "axiom_get_project", label: "axiom_get_project", description: "Get details of a specific Axiom project" },
+    { value: PREFIX + "axiom_create_task", label: "axiom_create_task", description: "Create a new task on an Axiom project" },
+    { value: PREFIX + "axiom_get_task_status", label: "axiom_get_task_status", description: "Get the status and details of a specific task" },
+    { value: PREFIX + "axiom_add_thread_entry", label: "axiom_add_thread_entry", description: "Post an update or message to a project's conversation thread" },
+    { value: PREFIX + "axiom_close_project", label: "axiom_close_project", description: "Close (complete) an Axiom project" },
+    { value: PREFIX + "axiom_reopen_project", label: "axiom_reopen_project", description: "Reopen a previously closed Axiom project" },
+    { value: PREFIX + "axiom_add_project_label", label: "axiom_add_project_label", description: "Add a label to an Axiom project" },
+    { value: PREFIX + "axiom_remove_project_label", label: "axiom_remove_project_label", description: "Remove a label from an Axiom project" },
+    { value: PREFIX + "axiom_add_report_label", label: "axiom_add_report_label", description: "Add a label to a generated Axiom report" },
+    { value: PREFIX + "axiom_remove_report_label", label: "axiom_remove_report_label", description: "Remove a label from a generated Axiom report" },
+    { value: PREFIX + "axiom_list_tools", label: "axiom_list_tools", description: "List all custom tool definitions configured in Axiom" },
+    { value: PREFIX + "axiom_list_report_definitions", label: "axiom_list_report_definitions", description: "List all report definitions configured in Axiom" },
+    { value: PREFIX + "axiom_list_reports", label: "axiom_list_reports", description: "List generated reports with optional filtering" },
+    { value: PREFIX + "axiom_get_project_thread", label: "axiom_get_project_thread", description: "Read the conversation thread for a project" },
+    { value: PREFIX + "axiom_list_action_types", label: "axiom_list_action_types", description: "List all action types configured in Axiom" },
+    { value: PREFIX + "axiom_list_actors", label: "axiom_list_actors", description: "List all actors configured in Axiom" },
+    { value: PREFIX + "axiom_update_project", label: "axiom_update_project", description: "Update an Axiom project's metadata" },
+    { value: PREFIX + "axiom_list_events", label: "axiom_list_events", description: "List events related to an Axiom project" },
+    { value: PREFIX + "axiom_respond_to_task", label: "axiom_respond_to_task", description: "Submit a response to a task awaiting human input" },
+    { value: PREFIX + "axiom_get_activity_log", label: "axiom_get_activity_log", description: "Get the global activity log" },
+    { value: PREFIX + "axiom_update_project_body", label: "axiom_update_project_body", description: "Update an Axiom project's body with markdown content" },
+];
+
+/** All SDK tool qualified names (value strings). */
+export const SDK_TOOL_VALUES: string[] = SDK_TOOLS.map(t => t.value);


### PR DESCRIPTION
## Summary

The `sdkTools` set in both `ActionResourceImpl` and `ScheduledJobsResourceImpl` only listed 12 of the 22 tools actually implemented in `sdk-server.js`. This caused the remaining 10 tools to be rejected as "not recognized" when users tried to add them to allowed tools lists.

## Changes

Added the following 10 missing tools to the `sdkTools` set in **both** `ActionResourceImpl.getKnownNames()` and `ScheduledJobsResourceImpl.getKnownNames()`:

- `axiom_list_reports`
- `axiom_update_project`
- `axiom_list_events`
- `axiom_respond_to_task`
- `axiom_get_activity_log`
- `axiom_list_action_types`
- `axiom_list_actors`
- `axiom_add_report_label`
- `axiom_remove_report_label`
- `axiom_get_project_thread`

Both validator sets now contain all 22 SDK tools, matching `sdk-server.js` exactly.

## Files Modified

- `app/src/main/java/io/apitomy/axiom/app/rest/ActionResourceImpl.java`
- `app/src/main/java/io/apitomy/axiom/app/rest/ScheduledJobsResourceImpl.java`

Fixes #195