### PR TITLE
feat: Add Events tab to Event Source detail page

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/rest/EventsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/EventsResourceImpl.java
@@ -44,7 +44,7 @@ public class EventsResourceImpl implements EventsResource {
     public EventSearchResults listEvents(BigInteger page, BigInteger limit,
                                           String filterSource, String filterEventType,
                                           String filterRepository, String filterLabels,
-                                          String filterFilterStatus) {
+                                          String filterFilterStatus, BigInteger filterEventSourceId) {
         int pageNum = page != null ? page.intValue() : 1;
         int pageSize = limit != null ? limit.intValue() : 20;
 
@@ -75,6 +75,10 @@ public class EventsResourceImpl implements EventsResource {
         if (filterFilterStatus != null && !filterFilterStatus.isBlank()) {
             hql.append(" and filterStatus = :filterStatus");
             params.put("filterStatus", filterFilterStatus);
+        }
+        if (filterEventSourceId != null) {
+            hql.append(" and eventSourceId = :eventSourceId");
+            params.put("eventSourceId", filterEventSourceId.longValue());
         }
 
         long totalCount = EventEntity.count(hql.toString(), params);

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -1871,6 +1871,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "filterEventSourceId",
+            "in": "query",
+            "description": "Filter by event source ID",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
           }
         ],
         "responses": {

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -1255,7 +1255,7 @@ export async function fetchProjectEvents(projectId: number): Promise<AxiomEvent[
 export async function fetchEvents(
     page = 1, limit = 20,
     filterSource?: string, filterEventType?: string, filterRepository?: string,
-    filterLabels?: string, filterFilterStatus?: string
+    filterLabels?: string, filterFilterStatus?: string, filterEventSourceId?: number
 ): Promise<SearchResults<AxiomEvent>> {
     const params = new URLSearchParams();
     params.set("page", String(page));
@@ -1265,6 +1265,7 @@ export async function fetchEvents(
     if (filterRepository) params.set("filterRepository", filterRepository);
     if (filterLabels) params.set("filterLabels", filterLabels);
     if (filterFilterStatus) params.set("filterFilterStatus", filterFilterStatus);
+    if (filterEventSourceId != null) params.set("filterEventSourceId", String(filterEventSourceId));
     const response = await fetch(`${API}/events?${params}`);
     if (!response.ok) throw new Error(`Failed to fetch events: ${response.status}`);
     return response.json();

--- a/ui/src/pages/EventSourceDetailPage.tsx
+++ b/ui/src/pages/EventSourceDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
-import { useParams, Link } from "react-router-dom";
+import { useParams, Link, useNavigate } from "react-router-dom";
 import {
     Breadcrumb,
     BreadcrumbItem,
@@ -55,13 +55,16 @@ import {
     type FilterDryRunRequest,
     type FilterDryRunResponse,
     type FilterDryRunResult,
+    type AxiomEvent,
     type Secret,
     fetchEventSource,
     updateEventSource,
     fetchEventSourceLogs,
+    fetchEvents,
     fetchSecrets,
     dryRunFilters,
 } from "../config/api";
+import { EventDetailModal } from "../components/EventDetailModal";
 
 export function EventSourceDetailPage() {
     const { eventSourceId } = useParams<{ eventSourceId: string }>();
@@ -204,10 +207,16 @@ export function EventSourceDetailPage() {
                         )}
                     </TabContent>
                 </Tab>
-                <Tab eventKey={2} title={<TabTitleText>
+                <Tab eventKey={2} title={<TabTitleText>Events</TabTitleText>}>
+                    <TabContent id="events-tab" eventKey={2} activeKey={activeTab}
+                        style={{ marginTop: "24px" }}>
+                        <EventsTab eventSourceId={id} isActive={activeTab === 2} />
+                    </TabContent>
+                </Tab>
+                <Tab eventKey={3} title={<TabTitleText>
                     Poll Logs{logs.length > 0 ? ` (${logs.length})` : ""}
                 </TabTitleText>}>
-                    <TabContent id="logs-tab" eventKey={2} activeKey={activeTab}
+                    <TabContent id="logs-tab" eventKey={3} activeKey={activeTab}
                         style={{ marginTop: "24px" }}>
                         <LogsTab logs={logs} totalCount={logsTotalCount}
                             page={logsPage} perPage={logsPerPage}
@@ -290,6 +299,156 @@ function InfoTab({ form, updateForm, sourceUrl, setSourceUrl, secrets, labels, o
                 <HelperText><HelperTextItem>Select a secret for API authentication. Falls back to the default provider secret if not set.</HelperTextItem></HelperText>
             </FormGroup>
         </Form>
+    );
+}
+
+const SOURCE_COLORS: Record<string, "blue" | "green" | "orange" | "grey"> = {
+    github: "blue",
+    jira: "green",
+    internal: "orange",
+};
+
+const FILTER_STATUS_COLORS: Record<string, "green" | "red" | "grey"> = {
+    allowed: "green",
+    blocked: "red",
+};
+
+function EventsTab({ eventSourceId, isActive }: {
+    eventSourceId: number;
+    isActive: boolean;
+}) {
+    const navigate = useNavigate();
+    const [events, setEvents] = useState<AxiomEvent[]>([]);
+    const [totalCount, setTotalCount] = useState(0);
+    const [page, setPage] = useState(1);
+    const [perPage, setPerPage] = useState(20);
+    const [loading, setLoading] = useState(false);
+    const [selectedEvent, setSelectedEvent] = useState<AxiomEvent | null>(null);
+    const loadedRef = useRef(false);
+
+    const loadEvents = useCallback((p?: number, pp?: number) => {
+        const pg = p ?? page;
+        const sz = pp ?? perPage;
+        setLoading(true);
+        fetchEvents(pg, sz, undefined, undefined, undefined, undefined, undefined, eventSourceId)
+            .then((results) => {
+                setEvents(results.items);
+                setTotalCount(results.totalCount);
+            })
+            .catch(console.error)
+            .finally(() => setLoading(false));
+    }, [eventSourceId, page, perPage]);
+
+    useEffect(() => {
+        if (isActive && !loadedRef.current) {
+            loadedRef.current = true;
+            loadEvents();
+        }
+    }, [isActive, loadEvents]);
+
+    return (
+        <div>
+            <Flex justifyContent={{ default: "justifyContentSpaceBetween" }}
+                alignItems={{ default: "alignItemsCenter" }}
+                style={{ marginBottom: "16px" }}>
+                <FlexItem>
+                    <p className="axiom-text-subtle">
+                        Events fired by this event source. Click a row to view details.
+                    </p>
+                </FlexItem>
+                <FlexItem>
+                    <Button variant="plain" aria-label="Refresh" onClick={() => loadEvents()}>
+                        <SyncAltIcon />
+                    </Button>
+                </FlexItem>
+            </Flex>
+
+            {loading ? (
+                <EmptyState>
+                    <EmptyStateBody>Loading events...</EmptyStateBody>
+                </EmptyState>
+            ) : events.length === 0 ? (
+                <EmptyState>
+                    <EmptyStateBody>No events recorded for this source yet.</EmptyStateBody>
+                </EmptyState>
+            ) : (
+                <>
+                    <Table aria-label="Events" variant="compact">
+                        <Thead>
+                            <Tr>
+                                <Th>Time</Th>
+                                <Th>Source</Th>
+                                <Th>Filter</Th>
+                                <Th>Event Type</Th>
+                                <Th>Repository</Th>
+                                <Th>Issue</Th>
+                                <Th>Project</Th>
+                                <Th>Trace</Th>
+                            </Tr>
+                        </Thead>
+                        <Tbody>
+                            {events.map((event) => (
+                                <Tr key={event.id} isClickable
+                                    onRowClick={() => setSelectedEvent(event)}>
+                                    <Td style={{ whiteSpace: "nowrap" }}>
+                                        {new Date(event.receivedAt).toLocaleString()}
+                                    </Td>
+                                    <Td>
+                                        <Label isCompact
+                                            color={SOURCE_COLORS[event.source] || "grey"}>
+                                            {event.source}
+                                        </Label>
+                                    </Td>
+                                    <Td>
+                                        {event.filterStatus ? (
+                                            <Label isCompact
+                                                color={FILTER_STATUS_COLORS[event.filterStatus] || "grey"}>
+                                                {event.filterStatus}
+                                            </Label>
+                                        ) : (
+                                            <Label isCompact color="grey">—</Label>
+                                        )}
+                                    </Td>
+                                    <Td>{event.eventType}</Td>
+                                    <Td>{event.repository || "—"}</Td>
+                                    <Td>{event.issueRef || "—"}</Td>
+                                    <Td>
+                                        {event.projectId
+                                            ? `Project #${event.projectId}`
+                                            : "—"}
+                                    </Td>
+                                    <Td>
+                                        {event.traceId ? (
+                                            <Button variant="link" isInline
+                                                onClick={(e) => {
+                                                    e.stopPropagation();
+                                                    navigate(`/logs/traces/${event.traceId}`);
+                                                }}>
+                                                View Trace
+                                            </Button>
+                                        ) : "—"}
+                                    </Td>
+                                </Tr>
+                            ))}
+                        </Tbody>
+                    </Table>
+                    <Pagination
+                        itemCount={totalCount}
+                        page={page}
+                        perPage={perPage}
+                        onSetPage={(_e, p) => { setPage(p); loadEvents(p); }}
+                        onPerPageSelect={(_e, pp) => { setPerPage(pp); setPage(1); loadEvents(1, pp); }}
+                        variant="bottom"
+                        style={{ marginTop: "8px" }}
+                    />
+                </>
+            )}
+
+            <EventDetailModal
+                event={selectedEvent}
+                onClose={() => setSelectedEvent(null)}
+            />
+        </div>
     );
 }
 


### PR DESCRIPTION
## Summary

Adds an **Events** tab to the Event Source detail page that lists all events fired by that specific event source. This gives users a quick way to see the event history for a single source without navigating to the global Events log and manually filtering.

Fixes #189

## Changes

### Backend
- **`openapi.json`** — Added `filterEventSourceId` query parameter (integer) to the `GET /events` endpoint
- **`EventsResourceImpl.java`** — Added `filterEventSourceId` parameter to `listEvents` and implemented the filtering logic (`eventSourceId = :eventSourceId`)

### Frontend
- **`api.ts`** — Added optional `filterEventSourceId` parameter to the `fetchEvents` function
- **`EventSourceDetailPage.tsx`** — Added a new **Events** tab (between Filters and Poll Logs) with:
  - Paginated table showing: Time, Source, Filter Status, Event Type, Repository, Issue, Project, and Trace
  - Clickable rows that open the existing `EventDetailModal`
  - Lazy loading (events are fetched when the tab is first activated)
  - Refresh button and pagination controls
  - Empty state when no events exist

## Files Modified
- `common/api/src/main/resources/openapi.json`
- `app/src/main/java/io/apitomy/axiom/app/rest/EventsResourceImpl.java`
- `ui/src/config/api.ts`
- `ui/src/pages/EventSourceDetailPage.tsx`