### PR TITLE
Replace project description with markdown body field

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/PipelineOrchestrator.java
+++ b/app/src/main/java/io/apitomy/axiom/app/PipelineOrchestrator.java
@@ -535,6 +535,7 @@ public class PipelineOrchestrator {
     private ProjectEntity createProjectFromEvent(EventEntity event) {
         ProjectEntity project = new ProjectEntity();
         project.name = extractIssueTitle(event);
+        project.body = extractIssueBody(event);
         project.type = determineProjectType(event.eventType);
         project.status = ProjectStatus.Created.name();
         project.issueSource = event.source;
@@ -613,6 +614,29 @@ public class PipelineOrchestrator {
             }
         }
         return event.issueRef != null ? event.issueRef : "Project from event " + event.id;
+    }
+
+    /**
+     * Extracts the issue/PR body from the event payload. Returns {@code null}
+     * if the body cannot be found.
+     */
+    private String extractIssueBody(EventEntity event) {
+        if (event.payload != null) {
+            try {
+                JsonNode root = objectMapper.readTree(event.payload);
+                String body = root.path("issue").path("body").asText(null);
+                if (body != null && !body.isBlank()) {
+                    return body;
+                }
+                body = root.path("pull_request").path("body").asText(null);
+                if (body != null && !body.isBlank()) {
+                    return body;
+                }
+            } catch (Exception e) {
+                LOG.debugf("Could not parse event payload for issue body: %s", e.getMessage());
+            }
+        }
+        return null;
     }
 
     private void logActivity(Long projectId, Long taskId, Long eventId,

--- a/app/src/main/java/io/apitomy/axiom/app/TaskExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/TaskExecutionService.java
@@ -328,8 +328,8 @@ public class TaskExecutionService {
         sb.append("You are working on project: ").append(project.name).append("\n");
         sb.append("Issue: ").append(project.issueRef).append("\n");
         sb.append("Action type: ").append(task.actionType).append("\n");
-        if (project.description != null) {
-            sb.append("Project description: ").append(project.description).append("\n");
+        if (project.body != null) {
+            sb.append("Project description: ").append(project.body).append("\n");
         }
         return sb.toString();
     }

--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSessionManager.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSessionManager.java
@@ -522,8 +522,8 @@ public class AssistantSessionManager {
         context.append("\n\n## Project Context\n\n");
         context.append("This session is scoped to the following project:\n\n");
         context.append("- **Name**: ").append(project.name).append("\n");
-        if (project.description != null && !project.description.isBlank()) {
-            context.append("- **Description**: ").append(project.description).append("\n");
+        if (project.body != null && !project.body.isBlank()) {
+            context.append("- **Description**: ").append(project.body).append("\n");
         }
         context.append("- **Type**: ").append(project.type).append("\n");
         context.append("- **Status**: ").append(project.status).append("\n");

--- a/app/src/main/java/io/apitomy/axiom/app/rest/ProjectsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/ProjectsResourceImpl.java
@@ -135,7 +135,7 @@ public class ProjectsResourceImpl implements ProjectsResource {
     public Project createProject(NewProject data) {
         ProjectEntity entity = new ProjectEntity();
         entity.name = data.getName();
-        entity.description = data.getDescription();
+        entity.body = data.getBody();
         entity.type = data.getType().value();
         entity.status = ProjectStatus.Created.name();
         entity.issueSource = data.getIssueSource().value();
@@ -165,8 +165,8 @@ public class ProjectsResourceImpl implements ProjectsResource {
         if (data.getName() != null) {
             entity.name = data.getName();
         }
-        if (data.getDescription() != null) {
-            entity.description = data.getDescription();
+        if (data.getBody() != null) {
+            entity.body = data.getBody();
         }
         if (data.getType() != null) {
             entity.type = data.getType().value();
@@ -225,6 +225,17 @@ public class ProjectsResourceImpl implements ProjectsResource {
         entity.status = "InProgress";
         entity.updatedOn = Instant.now();
         return toProjectBean(entity);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Transactional
+    public void updateProjectBody(long projectId, String body) {
+        ProjectEntity entity = findProjectOrThrow(projectId);
+        entity.body = body;
+        entity.updatedOn = Instant.now();
     }
 
     // ── Tasks ─────────────────────────────────────────────────────────
@@ -496,7 +507,7 @@ public class ProjectsResourceImpl implements ProjectsResource {
         Project project = new Project();
         project.setId(entity.id);
         project.setName(entity.name);
-        project.setDescription(entity.description);
+        project.setBody(entity.body);
         project.setType(Project.Type.fromValue(entity.type));
         project.setStatus(Project.Status.fromValue(entity.status));
         project.setIssueSource(Project.IssueSource.fromValue(entity.issueSource));

--- a/app/src/main/resources/db/migration/V40__rename_description_to_body.sql
+++ b/app/src/main/resources/db/migration/V40__rename_description_to_body.sql
@@ -1,0 +1,1 @@
+ALTER TABLE project RENAME COLUMN description TO body;

--- a/app/src/main/resources/templates/axiom-mcp-server/sdk-server.js
+++ b/app/src/main/resources/templates/axiom-mcp-server/sdk-server.js
@@ -16,13 +16,13 @@ function log(level, message, data) {
 
 const AXIOM_API_URL = process.env.AXIOM_API_URL || "http://localhost:9090/api/v1";
 
-async function axiomApi(method, path, body) {
+async function axiomApi(method, path, body, { contentType = "application/json", rawBody = false } = {}) {
     const url = `${AXIOM_API_URL}${path}`;
     const opts = {
         method,
-        headers: { "Content-Type": "application/json", "Accept": "application/json" },
+        headers: { "Content-Type": contentType, "Accept": "application/json" },
     };
-    if (body) opts.body = JSON.stringify(body);
+    if (body) opts.body = rawBody ? body : JSON.stringify(body);
     const resp = await fetch(url, opts);
     const text = await resp.text();
     if (!resp.ok) {
@@ -299,16 +299,9 @@ const SDK_TOOLS = [
             { name: "body", type: "string", description: "The markdown body content", required: true },
         ],
         handler: async (args) => {
-            const url = `${AXIOM_API_URL}/projects/${args.projectId}/body`;
-            const resp = await fetch(url, {
-                method: "PUT",
-                headers: { "Content-Type": "text/markdown" },
-                body: args.body,
+            await axiomApi("PUT", `/projects/${args.projectId}/body`, args.body, {
+                contentType: "text/markdown", rawBody: true,
             });
-            if (!resp.ok) {
-                const text = await resp.text();
-                throw new Error(`Axiom API PUT /projects/${args.projectId}/body returned ${resp.status}: ${text.substring(0, 500)}`);
-            }
             return "OK";
         },
     },

--- a/app/src/main/resources/templates/axiom-mcp-server/sdk-server.js
+++ b/app/src/main/resources/templates/axiom-mcp-server/sdk-server.js
@@ -276,19 +276,40 @@ const SDK_TOOLS = [
     },
     {
         name: "axiom_update_project",
-        description: "Update an Axiom project's metadata such as name, description, or labels.",
+        description: "Update an Axiom project's metadata such as name, body, or labels.",
         parameters: [
             { name: "projectId", type: "number", description: "The project ID to update", required: true },
             { name: "name", type: "string", description: "New project name", required: false },
-            { name: "description", type: "string", description: "New project description", required: false },
+            { name: "body", type: "string", description: "New project body (markdown)", required: false },
             { name: "labels", type: "string", description: "Comma-separated list of labels to set on the project", required: false },
         ],
         handler: async (args) => {
-            const body = {};
-            if (args.name) body.name = args.name;
-            if (args.description) body.description = args.description;
-            if (args.labels) body.labels = args.labels.split(",").map(l => l.trim()).filter(Boolean);
-            return await axiomApi("PUT", `/projects/${args.projectId}`, body);
+            const payload = {};
+            if (args.name) payload.name = args.name;
+            if (args.body) payload.body = args.body;
+            if (args.labels) payload.labels = args.labels.split(",").map(l => l.trim()).filter(Boolean);
+            return await axiomApi("PUT", `/projects/${args.projectId}`, payload);
+        },
+    },
+    {
+        name: "axiom_update_project_body",
+        description: "Update an Axiom project's body with markdown content.",
+        parameters: [
+            { name: "projectId", type: "number", description: "The project ID", required: true },
+            { name: "body", type: "string", description: "The markdown body content", required: true },
+        ],
+        handler: async (args) => {
+            const url = `${AXIOM_API_URL}/projects/${args.projectId}/body`;
+            const resp = await fetch(url, {
+                method: "PUT",
+                headers: { "Content-Type": "text/markdown" },
+                body: args.body,
+            });
+            if (!resp.ok) {
+                const text = await resp.text();
+                throw new Error(`Axiom API PUT /projects/${args.projectId}/body returned ${resp.status}: ${text.substring(0, 500)}`);
+            }
+            return "OK";
         },
     },
     {

--- a/app/src/test/java/io/apitomy/axiom/app/ProjectsResourceTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/ProjectsResourceTest.java
@@ -121,6 +121,37 @@ class ProjectsResourceTest {
                 .statusCode(404);
     }
 
+    @Test
+    void testUpdateProjectBody() {
+        int id = createProject("Body Test", "feature", "owner/repo#150");
+
+        given()
+            .contentType("text/markdown")
+            .body("# Hello\n\nThis is **markdown** body content.")
+            .when()
+                .put(PROJECTS_PATH + "/" + id + "/body")
+            .then()
+                .statusCode(204);
+
+        given()
+            .when()
+                .get(PROJECTS_PATH + "/" + id)
+            .then()
+                .statusCode(200)
+                .body("body", equalTo("# Hello\n\nThis is **markdown** body content."));
+    }
+
+    @Test
+    void testUpdateProjectBodyNotFound() {
+        given()
+            .contentType("text/markdown")
+            .body("some content")
+            .when()
+                .put(PROJECTS_PATH + "/999999/body")
+            .then()
+                .statusCode(404);
+    }
+
     // ── Project Lifecycle ─────────────────────────────────────────────
 
     @Test

--- a/app/src/test/java/io/apitomy/axiom/app/ProjectsResourceTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/ProjectsResourceTest.java
@@ -38,7 +38,7 @@ class ProjectsResourceTest {
             .body("""
                 {
                     "name": "Test Project",
-                    "description": "A test project",
+                    "body": "A test project",
                     "type": "bug-fix",
                     "issueSource": "github",
                     "issueRef": "owner/repo#1",
@@ -50,7 +50,7 @@ class ProjectsResourceTest {
             .then()
                 .statusCode(200)
                 .body("name", equalTo("Test Project"))
-                .body("description", equalTo("A test project"))
+                .body("body", equalTo("A test project"))
                 .body("type", equalTo("bug-fix"))
                 .body("status", equalTo("Created"))
                 .body("issueSource", equalTo("github"))
@@ -79,7 +79,7 @@ class ProjectsResourceTest {
             .body("""
                 {
                     "name": "Updated Name",
-                    "description": "Updated description"
+                    "body": "Updated description"
                 }
                 """)
             .when()
@@ -87,7 +87,7 @@ class ProjectsResourceTest {
             .then()
                 .statusCode(200)
                 .body("name", equalTo("Updated Name"))
-                .body("description", equalTo("Updated description"))
+                .body("body", equalTo("Updated description"))
                 .body("type", equalTo("feature"));
     }
 

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -397,6 +397,39 @@
         }
       ]
     },
+    "/projects/{projectId}/body": {
+      "put": {
+        "tags": [
+          "Projects"
+        ],
+        "summary": "Update a project's body",
+        "description": "Replaces the project body with the supplied markdown content.",
+        "operationId": "updateProjectBody",
+        "requestBody": {
+          "content": {
+            "text/markdown": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Body updated"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/ProjectId"
+        }
+      ]
+    },
     "/projects/{projectId}/tasks": {
       "get": {
         "tags": [
@@ -5024,7 +5057,8 @@
           "name": {
             "type": "string"
           },
-          "description": {
+          "body": {
+            "description": "Markdown content (e.g. issue body)",
             "type": "string"
           },
           "type": {
@@ -5097,7 +5131,8 @@
           "name": {
             "type": "string"
           },
-          "description": {
+          "body": {
+            "description": "Markdown content (e.g. issue body)",
             "type": "string"
           },
           "type": {
@@ -5139,7 +5174,8 @@
           "name": {
             "type": "string"
           },
-          "description": {
+          "body": {
+            "description": "Markdown content (e.g. issue body)",
             "type": "string"
           },
           "type": {

--- a/core/src/main/java/io/apitomy/axiom/core/entities/ProjectEntity.java
+++ b/core/src/main/java/io/apitomy/axiom/core/entities/ProjectEntity.java
@@ -24,7 +24,7 @@ public class ProjectEntity extends PanacheEntity {
     public String name;
 
     @Column(columnDefinition = "TEXT")
-    public String description;
+    public String body;
 
     @Column(nullable = false)
     public String type;

--- a/ui/src/components/AddToolInput.tsx
+++ b/ui/src/components/AddToolInput.tsx
@@ -59,6 +59,8 @@ const AXIOM_SDK_TOOLS = [
     "mcp__axiom-sdk__axiom_remove_project_label",
     "mcp__axiom-sdk__axiom_list_tools",
     "mcp__axiom-sdk__axiom_list_report_definitions",
+    "mcp__axiom-sdk__axiom_update_project",
+    "mcp__axiom-sdk__axiom_update_project_body",
 ];
 
 const TOOLSET_STYLE: React.CSSProperties = {

--- a/ui/src/components/BrowseToolsModal.tsx
+++ b/ui/src/components/BrowseToolsModal.tsx
@@ -37,6 +37,8 @@ const SDK_TOOLS: ToolEntry[] = [
     { value: "mcp__axiom-sdk__axiom_remove_project_label", label: "axiom_remove_project_label", description: "Remove a label from an Axiom project", category: "sdk" },
     { value: "mcp__axiom-sdk__axiom_list_tools", label: "axiom_list_tools", description: "List all custom tool definitions configured in Axiom", category: "sdk" },
     { value: "mcp__axiom-sdk__axiom_list_report_definitions", label: "axiom_list_report_definitions", description: "List all report definitions configured in Axiom", category: "sdk" },
+    { value: "mcp__axiom-sdk__axiom_update_project", label: "axiom_update_project", description: "Update an Axiom project's metadata such as name, body, or labels", category: "sdk" },
+    { value: "mcp__axiom-sdk__axiom_update_project_body", label: "axiom_update_project_body", description: "Update an Axiom project's body with markdown content", category: "sdk" },
 ];
 
 interface BrowseToolsModalProps {

--- a/ui/src/components/dashboards/widgets/ProjectSpotlightWidget.tsx
+++ b/ui/src/components/dashboards/widgets/ProjectSpotlightWidget.tsx
@@ -46,10 +46,10 @@ function ProjectSpotlightWidget({ config }: WidgetProps) {
                     <Label isCompact>{project.issueRef}</Label>
                 </FlexItem>
             </Flex>
-            {project.description && (
+            {project.body && (
                 <p style={{ marginTop: "8px", fontSize: "0.9em",
                             color: "var(--pf-t--global--color--200)" }}>
-                    {project.description}
+                    {project.body}
                 </p>
             )}
             <div style={{ marginTop: "12px" }}>

--- a/ui/src/components/dashboards/widgets/ProjectSpotlightWidget.tsx
+++ b/ui/src/components/dashboards/widgets/ProjectSpotlightWidget.tsx
@@ -4,6 +4,19 @@ import { type Project, type Task, fetchProject, fetchProjectTasks } from "../../
 import { registerWidget, type WidgetProps } from "../widget-registry";
 import { WidgetError } from "../WidgetError";
 
+function stripMarkdown(md: string): string {
+    const plain = md
+        .replace(/^#{1,6}\s+/gm, "")
+        .replace(/\*\*(.+?)\*\*/g, "$1")
+        .replace(/\*(.+?)\*/g, "$1")
+        .replace(/`(.+?)`/g, "$1")
+        .replace(/\[(.+?)\]\(.+?\)/g, "$1")
+        .replace(/^[-*+]\s+/gm, "")
+        .replace(/\n+/g, " ")
+        .trim();
+    return plain.length > 150 ? plain.slice(0, 147) + "..." : plain;
+}
+
 function ProjectSpotlightWidget({ config }: WidgetProps) {
     const [project, setProject] = useState<Project | null>(null);
     const [tasks, setTasks] = useState<Task[]>([]);
@@ -49,7 +62,7 @@ function ProjectSpotlightWidget({ config }: WidgetProps) {
             {project.body && (
                 <p style={{ marginTop: "8px", fontSize: "0.9em",
                             color: "var(--pf-t--global--color--200)" }}>
-                    {project.body}
+                    {stripMarkdown(project.body)}
                 </p>
             )}
             <div style={{ marginTop: "12px" }}>

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -46,7 +46,7 @@ export interface SearchResults<T> {
 export interface Project {
     id: number;
     name: string;
-    description?: string;
+    body?: string;
     type: string;
     status: string;
     issueSource: string;
@@ -60,7 +60,7 @@ export interface Project {
 
 export interface NewProject {
     name: string;
-    description?: string;
+    body?: string;
     type: string;
     issueSource: string;
     issueRef: string;
@@ -249,6 +249,15 @@ export async function createProject(project: NewProject): Promise<Project> {
 export async function deleteProject(id: number): Promise<void> {
     const response = await fetch(`${API}/projects/${id}`, { method: "DELETE" });
     if (!response.ok) throw new Error(`Failed to delete project: ${response.status}`);
+}
+
+export async function updateProjectBody(id: number, body: string): Promise<void> {
+    const response = await fetch(`${API}/projects/${id}/body`, {
+        method: "PUT",
+        headers: { "Content-Type": "text/markdown" },
+        body,
+    });
+    if (!response.ok) throw new Error(`Failed to update project body: ${response.status}`);
 }
 
 // ── Tasks ─────────────────────────────────────────────────────────

--- a/ui/src/pages/ProjectDetailPage.tsx
+++ b/ui/src/pages/ProjectDetailPage.tsx
@@ -105,6 +105,7 @@ export function ProjectDetailPage() {
     // Body edit state
     const [isEditingBody, setIsEditingBody] = useState(false);
     const [editBody, setEditBody] = useState("");
+    const [bodySaveError, setBodySaveError] = useState("");
 
     // Trigger Action state
     const [isActionModalOpen, setIsActionModalOpen] = useState(false);
@@ -324,63 +325,73 @@ export function ProjectDetailPage() {
             </DescriptionList>
 
             {/* Body */}
-            {(project.body || isEditingBody) && (
-                <Card isCompact style={{ marginTop: "16px" }}>
-                    <CardBody>
-                        <Flex justifyContent={{ default: "justifyContentSpaceBetween" }}
-                            alignItems={{ default: "alignItemsCenter" }}
-                            style={{ marginBottom: "8px" }}>
-                            <FlexItem>
-                                <Title headingLevel="h3" size="md">Body</Title>
-                            </FlexItem>
-                            <FlexItem>
-                                {isEditingBody ? (
-                                    <>
-                                        <Button variant="plain" aria-label="Save body"
-                                            onClick={() => {
-                                                updateProjectBody(id, editBody)
-                                                    .then(() => {
-                                                        setProject({ ...project, body: editBody });
-                                                        setIsEditingBody(false);
-                                                    })
-                                                    .catch(console.error);
-                                            }}>
-                                            <CheckIcon />
-                                        </Button>
-                                        <Button variant="plain" aria-label="Cancel edit"
-                                            onClick={() => setIsEditingBody(false)}>
-                                            <TimesIcon />
-                                        </Button>
-                                    </>
-                                ) : (
-                                    <Button variant="plain" aria-label="Edit body"
+            <Card isCompact style={{ marginTop: "16px" }}>
+                <CardBody>
+                    <Flex justifyContent={{ default: "justifyContentSpaceBetween" }}
+                        alignItems={{ default: "alignItemsCenter" }}
+                        style={{ marginBottom: "8px" }}>
+                        <FlexItem>
+                            <Title headingLevel="h3" size="md">Body</Title>
+                        </FlexItem>
+                        <FlexItem>
+                            {isEditingBody ? (
+                                <>
+                                    <Button variant="plain" aria-label="Save body"
                                         onClick={() => {
-                                            setEditBody(project.body || "");
-                                            setIsEditingBody(true);
+                                            setBodySaveError("");
+                                            updateProjectBody(id, editBody)
+                                                .then(() => {
+                                                    setProject({ ...project, body: editBody });
+                                                    setIsEditingBody(false);
+                                                })
+                                                .catch((err) => {
+                                                    setBodySaveError(err.message || "Failed to save body");
+                                                });
                                         }}>
-                                        <PencilAltIcon />
+                                        <CheckIcon />
                                     </Button>
-                                )}
-                            </FlexItem>
-                        </Flex>
-                        {isEditingBody ? (
-                            <TextArea
-                                id="project-body-edit"
-                                value={editBody}
-                                onChange={(_e, v) => setEditBody(v)}
-                                rows={12}
-                                style={{ fontFamily: "var(--pf-t--global--font--family--mono)" }}
-                            />
-                        ) : (
-                            <Content>
-                                <Markdown remarkPlugins={[remarkGfm]} components={markdownMermaidComponents}>
-                                    {project.body || ""}
-                                </Markdown>
-                            </Content>
-                        )}
-                    </CardBody>
-                </Card>
-            )}
+                                    <Button variant="plain" aria-label="Cancel edit"
+                                        onClick={() => { setIsEditingBody(false); setBodySaveError(""); }}>
+                                        <TimesIcon />
+                                    </Button>
+                                </>
+                            ) : (
+                                <Button variant="plain" aria-label="Edit body"
+                                    onClick={() => {
+                                        setEditBody(project.body || "");
+                                        setIsEditingBody(true);
+                                    }}>
+                                    <PencilAltIcon />
+                                </Button>
+                            )}
+                        </FlexItem>
+                    </Flex>
+                    {bodySaveError && (
+                        <p style={{ color: "var(--pf-t--global--color--status--danger--default)", marginBottom: "8px" }}>
+                            {bodySaveError}
+                        </p>
+                    )}
+                    {isEditingBody ? (
+                        <TextArea
+                            id="project-body-edit"
+                            value={editBody}
+                            onChange={(_e, v) => setEditBody(v)}
+                            rows={12}
+                            style={{ fontFamily: "var(--pf-t--global--font--family--mono)" }}
+                        />
+                    ) : project.body ? (
+                        <Content>
+                            <Markdown remarkPlugins={[remarkGfm]} components={markdownMermaidComponents}>
+                                {project.body}
+                            </Markdown>
+                        </Content>
+                    ) : (
+                        <p className="axiom-text-subtle" style={{ fontStyle: "italic" }}>
+                            No body content. Click the edit button to add markdown content.
+                        </p>
+                    )}
+                </CardBody>
+            </Card>
 
             {/* Tabs */}
             <div style={{ marginTop: "24px" }}>

--- a/ui/src/pages/ProjectDetailPage.tsx
+++ b/ui/src/pages/ProjectDetailPage.tsx
@@ -42,6 +42,9 @@ import ChatIcon from "@patternfly/react-icons/dist/esm/icons/chat-icon";
 import PlayIcon from "@patternfly/react-icons/dist/esm/icons/play-icon";
 import SyncAltIcon from "@patternfly/react-icons/dist/esm/icons/sync-alt-icon";
 import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
+import PencilAltIcon from "@patternfly/react-icons/dist/esm/icons/pencil-alt-icon";
+import CheckIcon from "@patternfly/react-icons/dist/esm/icons/check-icon";
+import TimesIcon from "@patternfly/react-icons/dist/esm/icons/times-icon";
 import CodeBranchIcon from "@patternfly/react-icons/dist/esm/icons/code-branch-icon";
 import BugIcon from "@patternfly/react-icons/dist/esm/icons/bug-icon";
 import GithubIcon from "@patternfly/react-icons/dist/esm/icons/github-icon";
@@ -63,6 +66,7 @@ import {
     createTask,
     deleteProject,
     updateProject,
+    updateProjectBody,
     formatBytes,
     respondToTask,
 } from "../config/api";
@@ -97,6 +101,10 @@ export function ProjectDetailPage() {
 
     const [isDeleteOpen, setIsDeleteOpen] = useState(false);
     const [isLabelsOpen, setIsLabelsOpen] = useState(false);
+
+    // Body edit state
+    const [isEditingBody, setIsEditingBody] = useState(false);
+    const [editBody, setEditBody] = useState("");
 
     // Trigger Action state
     const [isActionModalOpen, setIsActionModalOpen] = useState(false);
@@ -306,14 +314,6 @@ export function ProjectDetailPage() {
                         </code>
                     </DescriptionListDescription>
                 </DescriptionListGroup>
-                {project.description && (
-                    <DescriptionListGroup>
-                        <DescriptionListTerm>Description</DescriptionListTerm>
-                        <DescriptionListDescription>
-                            {project.description}
-                        </DescriptionListDescription>
-                    </DescriptionListGroup>
-                )}
                 <DescriptionListGroup>
                     <DescriptionListTerm>Labels</DescriptionListTerm>
                     <DescriptionListDescription>
@@ -322,6 +322,65 @@ export function ProjectDetailPage() {
                     </DescriptionListDescription>
                 </DescriptionListGroup>
             </DescriptionList>
+
+            {/* Body */}
+            {(project.body || isEditingBody) && (
+                <Card isCompact style={{ marginTop: "16px" }}>
+                    <CardBody>
+                        <Flex justifyContent={{ default: "justifyContentSpaceBetween" }}
+                            alignItems={{ default: "alignItemsCenter" }}
+                            style={{ marginBottom: "8px" }}>
+                            <FlexItem>
+                                <Title headingLevel="h3" size="md">Body</Title>
+                            </FlexItem>
+                            <FlexItem>
+                                {isEditingBody ? (
+                                    <>
+                                        <Button variant="plain" aria-label="Save body"
+                                            onClick={() => {
+                                                updateProjectBody(id, editBody)
+                                                    .then(() => {
+                                                        setProject({ ...project, body: editBody });
+                                                        setIsEditingBody(false);
+                                                    })
+                                                    .catch(console.error);
+                                            }}>
+                                            <CheckIcon />
+                                        </Button>
+                                        <Button variant="plain" aria-label="Cancel edit"
+                                            onClick={() => setIsEditingBody(false)}>
+                                            <TimesIcon />
+                                        </Button>
+                                    </>
+                                ) : (
+                                    <Button variant="plain" aria-label="Edit body"
+                                        onClick={() => {
+                                            setEditBody(project.body || "");
+                                            setIsEditingBody(true);
+                                        }}>
+                                        <PencilAltIcon />
+                                    </Button>
+                                )}
+                            </FlexItem>
+                        </Flex>
+                        {isEditingBody ? (
+                            <TextArea
+                                id="project-body-edit"
+                                value={editBody}
+                                onChange={(_e, v) => setEditBody(v)}
+                                rows={12}
+                                style={{ fontFamily: "var(--pf-t--global--font--family--mono)" }}
+                            />
+                        ) : (
+                            <Content>
+                                <Markdown remarkPlugins={[remarkGfm]} components={markdownMermaidComponents}>
+                                    {project.body || ""}
+                                </Markdown>
+                            </Content>
+                        )}
+                    </CardBody>
+                </Card>
+            )}
 
             {/* Tabs */}
             <div style={{ marginTop: "24px" }}>

--- a/ui/src/pages/ProjectsPage.tsx
+++ b/ui/src/pages/ProjectsPage.tsx
@@ -349,14 +349,14 @@ export function ProjectsPage() {
                                 }
                             />
                         </FormGroup>
-                        <FormGroup label="Description" fieldId="description">
+                        <FormGroup label="Body" fieldId="body">
                             <TextArea
-                                id="description"
-                                value={newProject.description || ""}
+                                id="body"
+                                value={newProject.body || ""}
                                 onChange={(_e, v) =>
                                     setNewProject({
                                         ...newProject,
-                                        description: v,
+                                        body: v,
                                     })
                                 }
                             />


### PR DESCRIPTION
## Summary

Replaces the `description` field on Projects with a `body` field that holds markdown content.

Fixes #190

## Changes

### Database Migration
- Added Flyway migration `V40__rename_description_to_body.sql` to rename the `description` column to `body` in the `project` table

### OpenAPI Spec
- Renamed `description` property to `body` on `Project`, `NewProject`, and `UpdateProject` schemas
- Added new `PUT /projects/{projectId}/body` endpoint with `text/markdown` content type (returns 204)

### Backend
- **ProjectEntity.java** — renamed `description` field to `body`
- **ProjectsResourceImpl.java** — updated `createProject()`, `updateProject()`, and `toProjectBean()` to use `body` instead of `description`; added `updateProjectBody()` endpoint implementation
- **PipelineOrchestrator.java** — added `extractIssueBody()` method (mirrors `extractIssueTitle()` pattern) and wired it into `createProjectFromEvent()` to auto-populate the body from GitHub issue/PR payloads

### UI
- **api.ts** — updated `Project` and `NewProject` interfaces (`description` → `body`); added `updateProjectBody()` API function
- **ProjectDetailPage.tsx** — removed inline description from DescriptionList; added a Body card with markdown viewer (using existing `react-markdown` + `remarkGfm`) and an edit toggle that switches to a monospace TextArea, saving via the new `updateProjectBody()` endpoint
- **ProjectsPage.tsx** — renamed create modal form group from "Description" to "Body" and updated field bindings

### SDK MCP Server
- **sdk-server.js** — renamed `description` parameter to `body` on `axiom_update_project` tool; added new `axiom_update_project_body` tool that calls `PUT /projects/{projectId}/body` with `text/markdown` content type

### UI Tool Lists
- **BrowseToolsModal.tsx** — added `axiom_update_project` and `axiom_update_project_body` to the SDK_TOOLS list
- **AddToolInput.tsx** — added both tools to the AXIOM_SDK_TOOLS array

### Tests
- **ProjectsResourceTest.java** — updated test JSON bodies and assertions to use `body` instead of `description`