### PR TITLE
Add project lookup by ref to SDK tools

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/rest/ProjectsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/ProjectsResourceImpl.java
@@ -83,7 +83,7 @@ public class ProjectsResourceImpl implements ProjectsResource {
     @Override
     public ProjectSearchResults listProjects(BigInteger page, BigInteger limit,
                                               String filterName, String filterStatus,
-                                              String filterLabels) {
+                                              String filterLabels, String filterRef) {
         int pageNum = page != null ? page.intValue() : 1;
         int pageSize = limit != null ? limit.intValue() : 20;
 
@@ -108,6 +108,10 @@ public class ProjectsResourceImpl implements ProjectsResource {
                     + " GROUP BY p.id HAVING COUNT(DISTINCT pl) = :labelCount)");
             params.put("labels", labels);
             params.put("labelCount", (long) labels.size());
+        }
+        if (filterRef != null && !filterRef.isBlank()) {
+            hql.append(" and issueRef = :ref");
+            params.put("ref", filterRef);
         }
 
         long totalCount = ProjectEntity.count(hql.toString(), params);

--- a/app/src/main/resources/templates/axiom-mcp-server/sdk-server.js
+++ b/app/src/main/resources/templates/axiom-mcp-server/sdk-server.js
@@ -54,11 +54,12 @@ const SDK_TOOLS = [
     },
     {
         name: "axiom_list_projects",
-        description: "List existing Axiom projects with optional filtering by name, status, and labels.",
+        description: "List existing Axiom projects with optional filtering by name, status, labels, and ref.",
         parameters: [
             { name: "filterName", type: "string", description: "Filter by project name or issue ref (substring match)", required: false },
             { name: "filterStatus", type: "string", description: "Filter by status: Created, InProgress, Idle, Completed (comma-separated for multiple)", required: false },
             { name: "filterLabels", type: "string", description: "Filter by labels (comma-separated, AND logic)", required: false },
+            { name: "filterRef", type: "string", description: "Exact-match filter on the project issue reference (e.g. 'owner/repo#42')", required: false },
         ],
         handler: async (args) => {
             const params = new URLSearchParams();
@@ -66,6 +67,7 @@ const SDK_TOOLS = [
             if (args.filterName) params.set("filterName", args.filterName);
             if (args.filterStatus) params.set("filterStatus", args.filterStatus);
             if (args.filterLabels) params.set("filterLabels", args.filterLabels);
+            if (args.filterRef) params.set("filterRef", args.filterRef);
             return await axiomApi("GET", `/projects?${params}`);
         },
     },

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -218,6 +218,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "filterRef",
+            "in": "query",
+            "description": "Exact-match filter on the project issue reference (e.g. 'owner/repo#42')",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {


### PR DESCRIPTION
## Summary

Adds a `filterRef` query parameter to the `GET /api/v1/projects` endpoint for exact-match lookup on the project's issue reference (`issueRef`). This allows scheduled jobs and action types to check whether a project already exists for a given identifier (e.g. a CVE ID) before creating a new one.

Fixes #194

## Changes

### OpenAPI spec (`common/api/src/main/resources/openapi.json`)
- Added `filterRef` query parameter (optional, string) to the `listProjects` operation

### REST implementation (`ProjectsResourceImpl.java`)
- Added `filterRef` parameter to the `listProjects` method signature
- Added exact-match HQL filter clause: `issueRef = :ref`

### SDK server (`sdk-server.js`)
- Added `filterRef` parameter to the `axiom_list_projects` tool definition
- Updated handler to pass `filterRef` through to the REST API
- Updated tool description to mention the new filter option

## Use case

A scheduled job that queries a CVE tracking system can now call:
```
axiom_list_projects({ filterRef: "owner/repo#CVE-2026-1234" })
```
to check if a project already exists for that reference before creating a new one.