### PR TITLE
Improve AI Assistant feedback during subagent execution (#198)

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantEventParser.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantEventParser.java
@@ -21,8 +21,14 @@ import java.util.List;
  * <h3>Event type mapping</h3>
  * <ul>
  *   <li>{@code system} (subtype init) → {@code session_init}</li>
+ *   <li>{@code system} (subtype task_started) → {@code subagent_started}</li>
+ *   <li>{@code system} (subtype task_progress) → {@code subagent_progress}</li>
+ *   <li>{@code system} (subtype task_updated) → {@code subagent_status}</li>
+ *   <li>{@code system} (subtype task_notification) → {@code subagent_completed}</li>
  *   <li>{@code assistant} → {@code assistant_text}, {@code tool_use}, {@code thinking}</li>
+ *   <li>{@code assistant} with non-null {@code parent_tool_use_id} → suppressed</li>
  *   <li>{@code user} (with tool_use_result) → {@code tool_result}</li>
+ *   <li>{@code user} with non-null {@code parent_tool_use_id} → suppressed</li>
  *   <li>{@code result} → {@code turn_complete}</li>
  *   <li>{@code sdk_control_request} / {@code control_request} → {@code permission_request}</li>
  *   <li>{@code conversation_reset} → {@code conversation_reset}</li>
@@ -73,27 +79,76 @@ public class AssistantEventParser {
         }
     }
 
+    /**
+     * Parses system events: session init and subagent lifecycle.
+     *
+     * @param root the raw NDJSON node
+     * @return normalised SSE events for the frontend
+     */
     private List<SseEvent> parseSystem(JsonNode root) {
         String subtype = root.path("subtype").asText("");
-        if (!"init".equals(subtype)) {
-            return Collections.emptyList();
-        }
-        ObjectNode data = JsonNodeFactory.instance.objectNode();
-        data.put("sessionId", root.path("session_id").asText());
-        data.put("cwd", root.path("cwd").asText());
-        data.put("model", root.path("model").asText());
-        JsonNode slashCommands = root.path("slash_commands");
-        if (slashCommands.isArray()) {
-            data.set("slashCommands", slashCommands);
-        }
-        JsonNode tools = root.path("tools");
-        if (tools.isArray()) {
-            data.set("tools", tools);
-        }
-        return List.of(new SseEvent("session_init", data));
+        return switch (subtype) {
+            case "init" -> {
+                ObjectNode data = JsonNodeFactory.instance.objectNode();
+                data.put("sessionId", root.path("session_id").asText());
+                data.put("cwd", root.path("cwd").asText());
+                data.put("model", root.path("model").asText());
+                JsonNode slashCommands = root.path("slash_commands");
+                if (slashCommands.isArray()) {
+                    data.set("slashCommands", slashCommands);
+                }
+                JsonNode tools = root.path("tools");
+                if (tools.isArray()) {
+                    data.set("tools", tools);
+                }
+                yield List.of(new SseEvent("session_init", data));
+            }
+            case "task_started" -> {
+                ObjectNode data = JsonNodeFactory.instance.objectNode();
+                data.put("toolUseId", root.path("tool_use_id").asText());
+                data.put("taskId", root.path("task_id").asText());
+                data.put("description", root.path("description").asText());
+                data.put("subagentType", root.path("subagent_type").asText());
+                yield List.of(new SseEvent("subagent_started", data));
+            }
+            case "task_progress" -> {
+                ObjectNode data = JsonNodeFactory.instance.objectNode();
+                data.put("toolUseId", root.path("tool_use_id").asText());
+                data.put("taskId", root.path("task_id").asText());
+                data.put("description", root.path("description").asText());
+                data.put("lastToolName", root.path("last_tool_name").asText());
+                JsonNode usage = root.path("usage");
+                data.put("toolCount", usage.path("tool_uses").asInt(0));
+                data.put("durationMs", usage.path("duration_ms").asLong(0));
+                yield List.of(new SseEvent("subagent_progress", data));
+            }
+            case "task_updated" -> {
+                String status = root.path("patch").path("status").asText("");
+                if (status.isEmpty()) {
+                    yield Collections.emptyList();
+                }
+                ObjectNode data = JsonNodeFactory.instance.objectNode();
+                data.put("taskId", root.path("task_id").asText());
+                data.put("status", status);
+                yield List.of(new SseEvent("subagent_status", data));
+            }
+            case "task_notification" -> {
+                ObjectNode data = JsonNodeFactory.instance.objectNode();
+                data.put("toolUseId", root.path("tool_use_id").asText());
+                data.put("taskId", root.path("task_id").asText());
+                data.put("status", root.path("status").asText());
+                data.put("summary", root.path("summary").asText());
+                yield List.of(new SseEvent("subagent_completed", data));
+            }
+            default -> Collections.emptyList();
+        };
     }
 
     private List<SseEvent> parseAssistant(JsonNode root) {
+        String parentToolUseId = root.path("parent_tool_use_id").asText("");
+        if (!parentToolUseId.isEmpty()) {
+            return Collections.emptyList();
+        }
         JsonNode content = root.path("message").path("content");
         if (!content.isArray()) {
             return Collections.emptyList();
@@ -124,6 +179,10 @@ public class AssistantEventParser {
     }
 
     private List<SseEvent> parseUser(JsonNode root) {
+        String parentToolUseId = root.path("parent_tool_use_id").asText("");
+        if (!parentToolUseId.isEmpty()) {
+            return Collections.emptyList();
+        }
         JsonNode toolResult = root.path("tool_use_result");
         if (toolResult.isMissingNode()) {
             return Collections.emptyList();
@@ -224,7 +283,9 @@ public class AssistantEventParser {
      *
      * @param type the normalised event type (session_init, assistant_text,
      *             tool_use, tool_result, tool_progress, turn_complete,
-     *             permission_request, thinking, conversation_reset)
+     *             permission_request, thinking, conversation_reset,
+     *             subagent_started, subagent_progress, subagent_status,
+     *             subagent_completed)
      * @param data the extracted/transformed JSON data
      */
     public record SseEvent(String type, JsonNode data) {

--- a/app/src/test/java/io/apitomy/axiom/app/assistant/AssistantEventParserTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/assistant/AssistantEventParserTest.java
@@ -231,6 +231,122 @@ class AssistantEventParserTest {
         assertTrue(events.isEmpty());
     }
 
+    // ── Subagent lifecycle events ─────────────────────────────────────
+
+    @Test
+    void parseSystemTaskStartedEvent() {
+        String line = """
+                {"type":"system","subtype":"task_started","task_id":"task-1",\
+                "tool_use_id":"tu-agent-1","description":"Explore codebase",\
+                "subagent_type":"Explore","task_type":"local_agent"}""";
+
+        List<SseEvent> events = parser.parse(line);
+
+        assertEquals(1, events.size());
+        SseEvent event = events.get(0);
+        assertEquals("subagent_started", event.type());
+        assertEquals("tu-agent-1", event.data().path("toolUseId").asText());
+        assertEquals("task-1", event.data().path("taskId").asText());
+        assertEquals("Explore codebase", event.data().path("description").asText());
+        assertEquals("Explore", event.data().path("subagentType").asText());
+    }
+
+    @Test
+    void parseSystemTaskProgressEvent() {
+        String line = """
+                {"type":"system","subtype":"task_progress","task_id":"task-1",\
+                "tool_use_id":"tu-agent-1","description":"Reading src/Main.java",\
+                "subagent_type":"Explore","last_tool_name":"Read",\
+                "usage":{"total_tokens":15000,"tool_uses":5,"duration_ms":8000}}""";
+
+        List<SseEvent> events = parser.parse(line);
+
+        assertEquals(1, events.size());
+        SseEvent event = events.get(0);
+        assertEquals("subagent_progress", event.type());
+        assertEquals("tu-agent-1", event.data().path("toolUseId").asText());
+        assertEquals("Reading src/Main.java", event.data().path("description").asText());
+        assertEquals("Read", event.data().path("lastToolName").asText());
+        assertEquals(5, event.data().path("toolCount").asInt());
+        assertEquals(8000, event.data().path("durationMs").asLong());
+    }
+
+    @Test
+    void parseSystemTaskUpdatedCompletedEvent() {
+        String line = """
+                {"type":"system","subtype":"task_updated","task_id":"task-1",\
+                "patch":{"status":"completed","end_time":1700000000000}}""";
+
+        List<SseEvent> events = parser.parse(line);
+
+        assertEquals(1, events.size());
+        SseEvent event = events.get(0);
+        assertEquals("subagent_status", event.type());
+        assertEquals("task-1", event.data().path("taskId").asText());
+        assertEquals("completed", event.data().path("status").asText());
+    }
+
+    @Test
+    void parseSystemTaskUpdatedNoStatusIsIgnored() {
+        String line = """
+                {"type":"system","subtype":"task_updated","task_id":"task-1","patch":{}}""";
+
+        List<SseEvent> events = parser.parse(line);
+        assertTrue(events.isEmpty());
+    }
+
+    @Test
+    void parseSystemTaskNotificationEvent() {
+        String line = """
+                {"type":"system","subtype":"task_notification","task_id":"task-1",\
+                "tool_use_id":"tu-agent-1","status":"completed",\
+                "summary":"Found 5 relevant files."}""";
+
+        List<SseEvent> events = parser.parse(line);
+
+        assertEquals(1, events.size());
+        SseEvent event = events.get(0);
+        assertEquals("subagent_completed", event.type());
+        assertEquals("tu-agent-1", event.data().path("toolUseId").asText());
+        assertEquals("completed", event.data().path("status").asText());
+        assertEquals("Found 5 relevant files.", event.data().path("summary").asText());
+    }
+
+    // ── Subagent event suppression ────────────────────────────────────
+
+    @Test
+    void parseAssistantWithParentToolUseIdIsIgnored() {
+        String line = """
+                {"type":"assistant","parent_tool_use_id":"tu-agent-1",\
+                "message":{"content":[{"type":"tool_use","id":"tu-sub-1",\
+                "name":"Read","input":{"file_path":"src/Main.java"}}]}}""";
+
+        List<SseEvent> events = parser.parse(line);
+        assertTrue(events.isEmpty());
+    }
+
+    @Test
+    void parseAssistantWithNullParentToolUseIdIsProcessed() {
+        String line = """
+                {"type":"assistant","parent_tool_use_id":null,\
+                "message":{"content":[{"type":"text","text":"Hello"}]}}""";
+
+        List<SseEvent> events = parser.parse(line);
+        assertEquals(1, events.size());
+        assertEquals("assistant_text", events.get(0).type());
+    }
+
+    @Test
+    void parseUserWithParentToolUseIdIsIgnored() {
+        String line = """
+                {"type":"user","parent_tool_use_id":"tu-agent-1",\
+                "message":{"content":[{"type":"tool_result",\
+                "tool_use_id":"tu-sub-1","content":"result"}]}}""";
+
+        List<SseEvent> events = parser.parse(line);
+        assertTrue(events.isEmpty());
+    }
+
     // ── Unknown types ───────────────────────────────────────────────
 
     @Test

--- a/docs/superpowers/plans/2026-08-14-project-body-field.md
+++ b/docs/superpowers/plans/2026-08-14-project-body-field.md
@@ -1,0 +1,565 @@
+# Project Body Field Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the `description` field on Projects with a `body` field (markdown content) that
+auto-populates from the linked GitHub issue/PR body and can be edited via UI, REST API, and SDK
+tools.
+
+**Architecture:** API-first: update OpenAPI spec, regenerate beans via `mvn install`, then implement
+the backend changes (entity, REST resource, pipeline orchestrator), then UI and SDK. A dedicated
+`PUT /projects/{projectId}/body` endpoint with `text/markdown` content type makes it easy for
+callers to set large markdown content without JSON wrapping.
+
+**Tech Stack:** Java 25 / Quarkus 3.33, React 19 / PatternFly 6, Flyway, Jackson, Node.js MCP
+server
+
+**Spec:** Bounded design approved in conversation (no spec file for bounded tasks)
+
+## Global Constraints
+
+- API-first: all REST API changes start in `common/api/src/main/resources/openapi.json`
+- Run `mvn install` (or `build.sh`) after OpenAPI changes to regenerate JAX-RS interfaces and beans
+- REST impl classes must implement the generated interface — no `@Path` annotations on impl classes
+- Use generated beans from `io.apitomy.axiom.api.beans` for request/response types
+- Do NOT run tests or builds — the user handles compilation and testing
+
+---
+
+### Task 1: Database Migration and OpenAPI Spec
+
+**Files:**
+- Create: `app/src/main/resources/db/migration/V39__rename_description_to_body.sql`
+- Modify: `common/api/src/main/resources/openapi.json`
+
+**Interfaces:**
+- Consumes: nothing
+- Produces: Updated OpenAPI spec with `body` field on `Project`, `NewProject`, `UpdateProject`
+  schemas and new `PUT /projects/{projectId}/body` endpoint. Generated beans will have `getBody()`
+  / `setBody()` after `mvn install`.
+
+- [ ] **Step 1: Create the Flyway migration**
+
+Create `app/src/main/resources/db/migration/V39__rename_description_to_body.sql`:
+
+```sql
+ALTER TABLE project RENAME COLUMN description TO body;
+```
+
+- [ ] **Step 2: Update the OpenAPI spec — rename `description` to `body` on all three schemas**
+
+In `common/api/src/main/resources/openapi.json`, replace the `"description"` property with `"body"`
+in the following three schemas:
+
+**`Project` schema** (~line 4982): Change `"description": { "type": "string" }` to
+`"body": { "type": "string" }`.
+
+**`NewProject` schema** (~line 5055): Change `"description": { "type": "string" }` to
+`"body": { "type": "string" }`.
+
+**`UpdateProject` schema** (~line 5098): Change `"description": { "type": "string" }` to
+`"body": { "type": "string" }`.
+
+- [ ] **Step 3: Add the dedicated body endpoint to the OpenAPI spec**
+
+Add a new path entry in the `paths` section, after the `/projects/{projectId}/reopen` block
+(~line 386). Insert the following path:
+
+```json
+"/projects/{projectId}/body": {
+  "put": {
+    "tags": ["Projects"],
+    "summary": "Update a project's body",
+    "description": "Sets the project body (markdown content).",
+    "operationId": "updateProjectBody",
+    "requestBody": {
+      "content": {
+        "text/markdown": {
+          "schema": {
+            "type": "string"
+          }
+        }
+      },
+      "required": true
+    },
+    "responses": {
+      "204": {
+        "description": "Body updated"
+      },
+      "404": {
+        "$ref": "#/components/responses/NotFound"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "$ref": "#/components/parameters/ProjectId"
+    }
+  ]
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/resources/db/migration/V39__rename_description_to_body.sql \
+       common/api/src/main/resources/openapi.json
+git commit -m "feat: add project body field — migration and OpenAPI spec"
+```
+
+---
+
+### Task 2: Backend — Entity, REST Resource, and Pipeline Orchestrator
+
+**Files:**
+- Modify: `core/src/main/java/io/apitomy/axiom/core/entities/ProjectEntity.java:26-27`
+- Modify: `app/src/main/java/io/apitomy/axiom/app/rest/ProjectsResourceImpl.java:138,168-170,499`
+- Modify: `app/src/main/java/io/apitomy/axiom/app/PipelineOrchestrator.java:522-557,586-603`
+
+**Interfaces:**
+- Consumes: Generated `Project`, `NewProject`, `UpdateProject` beans with `getBody()` / `setBody()`
+  from Task 1 (after `mvn install`)
+- Produces: Working REST API with `body` field on projects, dedicated `PUT /projects/{id}/body`
+  endpoint, and auto-population of body from GitHub issue/PR events
+
+**Important:** Run `mvn install` (or `build.sh`) before starting this task so the generated beans
+reflect the OpenAPI changes from Task 1.
+
+- [ ] **Step 1: Rename the entity field**
+
+In `core/src/main/java/io/apitomy/axiom/core/entities/ProjectEntity.java`, rename the field at
+line 27 from `description` to `body`:
+
+```java
+@Column(columnDefinition = "TEXT")
+public String body;
+```
+
+- [ ] **Step 2: Update `createProject()` in `ProjectsResourceImpl`**
+
+In `app/src/main/java/io/apitomy/axiom/app/rest/ProjectsResourceImpl.java`, change line 138 from:
+
+```java
+entity.description = data.getDescription();
+```
+
+to:
+
+```java
+entity.body = data.getBody();
+```
+
+- [ ] **Step 3: Update `updateProject()` in `ProjectsResourceImpl`**
+
+Change lines 168-170 from:
+
+```java
+if (data.getDescription() != null) {
+    entity.description = data.getDescription();
+}
+```
+
+to:
+
+```java
+if (data.getBody() != null) {
+    entity.body = data.getBody();
+}
+```
+
+- [ ] **Step 4: Update `toProjectBean()` in `ProjectsResourceImpl`**
+
+Change line 499 from:
+
+```java
+project.setDescription(entity.description);
+```
+
+to:
+
+```java
+project.setBody(entity.body);
+```
+
+- [ ] **Step 5: Implement the dedicated body endpoint**
+
+Add the following method to `ProjectsResourceImpl`, after the `reopenProject` method (~line 228):
+
+```java
+/**
+ * {@inheritDoc}
+ */
+@Override
+@Transactional
+public void updateProjectBody(long projectId, String body) {
+    ProjectEntity entity = findProjectOrThrow(projectId);
+    entity.body = body;
+    entity.updatedOn = Instant.now();
+}
+```
+
+Note: the exact method signature will be determined by the generated `ProjectsResource` interface
+after `mvn install`. Match whatever signature was generated — it should accept `long projectId`
+and `String body` based on the OpenAPI spec.
+
+- [ ] **Step 6: Add `extractIssueBody()` to `PipelineOrchestrator`**
+
+Add a new method after the existing `extractIssueTitle()` method (~line 603):
+
+```java
+/**
+ * Extracts the issue or pull request body from the event payload.
+ * Returns {@code null} if the body cannot be found or is blank.
+ */
+private String extractIssueBody(EventEntity event) {
+    if (event.payload != null) {
+        try {
+            JsonNode root = objectMapper.readTree(event.payload);
+            String body = root.path("issue").path("body").asText(null);
+            if (body != null && !body.isBlank()) {
+                return body;
+            }
+            body = root.path("pull_request").path("body").asText(null);
+            if (body != null && !body.isBlank()) {
+                return body;
+            }
+        } catch (Exception e) {
+            LOG.debugf("Could not parse event payload for issue body: %s", e.getMessage());
+        }
+    }
+    return null;
+}
+```
+
+- [ ] **Step 7: Wire `extractIssueBody()` into `createProjectFromEvent()`**
+
+In `createProjectFromEvent()`, after the line `project.name = extractIssueTitle(event);`
+(line 524), add:
+
+```java
+project.body = extractIssueBody(event);
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add core/src/main/java/io/apitomy/axiom/core/entities/ProjectEntity.java \
+       app/src/main/java/io/apitomy/axiom/app/rest/ProjectsResourceImpl.java \
+       app/src/main/java/io/apitomy/axiom/app/PipelineOrchestrator.java
+git commit -m "feat: implement project body field in backend"
+```
+
+---
+
+### Task 3: UI — API Types, Project Detail Page, and Create Modal
+
+**Files:**
+- Modify: `ui/src/config/api.ts:46-68`
+- Modify: `ui/src/pages/ProjectDetailPage.tsx:1-451`
+- Modify: `ui/src/pages/ProjectsPage.tsx:330-443`
+
+**Interfaces:**
+- Consumes: REST API from Task 2 — `body` field on project responses, `PUT /projects/{id}/body`
+  with `text/markdown` content type
+- Produces: Updated TypeScript types, `updateProjectBody()` API function, markdown viewer with edit
+  toggle on project detail page, renamed field in create modal
+
+- [ ] **Step 1: Update TypeScript types in `api.ts`**
+
+In `ui/src/config/api.ts`, update the `Project` interface (line 46) — replace `description` with
+`body`:
+
+```typescript
+export interface Project {
+    id: number;
+    name: string;
+    body?: string;
+    type: string;
+    status: string;
+    issueSource: string;
+    issueRef: string;
+    repository: string;
+    createdOn: string;
+    updatedOn: string;
+    metadata?: Record<string, string>;
+    labels?: string[];
+}
+```
+
+Update the `NewProject` interface (line 61) — replace `description` with `body`:
+
+```typescript
+export interface NewProject {
+    name: string;
+    body?: string;
+    type: string;
+    issueSource: string;
+    issueRef: string;
+    repository: string;
+}
+```
+
+- [ ] **Step 2: Add `updateProjectBody()` API function**
+
+Add after the existing `updateProject` function (~line 237):
+
+```typescript
+export async function updateProjectBody(id: number, body: string): Promise<void> {
+    const response = await fetch(`${API}/projects/${id}/body`, {
+        method: "PUT",
+        headers: { "Content-Type": "text/markdown" },
+        body,
+    });
+    if (!response.ok) throw new Error(`Failed to update project body: ${response.status}`);
+}
+```
+
+- [ ] **Step 3: Update the project detail page — replace description with markdown body viewer**
+
+In `ui/src/pages/ProjectDetailPage.tsx`:
+
+Add `updateProjectBody` to the imports from `../config/api` (line 66):
+
+```typescript
+import {
+    // ... existing imports ...
+    updateProjectBody,
+} from "../config/api";
+```
+
+Add `PencilAltIcon` to the icon imports:
+
+```typescript
+import PencilAltIcon from "@patternfly/react-icons/dist/esm/icons/pencil-alt-icon";
+import CheckIcon from "@patternfly/react-icons/dist/esm/icons/check-icon";
+import TimesIcon from "@patternfly/react-icons/dist/esm/icons/times-icon";
+```
+
+Add state variables for body editing, after the existing state declarations (~line 107):
+
+```typescript
+const [editingBody, setEditingBody] = useState(false);
+const [bodyDraft, setBodyDraft] = useState("");
+```
+
+Remove the `description` `DescriptionListGroup` block (lines 309-316) that currently renders:
+
+```tsx
+{project.description && (
+    <DescriptionListGroup>
+        <DescriptionListTerm>Description</DescriptionListTerm>
+        <DescriptionListDescription>
+            {project.description}
+        </DescriptionListDescription>
+    </DescriptionListGroup>
+)}
+```
+
+Replace it with a body section placed between the `DescriptionList` closing tag and the Tabs `div`.
+Insert after the `</DescriptionList>` (line 324) and before `{/* Tabs */}` (line 326):
+
+```tsx
+{/* Project body */}
+{(project.body || editingBody) && (
+    <Card style={{ marginTop: "16px" }}>
+        <CardBody>
+            <Flex justifyContent={{ default: "justifyContentSpaceBetween" }}
+                alignItems={{ default: "alignItemsCenter" }}
+                style={{ marginBottom: "8px" }}>
+                <FlexItem>
+                    <Title headingLevel="h3" size="md">Body</Title>
+                </FlexItem>
+                <FlexItem>
+                    {editingBody ? (
+                        <>
+                            <Button variant="plain" aria-label="Save body"
+                                onClick={() => {
+                                    updateProjectBody(id, bodyDraft)
+                                        .then(() => {
+                                            setProject({ ...project, body: bodyDraft });
+                                            setEditingBody(false);
+                                        })
+                                        .catch(console.error);
+                                }}>
+                                <CheckIcon />
+                            </Button>
+                            <Button variant="plain" aria-label="Cancel editing"
+                                onClick={() => setEditingBody(false)}>
+                                <TimesIcon />
+                            </Button>
+                        </>
+                    ) : (
+                        <Button variant="plain" aria-label="Edit body"
+                            onClick={() => {
+                                setBodyDraft(project.body || "");
+                                setEditingBody(true);
+                            }}>
+                            <PencilAltIcon />
+                        </Button>
+                    )}
+                </FlexItem>
+            </Flex>
+            {editingBody ? (
+                <TextArea
+                    id="body-editor"
+                    value={bodyDraft}
+                    onChange={(_e, v) => setBodyDraft(v)}
+                    rows={12}
+                    style={{ fontFamily: "var(--pf-t--global--font--family--mono)" }}
+                />
+            ) : (
+                <Content>
+                    <Markdown remarkPlugins={[remarkGfm]}
+                        components={markdownMermaidComponents}>
+                        {project.body}
+                    </Markdown>
+                </Content>
+            )}
+        </CardBody>
+    </Card>
+)}
+```
+
+Note: `Card`, `CardBody`, `Content`, `TextArea`, `Title`, `Markdown`, `remarkGfm`, and
+`markdownMermaidComponents` are all already imported in the file. The `CheckIcon` and `TimesIcon`
+are new imports.
+
+- [ ] **Step 4: Update the create project modal in `ProjectsPage.tsx`**
+
+In `ui/src/pages/ProjectsPage.tsx`, update the create modal form (~lines 352-363). Rename the
+"Description" form group to "Body" and update the field binding from `description` to `body`:
+
+```tsx
+<FormGroup label="Body" fieldId="body">
+    <TextArea
+        id="body"
+        value={newProject.body || ""}
+        onChange={(_e, v) =>
+            setNewProject({
+                ...newProject,
+                body: v,
+            })
+        }
+    />
+</FormGroup>
+```
+
+Also update the `newProject` state initialization (find where `setNewProject` is called with the
+initial/reset object) — change `description: ""` to `body: ""` if it exists, or ensure the initial
+state uses `body` instead of `description`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src/config/api.ts \
+       ui/src/pages/ProjectDetailPage.tsx \
+       ui/src/pages/ProjectsPage.tsx
+git commit -m "feat: add project body to UI with markdown viewer and editor"
+```
+
+---
+
+### Task 4: SDK MCP Server and UI Tool Lists
+
+**Files:**
+- Modify: `app/src/main/resources/templates/axiom-mcp-server/sdk-server.js:278-292`
+- Modify: `ui/src/components/AddToolInput.tsx:49-62`
+- Modify: `ui/src/components/BrowseToolsModal.tsx:27-40`
+
+**Interfaces:**
+- Consumes: REST API from Task 2 — `PUT /projects/{id}/body` with `text/markdown`
+- Produces: Updated `axiom_update_project` SDK tool (uses `body` instead of `description`), new
+  `axiom_update_project_body` SDK tool, updated UI tool autocomplete lists
+
+- [ ] **Step 1: Update `axiom_update_project` tool in the SDK server**
+
+In `app/src/main/resources/templates/axiom-mcp-server/sdk-server.js`, update the
+`axiom_update_project` tool definition (~lines 278-292):
+
+Change the `description` parameter to `body`:
+
+```javascript
+{
+    name: "axiom_update_project",
+    description: "Update an Axiom project's metadata such as name, body, or labels.",
+    parameters: [
+        { name: "projectId", type: "number", description: "The project ID to update", required: true },
+        { name: "name", type: "string", description: "New project name", required: false },
+        { name: "body", type: "string", description: "New project body (markdown)", required: false },
+        { name: "labels", type: "string", description: "Comma-separated list of labels to set on the project", required: false },
+    ],
+    handler: async (args) => {
+        const data = {};
+        if (args.name) data.name = args.name;
+        if (args.body) data.body = args.body;
+        if (args.labels) data.labels = args.labels.split(",").map(l => l.trim()).filter(Boolean);
+        return await axiomApi("PUT", `/projects/${args.projectId}`, data);
+    },
+},
+```
+
+- [ ] **Step 2: Add `axiom_update_project_body` tool to the SDK server**
+
+Add the following tool definition after the `axiom_update_project` entry (~line 293):
+
+```javascript
+{
+    name: "axiom_update_project_body",
+    description: "Update the markdown body of an Axiom project. Accepts raw markdown content.",
+    parameters: [
+        { name: "projectId", type: "number", description: "The project ID", required: true },
+        { name: "body", type: "string", description: "The markdown body content", required: true },
+    ],
+    handler: async (args) => {
+        const url = `${AXIOM_API_URL}/projects/${args.projectId}/body`;
+        const resp = await fetch(url, {
+            method: "PUT",
+            headers: { "Content-Type": "text/markdown" },
+            body: args.body,
+        });
+        const text = await resp.text();
+        if (!resp.ok) {
+            throw new Error(`Axiom API PUT /projects/${args.projectId}/body returned ${resp.status}: ${text.substring(0, 500)}`);
+        }
+        return text || "OK";
+    },
+},
+```
+
+Note: this tool calls `fetch` directly instead of `axiomApi()` because the dedicated endpoint uses
+`text/markdown` content type, not `application/json`.
+
+- [ ] **Step 3: Add the new tool to the `BrowseToolsModal` hardcoded list**
+
+In `ui/src/components/BrowseToolsModal.tsx`, add the following entry to the `SDK_TOOLS` array
+(~line 39, before the closing `];`):
+
+```typescript
+{ value: "mcp__axiom-sdk__axiom_update_project", label: "axiom_update_project", description: "Update an Axiom project's metadata", category: "sdk" },
+{ value: "mcp__axiom-sdk__axiom_update_project_body", label: "axiom_update_project_body", description: "Update the markdown body of an Axiom project", category: "sdk" },
+```
+
+Note: `axiom_update_project` is also missing from this list currently — add both entries.
+
+- [ ] **Step 4: Add the new tool to the `AddToolInput` hardcoded list**
+
+In `ui/src/components/AddToolInput.tsx`, add the following entries to the `AXIOM_SDK_TOOLS` array
+(~line 61, before the closing `];`):
+
+```typescript
+"mcp__axiom-sdk__axiom_update_project",
+"mcp__axiom-sdk__axiom_update_project_body",
+```
+
+Note: `axiom_update_project` is also missing from this list currently — add both entries.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/resources/templates/axiom-mcp-server/sdk-server.js \
+       ui/src/components/BrowseToolsModal.tsx \
+       ui/src/components/AddToolInput.tsx
+git commit -m "feat: add project body SDK tool and update UI tool lists"
+```

--- a/docs/superpowers/plans/2026-08-19-subagent-panel.md
+++ b/docs/superpowers/plans/2026-08-19-subagent-panel.md
@@ -1,0 +1,959 @@
+# Subagent Activity Panel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface real-time subagent activity in a side panel during AI Assistant sessions so
+users can see what each Agent is doing, how far along it is, and when it finishes.
+
+**Architecture:** The backend parser (`AssistantEventParser`) gains four new SSE event types for
+subagent lifecycle (`subagent_started`, `subagent_progress`, `subagent_status`,
+`subagent_completed`) parsed from Claude Code's `system` NDJSON events. Subagent-scoped
+`assistant`/`user` events (identified by a non-null `parent_tool_use_id` field) are suppressed at
+the parser level to keep the main chat timeline clean. The frontend adds a right-side panel
+(`AssistantSubagentPanel`) that renders one card per active/completed subagent, built entirely
+from these lifecycle events.
+
+**Tech Stack:** Java 25 / Quarkus (backend), React 19 / TypeScript / PatternFly 6 (frontend)
+
+**Spec:** GitHub issue
+[#198](https://github.com/Apitomy/apitomy-axiom/issues/198) + design conversation in this
+session.
+
+## Global Constraints
+
+- **API-first development** does NOT apply here — no REST API changes needed. All new events flow
+  through the existing SSE pipeline.
+- **Do not run tests or Maven builds.** The user handles compilation and test execution. Write
+  tests but do not execute them.
+- **Java style:** 4-space indentation, Javadoc on public methods, explicit types.
+- **Frontend style:** Follow existing PatternFly 6 patterns. Use CSS custom properties for
+  theming (see existing `.css` files for conventions).
+- **Commit messages:** Do not include any Claude attribution.
+
+## Claude Code Subagent Event Format (reference)
+
+When Claude Code spawns a subagent via the `Agent` tool, it emits these events on the same
+NDJSON stream:
+
+**Lifecycle events (`type: "system"`):**
+
+| Subtype | Key fields | Meaning |
+|---------|-----------|---------|
+| `task_started` | `tool_use_id`, `task_id`, `description`, `subagent_type`, `task_type` | Subagent spawned |
+| `task_progress` | `tool_use_id`, `task_id`, `description`, `last_tool_name`, `usage.tool_uses`, `usage.duration_ms` | Tool completed within subagent |
+| `task_updated` | `task_id`, `patch.status` | Status change (e.g. `"completed"`) |
+| `task_notification` | `tool_use_id`, `task_id`, `status`, `summary` | Subagent finished with summary |
+
+**Scoped activity events (`type: "assistant"` / `type: "user"`):**
+
+These carry a `parent_tool_use_id` field matching the Agent's `tool_use_id`. They represent the
+subagent's internal tool calls and results. We suppress them at the parser level because
+`task_progress` events provide better human-readable descriptions of the same activity.
+
+---
+
+### Task 1: Backend — Parse subagent events in AssistantEventParser
+
+**Files:**
+- Modify: `app/src/main/java/io/apitomy/axiom/app/assistant/AssistantEventParser.java`
+- Modify: `app/src/test/java/io/apitomy/axiom/app/assistant/AssistantEventParserTest.java`
+
+**Interfaces:**
+- Consumes: Claude Code NDJSON events (see format reference above)
+- Produces: New `SseEvent` types consumed by the frontend's `processEvent()` in Task 2:
+  - `subagent_started` — data: `{ toolUseId: string, taskId: string, description: string, subagentType: string }`
+  - `subagent_progress` — data: `{ toolUseId: string, taskId: string, description: string, lastToolName: string, toolCount: int, durationMs: long }`
+  - `subagent_status` — data: `{ taskId: string, status: string }`
+  - `subagent_completed` — data: `{ toolUseId: string, taskId: string, status: string, summary: string }`
+
+- [ ] **Step 1: Write tests for subagent lifecycle events**
+
+Add these tests to `AssistantEventParserTest.java` after the `// ── Tool progress events` section:
+
+```java
+// ── Subagent lifecycle events ─────────────────────────────────────
+
+@Test
+void parseSystemTaskStartedEvent() {
+    String line = """
+            {"type":"system","subtype":"task_started","task_id":"task-1",\
+            "tool_use_id":"tu-agent-1","description":"Explore codebase",\
+            "subagent_type":"Explore","task_type":"local_agent"}""";
+
+    List<SseEvent> events = parser.parse(line);
+
+    assertEquals(1, events.size());
+    SseEvent event = events.get(0);
+    assertEquals("subagent_started", event.type());
+    assertEquals("tu-agent-1", event.data().path("toolUseId").asText());
+    assertEquals("task-1", event.data().path("taskId").asText());
+    assertEquals("Explore codebase", event.data().path("description").asText());
+    assertEquals("Explore", event.data().path("subagentType").asText());
+}
+
+@Test
+void parseSystemTaskProgressEvent() {
+    String line = """
+            {"type":"system","subtype":"task_progress","task_id":"task-1",\
+            "tool_use_id":"tu-agent-1","description":"Reading src/Main.java",\
+            "subagent_type":"Explore","last_tool_name":"Read",\
+            "usage":{"total_tokens":15000,"tool_uses":5,"duration_ms":8000}}""";
+
+    List<SseEvent> events = parser.parse(line);
+
+    assertEquals(1, events.size());
+    SseEvent event = events.get(0);
+    assertEquals("subagent_progress", event.type());
+    assertEquals("tu-agent-1", event.data().path("toolUseId").asText());
+    assertEquals("Reading src/Main.java", event.data().path("description").asText());
+    assertEquals("Read", event.data().path("lastToolName").asText());
+    assertEquals(5, event.data().path("toolCount").asInt());
+    assertEquals(8000, event.data().path("durationMs").asLong());
+}
+
+@Test
+void parseSystemTaskUpdatedCompletedEvent() {
+    String line = """
+            {"type":"system","subtype":"task_updated","task_id":"task-1",\
+            "patch":{"status":"completed","end_time":1700000000000}}""";
+
+    List<SseEvent> events = parser.parse(line);
+
+    assertEquals(1, events.size());
+    SseEvent event = events.get(0);
+    assertEquals("subagent_status", event.type());
+    assertEquals("task-1", event.data().path("taskId").asText());
+    assertEquals("completed", event.data().path("status").asText());
+}
+
+@Test
+void parseSystemTaskUpdatedNoStatusIsIgnored() {
+    String line = """
+            {"type":"system","subtype":"task_updated","task_id":"task-1","patch":{}}""";
+
+    List<SseEvent> events = parser.parse(line);
+    assertTrue(events.isEmpty());
+}
+
+@Test
+void parseSystemTaskNotificationEvent() {
+    String line = """
+            {"type":"system","subtype":"task_notification","task_id":"task-1",\
+            "tool_use_id":"tu-agent-1","status":"completed",\
+            "summary":"Found 5 relevant files."}""";
+
+    List<SseEvent> events = parser.parse(line);
+
+    assertEquals(1, events.size());
+    SseEvent event = events.get(0);
+    assertEquals("subagent_completed", event.type());
+    assertEquals("tu-agent-1", event.data().path("toolUseId").asText());
+    assertEquals("completed", event.data().path("status").asText());
+    assertEquals("Found 5 relevant files.", event.data().path("summary").asText());
+}
+```
+
+- [ ] **Step 2: Write tests for subagent event suppression**
+
+Add these tests after the lifecycle tests:
+
+```java
+// ── Subagent event suppression ────────────────────────────────────
+
+@Test
+void parseAssistantWithParentToolUseIdIsIgnored() {
+    String line = """
+            {"type":"assistant","parent_tool_use_id":"tu-agent-1",\
+            "message":{"content":[{"type":"tool_use","id":"tu-sub-1",\
+            "name":"Read","input":{"file_path":"src/Main.java"}}]}}""";
+
+    List<SseEvent> events = parser.parse(line);
+    assertTrue(events.isEmpty());
+}
+
+@Test
+void parseAssistantWithNullParentToolUseIdIsProcessed() {
+    String line = """
+            {"type":"assistant","parent_tool_use_id":null,\
+            "message":{"content":[{"type":"text","text":"Hello"}]}}""";
+
+    List<SseEvent> events = parser.parse(line);
+    assertEquals(1, events.size());
+    assertEquals("assistant_text", events.get(0).type());
+}
+
+@Test
+void parseUserWithParentToolUseIdIsIgnored() {
+    String line = """
+            {"type":"user","parent_tool_use_id":"tu-agent-1",\
+            "message":{"content":[{"type":"tool_result",\
+            "tool_use_id":"tu-sub-1","content":"result"}]}}""";
+
+    List<SseEvent> events = parser.parse(line);
+    assertTrue(events.isEmpty());
+}
+```
+
+- [ ] **Step 3: Implement `parseSystem()` with subagent subtypes**
+
+Replace the existing `parseSystem()` method in `AssistantEventParser.java` (lines 76–94)
+with a switch expression that handles `init` (existing) plus the four new subtypes:
+
+```java
+/**
+ * Parses system events: session init and subagent lifecycle.
+ *
+ * @param root the raw NDJSON node
+ * @return normalised SSE events for the frontend
+ */
+private List<SseEvent> parseSystem(JsonNode root) {
+    String subtype = root.path("subtype").asText("");
+    return switch (subtype) {
+        case "init" -> {
+            ObjectNode data = JsonNodeFactory.instance.objectNode();
+            data.put("sessionId", root.path("session_id").asText());
+            data.put("cwd", root.path("cwd").asText());
+            data.put("model", root.path("model").asText());
+            JsonNode slashCommands = root.path("slash_commands");
+            if (slashCommands.isArray()) {
+                data.set("slashCommands", slashCommands);
+            }
+            JsonNode tools = root.path("tools");
+            if (tools.isArray()) {
+                data.set("tools", tools);
+            }
+            yield List.of(new SseEvent("session_init", data));
+        }
+        case "task_started" -> {
+            ObjectNode data = JsonNodeFactory.instance.objectNode();
+            data.put("toolUseId", root.path("tool_use_id").asText());
+            data.put("taskId", root.path("task_id").asText());
+            data.put("description", root.path("description").asText());
+            data.put("subagentType", root.path("subagent_type").asText());
+            yield List.of(new SseEvent("subagent_started", data));
+        }
+        case "task_progress" -> {
+            ObjectNode data = JsonNodeFactory.instance.objectNode();
+            data.put("toolUseId", root.path("tool_use_id").asText());
+            data.put("taskId", root.path("task_id").asText());
+            data.put("description", root.path("description").asText());
+            data.put("lastToolName", root.path("last_tool_name").asText());
+            JsonNode usage = root.path("usage");
+            data.put("toolCount", usage.path("tool_uses").asInt(0));
+            data.put("durationMs", usage.path("duration_ms").asLong(0));
+            yield List.of(new SseEvent("subagent_progress", data));
+        }
+        case "task_updated" -> {
+            String status = root.path("patch").path("status").asText("");
+            if (status.isEmpty()) {
+                yield Collections.emptyList();
+            }
+            ObjectNode data = JsonNodeFactory.instance.objectNode();
+            data.put("taskId", root.path("task_id").asText());
+            data.put("status", status);
+            yield List.of(new SseEvent("subagent_status", data));
+        }
+        case "task_notification" -> {
+            ObjectNode data = JsonNodeFactory.instance.objectNode();
+            data.put("toolUseId", root.path("tool_use_id").asText());
+            data.put("taskId", root.path("task_id").asText());
+            data.put("status", root.path("status").asText());
+            data.put("summary", root.path("summary").asText());
+            yield List.of(new SseEvent("subagent_completed", data));
+        }
+        default -> Collections.emptyList();
+    };
+}
+```
+
+- [ ] **Step 4: Add subagent suppression guards to `parseAssistant()` and `parseUser()`**
+
+Add a guard at the top of each method. In `parseAssistant()` (line 96), add before the
+`content` extraction:
+
+```java
+private List<SseEvent> parseAssistant(JsonNode root) {
+    String parentToolUseId = root.path("parent_tool_use_id").asText("");
+    if (!parentToolUseId.isEmpty()) {
+        return Collections.emptyList();
+    }
+    JsonNode content = root.path("message").path("content");
+    // ... rest unchanged ...
+}
+```
+
+In `parseUser()` (line 126), add before the `tool_use_result` check:
+
+```java
+private List<SseEvent> parseUser(JsonNode root) {
+    String parentToolUseId = root.path("parent_tool_use_id").asText("");
+    if (!parentToolUseId.isEmpty()) {
+        return Collections.emptyList();
+    }
+    JsonNode toolResult = root.path("tool_use_result");
+    // ... rest unchanged ...
+}
+```
+
+- [ ] **Step 5: Update the class Javadoc**
+
+Add the new event types to the Javadoc event mapping list at the top of
+`AssistantEventParser.java` (lines 22–29):
+
+```java
+ *   <li>{@code system} (subtype task_started) → {@code subagent_started}</li>
+ *   <li>{@code system} (subtype task_progress) → {@code subagent_progress}</li>
+ *   <li>{@code system} (subtype task_updated) → {@code subagent_status}</li>
+ *   <li>{@code system} (subtype task_notification) → {@code subagent_completed}</li>
+ *   <li>{@code assistant} with non-null {@code parent_tool_use_id} → suppressed</li>
+ *   <li>{@code user} with non-null {@code parent_tool_use_id} → suppressed</li>
+```
+
+Also update the `SseEvent` record Javadoc (line 225) to list the new types.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/io/apitomy/axiom/app/assistant/AssistantEventParser.java \
+       app/src/test/java/io/apitomy/axiom/app/assistant/AssistantEventParserTest.java
+git commit -m "feat: parse subagent lifecycle events and suppress scoped events (#198)"
+```
+
+---
+
+### Task 2: Frontend — Subagent panel with activity cards
+
+**Files:**
+- Create: `ui/src/components/assistant/AssistantSubagentCard.tsx`
+- Create: `ui/src/components/assistant/AssistantSubagentCard.css`
+- Create: `ui/src/components/assistant/AssistantSubagentPanel.tsx`
+- Create: `ui/src/components/assistant/AssistantSubagentPanel.css`
+- Modify: `ui/src/components/assistant/AssistantChatPanel.tsx`
+
+**Interfaces:**
+- Consumes: SSE event types from Task 1 (`subagent_started`, `subagent_progress`,
+  `subagent_status`, `subagent_completed`)
+- Produces: Visual subagent panel; `SubagentCardData` interface and dismiss callbacks consumed
+  by Task 3 for cross-linking
+
+- [ ] **Step 1: Create `AssistantSubagentCard.tsx` with data interfaces and component**
+
+Create `ui/src/components/assistant/AssistantSubagentCard.tsx`:
+
+```tsx
+import { useState } from "react";
+import {
+    Button,
+    ExpandableSection,
+    Label,
+    Spinner,
+} from "@patternfly/react-core";
+import TimesIcon from "@patternfly/react-icons/dist/esm/icons/times-icon";
+import CheckCircleIcon from "@patternfly/react-icons/dist/esm/icons/check-circle-icon";
+import "./AssistantSubagentCard.css";
+
+export interface SubagentActivityEntry {
+    id: string;
+    toolName: string;
+    description: string;
+}
+
+export interface SubagentCardData {
+    id: string;
+    taskId: string;
+    description: string;
+    subagentType: string;
+    status: "running" | "completed";
+    currentActivity?: string;
+    lastToolName?: string;
+    toolCount: number;
+    durationMs: number;
+    summary?: string;
+    activityLog: SubagentActivityEntry[];
+    dismissed: boolean;
+}
+
+interface AssistantSubagentCardProps {
+    card: SubagentCardData;
+    onDismiss: (id: string) => void;
+    onNavigateToAgent?: (toolUseId: string) => void;
+    highlighted?: boolean;
+}
+
+export function AssistantSubagentCard({
+    card, onDismiss, onNavigateToAgent, highlighted,
+}: AssistantSubagentCardProps) {
+    const [isExpanded, setIsExpanded] = useState(false);
+    const isComplete = card.status === "completed";
+
+    return (
+        <div
+            className={`axiom-subagent-card${highlighted ? " axiom-subagent-card--highlighted" : ""}`}
+            data-status={card.status}
+        >
+            <div className="axiom-subagent-card__header">
+                <div className="axiom-subagent-card__title-row">
+                    <Label isCompact color="orange">{card.subagentType}</Label>
+                    <span className="axiom-subagent-card__description">
+                        {card.description}
+                    </span>
+                </div>
+                {isComplete && (
+                    <Button
+                        variant="plain"
+                        size="sm"
+                        aria-label="Dismiss"
+                        className="axiom-subagent-card__close-btn"
+                        onClick={() => onDismiss(card.id)}
+                    >
+                        <TimesIcon />
+                    </Button>
+                )}
+            </div>
+
+            <div className="axiom-subagent-card__status">
+                {isComplete ? (
+                    <span className="axiom-subagent-card__completed">
+                        <CheckCircleIcon />
+                        Completed in {formatDuration(card.durationMs)}
+                        {" · "}{card.toolCount} tools used
+                    </span>
+                ) : (
+                    <span className="axiom-subagent-card__running">
+                        <Spinner size="sm" />
+                        <span className="axiom-subagent-card__activity">
+                            {card.currentActivity || "Starting..."}
+                        </span>
+                        <span className="axiom-subagent-card__stats">
+                            {formatDuration(card.durationMs)} · {card.toolCount} tools
+                        </span>
+                    </span>
+                )}
+            </div>
+
+            {card.activityLog.length > 0 && (
+                <ExpandableSection
+                    toggleText={isExpanded
+                        ? "Hide activity"
+                        : `Show activity (${card.activityLog.length})`}
+                    isExpanded={isExpanded}
+                    onToggle={(_e, expanded) => setIsExpanded(expanded)}
+                    isIndented
+                    className="axiom-subagent-card__activity-section"
+                >
+                    <div className="axiom-subagent-card__activity-log">
+                        {card.activityLog.map((entry) => (
+                            <div key={entry.id} className="axiom-subagent-card__activity-entry">
+                                <Label isCompact color="blue"
+                                    className="axiom-subagent-card__tool-badge">
+                                    {entry.toolName}
+                                </Label>
+                                <span className="axiom-subagent-card__activity-desc">
+                                    {entry.description}
+                                </span>
+                            </div>
+                        ))}
+                    </div>
+                </ExpandableSection>
+            )}
+
+            {onNavigateToAgent && (
+                <Button
+                    variant="link"
+                    size="sm"
+                    className="axiom-subagent-card__navigate"
+                    onClick={() => onNavigateToAgent(card.id)}
+                >
+                    Show in conversation
+                </Button>
+            )}
+        </div>
+    );
+}
+
+function formatDuration(ms: number): string {
+    const seconds = Math.round(ms / 1000);
+    if (seconds < 60) return `${seconds}s`;
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return secs > 0 ? `${mins}m ${secs}s` : `${mins}m`;
+}
+```
+
+- [ ] **Step 2: Create `AssistantSubagentCard.css`**
+
+Create `ui/src/components/assistant/AssistantSubagentCard.css`. Key classes:
+
+- `.axiom-subagent-card` — bordered card with `border-radius: 6px`, `margin-bottom: 8px`
+- `.axiom-subagent-card--highlighted` — brand-blue border + box-shadow with a 2s fade-out
+  animation
+- `.axiom-subagent-card__header` — flex row with secondary background, holds type badge +
+  description + close button
+- `.axiom-subagent-card__title-row` — flex with gap, `min-width: 0` for text truncation
+- `.axiom-subagent-card__description` — 13px, `text-overflow: ellipsis`
+- `.axiom-subagent-card__close-btn` — `flex-shrink: 0`, small padding
+- `.axiom-subagent-card__status` — 12px text, secondary background, shows
+  running (spinner + activity text + stats) or completed (check icon + summary)
+- `.axiom-subagent-card__completed` — success green, flex with gap
+- `.axiom-subagent-card__running` — subtle grey, flex with gap
+- `.axiom-subagent-card__activity` — `flex: 1`, ellipsis overflow
+- `.axiom-subagent-card__stats` — mono font, 11px, `flex-shrink: 0`
+- `.axiom-subagent-card__activity-log` — `max-height: 200px`, `overflow-y: auto`
+- `.axiom-subagent-card__activity-entry` — flex row, 3px vertical padding
+- `.axiom-subagent-card__activity-desc` — subtle grey, ellipsis overflow
+- `.axiom-subagent-card__navigate` — link button, 12px, bottom of card
+
+Follow the existing CSS variable conventions from `AssistantToolUseBlock.css` — use
+`var(--pf-t--global--...)` tokens for all colors and fonts.
+
+- [ ] **Step 3: Create `AssistantSubagentPanel.tsx`**
+
+Create `ui/src/components/assistant/AssistantSubagentPanel.tsx`:
+
+```tsx
+import { Button } from "@patternfly/react-core";
+import {
+    AssistantSubagentCard,
+    type SubagentCardData,
+} from "./AssistantSubagentCard";
+import "./AssistantSubagentPanel.css";
+
+interface AssistantSubagentPanelProps {
+    cards: SubagentCardData[];
+    onDismiss: (id: string) => void;
+    onDismissAllCompleted: () => void;
+    onNavigateToAgent?: (toolUseId: string) => void;
+    highlightedCardId?: string;
+}
+
+export function AssistantSubagentPanel({
+    cards, onDismiss, onDismissAllCompleted, onNavigateToAgent, highlightedCardId,
+}: AssistantSubagentPanelProps) {
+    const hasCompleted = cards.some((c) => c.status === "completed");
+
+    return (
+        <div className="axiom-subagent-panel">
+            <div className="axiom-subagent-panel__header">
+                <span className="axiom-subagent-panel__title">Subagents</span>
+                {hasCompleted && (
+                    <Button variant="link" size="sm" onClick={onDismissAllCompleted}>
+                        Close All
+                    </Button>
+                )}
+            </div>
+            <div className="axiom-subagent-panel__cards">
+                {cards.map((card) => (
+                    <AssistantSubagentCard
+                        key={card.id}
+                        card={card}
+                        onDismiss={onDismiss}
+                        onNavigateToAgent={onNavigateToAgent}
+                        highlighted={highlightedCardId === card.id}
+                    />
+                ))}
+            </div>
+        </div>
+    );
+}
+```
+
+- [ ] **Step 4: Create `AssistantSubagentPanel.css`**
+
+Create `ui/src/components/assistant/AssistantSubagentPanel.css`:
+
+```css
+.axiom-subagent-panel {
+    width: 320px;
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: column;
+    border-left: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
+    background-color: var(--pf-t--global--background--color--primary--default, #fff);
+}
+
+.axiom-subagent-panel__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
+    flex-shrink: 0;
+}
+
+.axiom-subagent-panel__title {
+    font-weight: 600;
+    font-size: 14px;
+}
+
+.axiom-subagent-panel__cards {
+    flex: 1 1 0;
+    overflow-y: auto;
+    padding: 8px;
+}
+```
+
+- [ ] **Step 5: Add subagent state and event routing to `AssistantChatPanel.tsx`**
+
+In `AssistantChatPanel.tsx`, make these changes:
+
+**5a — Imports.** Add at top:
+```tsx
+import { AssistantSubagentPanel } from "./AssistantSubagentPanel";
+import type { SubagentCardData, SubagentActivityEntry } from "./AssistantSubagentCard";
+```
+
+**5b — State.** Add after the existing `useState` declarations (line 31):
+```tsx
+const [subagentCards, setSubagentCards] = useState<Map<string, SubagentCardData>>(new Map());
+```
+
+**5c — Derived values.** Add before the `return` statement (before line 403):
+```tsx
+const visibleCards = Array.from(subagentCards.values()).filter(c => !c.dismissed);
+```
+
+**5d — Dismiss handlers.** Add after `handleCreateAutoApproval` (after line 401):
+```tsx
+const handleDismissSubagent = useCallback((id: string) => {
+    setSubagentCards((prev) => {
+        const card = prev.get(id);
+        if (!card) return prev;
+        const next = new Map(prev);
+        next.set(id, { ...card, dismissed: true });
+        return next;
+    });
+}, []);
+
+const handleDismissAllCompleted = useCallback(() => {
+    setSubagentCards((prev) => {
+        const next = new Map(prev);
+        for (const [id, card] of next) {
+            if (card.status === "completed") {
+                next.set(id, { ...card, dismissed: true });
+            }
+        }
+        return next;
+    });
+}, []);
+```
+
+**5e — Event handlers.** Add these cases to the `processEvent` switch statement, before the
+`default` / closing brace (before `"unhandled_event"` at line 223):
+
+```tsx
+case "subagent_started":
+    setSubagentCards((prev) => {
+        const next = new Map(prev);
+        next.set(data.toolUseId as string, {
+            id: data.toolUseId as string,
+            taskId: data.taskId as string,
+            description: data.description as string,
+            subagentType: data.subagentType as string,
+            status: "running",
+            toolCount: 0,
+            durationMs: 0,
+            activityLog: [],
+            dismissed: false,
+        });
+        return next;
+    });
+    break;
+
+case "subagent_progress":
+    setSubagentCards((prev) => {
+        const card = prev.get(data.toolUseId as string);
+        if (!card) return prev;
+        const entry: SubagentActivityEntry = {
+            id: String(++messageIdCounter),
+            toolName: data.lastToolName as string,
+            description: data.description as string,
+        };
+        const next = new Map(prev);
+        next.set(card.id, {
+            ...card,
+            currentActivity: data.description as string,
+            lastToolName: data.lastToolName as string,
+            toolCount: data.toolCount as number,
+            durationMs: data.durationMs as number,
+            activityLog: [...card.activityLog, entry],
+        });
+        return next;
+    });
+    break;
+
+case "subagent_status":
+    setSubagentCards((prev) => {
+        for (const [id, card] of prev) {
+            if (card.taskId === (data.taskId as string)) {
+                const next = new Map(prev);
+                next.set(id, {
+                    ...card,
+                    status: (data.status as string) === "completed"
+                        ? "completed" : card.status,
+                });
+                return next;
+            }
+        }
+        return prev;
+    });
+    break;
+
+case "subagent_completed":
+    setSubagentCards((prev) => {
+        const card = prev.get(data.toolUseId as string);
+        if (!card) return prev;
+        const next = new Map(prev);
+        next.set(card.id, {
+            ...card,
+            status: "completed",
+            summary: data.summary as string,
+        });
+        return next;
+    });
+    break;
+```
+
+**5f — Clear subagent cards on conversation reset.** In the existing `conversation_reset` case
+(line 200), add after `setMessages(...)`:
+
+```tsx
+setSubagentCards(new Map());
+```
+
+**5g — Layout.** Replace the JSX `return` block (lines 403–419) with a flex row that
+conditionally includes the panel:
+
+```tsx
+return (
+    <div style={{
+        display: "flex",
+        flex: "1 1 0",
+        minHeight: 0,
+    }}>
+        <div style={{
+            display: "flex",
+            flexDirection: "column",
+            flex: "1 1 0",
+            minWidth: 0,
+            minHeight: 0,
+        }}>
+            <AssistantMessageList
+                messages={messages}
+                onPermissionRespond={handlePermissionRespond}
+                onCreateAutoApproval={handleCreateAutoApproval}
+                isProcessing={isProcessing}
+                processingText={processingText}
+            />
+            <AssistantMessageInput
+                onSend={handleSend}
+                disabled={isProcessing}
+                slashCommands={slashCommands}
+            />
+        </div>
+        {visibleCards.length > 0 && (
+            <AssistantSubagentPanel
+                cards={visibleCards}
+                onDismiss={handleDismissSubagent}
+                onDismissAllCompleted={handleDismissAllCompleted}
+            />
+        )}
+    </div>
+);
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ui/src/components/assistant/AssistantSubagentCard.tsx \
+       ui/src/components/assistant/AssistantSubagentCard.css \
+       ui/src/components/assistant/AssistantSubagentPanel.tsx \
+       ui/src/components/assistant/AssistantSubagentPanel.css \
+       ui/src/components/assistant/AssistantChatPanel.tsx
+git commit -m "feat: add subagent activity panel with live status cards (#198)"
+```
+
+---
+
+### Task 3: Frontend — Cross-linking between Agent blocks and panel cards
+
+**Files:**
+- Modify: `ui/src/components/assistant/AssistantMessageList.tsx`
+- Modify: `ui/src/components/assistant/AssistantToolUseBlock.tsx`
+- Modify: `ui/src/components/assistant/AssistantToolUseBlock.css`
+- Modify: `ui/src/components/assistant/AssistantChatPanel.tsx`
+
+**Interfaces:**
+- Consumes: `SubagentCardData` from Task 2, existing `ChatMessage` and
+  `AssistantToolUseBlock` props
+- Produces: Bidirectional navigation — clicking an Agent tool_use block in the chat scrolls
+  to its card in the panel; clicking a panel card scrolls to its Agent block in the chat
+
+- [ ] **Step 1: Add `data-tool-use-id` attribute to tool_use blocks in `AssistantMessageList.tsx`**
+
+Wrap the `AssistantToolUseBlock` in a `div` with a data attribute. In
+`AssistantMessageList.tsx`, replace the `case "tool_use"` block (lines 167–182) with:
+
+```tsx
+case "tool_use":
+    return (
+        <div key={msg.id} data-tool-use-id={msg.toolUseId}>
+            <AssistantToolUseBlock
+                toolName={msg.toolName || "unknown"}
+                toolUseId={msg.toolUseId}
+                input={msg.toolInput}
+                result={msg.toolResult}
+                isError={msg.isError}
+                elapsedSeconds={msg.elapsedSeconds}
+                permissionId={msg.permissionId}
+                permissionResolved={msg.permissionResolved}
+                permissionAllowed={msg.permissionAllowed}
+                onPermissionRespond={onPermissionRespond}
+                onCreateAutoApproval={onCreateAutoApproval}
+                onSubagentClick={onSubagentClick}
+                highlighted={msg.toolUseId === highlightedAgentBlockId}
+            />
+        </div>
+    );
+```
+
+- [ ] **Step 2: Add new props to `AssistantMessageList`**
+
+Add to `AssistantMessageListProps` (line 73) and destructure in the component:
+
+```tsx
+interface AssistantMessageListProps {
+    messages: ChatMessage[];
+    onPermissionRespond: (permissionId: string, allow: boolean,
+        toolInput?: Record<string, unknown>) => void;
+    onCreateAutoApproval?: (toolName: string, fieldName: string | undefined,
+        pattern: string | undefined, permissionId: string) => void;
+    isProcessing?: boolean;
+    processingText?: string;
+    onSubagentClick?: (toolUseId: string) => void;
+    highlightedAgentBlockId?: string;
+}
+```
+
+Destructure the two new props in the component function signature (line 82).
+
+- [ ] **Step 3: Add `onSubagentClick` and `highlighted` props to `AssistantToolUseBlock`**
+
+In `AssistantToolUseBlock.tsx`, add to the props interface (line 41):
+
+```tsx
+onSubagentClick?: (toolUseId: string) => void;
+highlighted?: boolean;
+```
+
+Destructure in the component (line 55). Add `toolUseId` to the props interface too — it's
+needed for the click callback:
+
+```tsx
+toolUseId?: string;
+```
+
+- [ ] **Step 4: Make Agent tool_use labels clickable**
+
+In `AssistantToolUseBlock.tsx`, modify the `Label` inside `toggleContent` (line 86). When
+`toolName === "Agent"` and `onSubagentClick` is provided, make the label clickable:
+
+```tsx
+<Label
+    isCompact
+    color={isError ? "red" : getToolColor(toolName)}
+    onClick={toolName === "Agent" && onSubagentClick && toolUseId
+        ? (e) => { e.stopPropagation(); onSubagentClick(toolUseId); }
+        : undefined}
+    style={toolName === "Agent" && onSubagentClick ? { cursor: "pointer" } : undefined}
+>
+    {toolName}
+</Label>
+```
+
+- [ ] **Step 5: Add highlight styling for Agent blocks**
+
+Add a `data-highlighted` attribute to the outer `div` in `AssistantToolUseBlock.tsx`
+(line 81):
+
+```tsx
+<div className="axiom-tool-use" data-border={borderVariant || undefined}
+    data-highlighted={highlighted || undefined}>
+```
+
+Add CSS to `AssistantToolUseBlock.css`:
+
+```css
+.axiom-tool-use[data-highlighted] {
+    border: 2px solid var(--pf-t--global--color--brand--default, #0066cc);
+    animation: axiom-tool-highlight 2s ease-out forwards;
+}
+
+@keyframes axiom-tool-highlight {
+    0% { box-shadow: 0 0 0 3px rgba(0, 102, 204, 0.3); }
+    100% { box-shadow: none; }
+}
+```
+
+- [ ] **Step 6: Wire up cross-linking in `AssistantChatPanel.tsx`**
+
+Add state and handlers after the dismiss handlers (from Task 2):
+
+```tsx
+const [highlightedCardId, setHighlightedCardId] = useState<string | null>(null);
+const [highlightedAgentBlockId, setHighlightedAgentBlockId] = useState<string | null>(null);
+
+const handleSubagentClick = useCallback((toolUseId: string) => {
+    setHighlightedCardId(toolUseId);
+    setTimeout(() => setHighlightedCardId(null), 2000);
+}, []);
+
+const handleNavigateToAgent = useCallback((toolUseId: string) => {
+    const el = document.querySelector(`[data-tool-use-id="${CSS.escape(toolUseId)}"]`);
+    if (el) {
+        el.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+    setHighlightedAgentBlockId(toolUseId);
+    setTimeout(() => setHighlightedAgentBlockId(null), 2000);
+}, []);
+```
+
+Pass to `AssistantMessageList`:
+
+```tsx
+<AssistantMessageList
+    messages={messages}
+    onPermissionRespond={handlePermissionRespond}
+    onCreateAutoApproval={handleCreateAutoApproval}
+    isProcessing={isProcessing}
+    processingText={processingText}
+    onSubagentClick={handleSubagentClick}
+    highlightedAgentBlockId={highlightedAgentBlockId}
+/>
+```
+
+Pass to `AssistantSubagentPanel`:
+
+```tsx
+<AssistantSubagentPanel
+    cards={visibleCards}
+    onDismiss={handleDismissSubagent}
+    onDismissAllCompleted={handleDismissAllCompleted}
+    onNavigateToAgent={handleNavigateToAgent}
+    highlightedCardId={highlightedCardId}
+/>
+```
+
+Also pass `toolUseId` to `AssistantToolUseBlock` in `AssistantMessageList.tsx` — add
+`toolUseId={msg.toolUseId}` to the props in the `case "tool_use"` block.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ui/src/components/assistant/AssistantMessageList.tsx \
+       ui/src/components/assistant/AssistantToolUseBlock.tsx \
+       ui/src/components/assistant/AssistantToolUseBlock.css \
+       ui/src/components/assistant/AssistantChatPanel.tsx
+git commit -m "feat: add cross-linking between Agent blocks and subagent panel cards (#198)"
+```

--- a/ui/src/components/assistant/AssistantChatPanel.tsx
+++ b/ui/src/components/assistant/AssistantChatPanel.tsx
@@ -498,12 +498,12 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
         });
     }, []);
 
-    const [highlightedCardId, setHighlightedCardId] = useState<string | null>(null);
-    const [highlightedAgentBlockId, setHighlightedAgentBlockId] = useState<string | null>(null);
+    const [highlightedCardId, setHighlightedCardId] = useState<string | undefined>(undefined);
+    const [highlightedAgentBlockId, setHighlightedAgentBlockId] = useState<string | undefined>(undefined);
 
     const handleSubagentClick = useCallback((toolUseId: string) => {
         setHighlightedCardId(toolUseId);
-        setTimeout(() => setHighlightedCardId(null), 2000);
+        setTimeout(() => setHighlightedCardId(undefined), 2000);
     }, []);
 
     const handleNavigateToAgent = useCallback((toolUseId: string) => {
@@ -512,7 +512,7 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
             el.scrollIntoView({ behavior: "smooth", block: "center" });
         }
         setHighlightedAgentBlockId(toolUseId);
-        setTimeout(() => setHighlightedAgentBlockId(null), 2000);
+        setTimeout(() => setHighlightedAgentBlockId(undefined), 2000);
     }, []);
 
     const visibleCards = Array.from(subagentCards.values()).filter(c => !c.dismissed);

--- a/ui/src/components/assistant/AssistantChatPanel.tsx
+++ b/ui/src/components/assistant/AssistantChatPanel.tsx
@@ -32,6 +32,7 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
     const [processingText, setProcessingText] = useState("");
     const [slashCommands, setSlashCommands] = useState<string[]>([]);
     const [subagentCards, setSubagentCards] = useState<Map<string, SubagentCardData>>(new Map());
+    const [panelWidth, setPanelWidth] = useState(320);
     const sessionEndedRef = useRef(false);
     const lastSeenIndexRef = useRef(-1);
 
@@ -552,6 +553,8 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
                     onDismissAllCompleted={handleDismissAllCompleted}
                     onNavigateToAgent={handleNavigateToAgent}
                     highlightedCardId={highlightedCardId}
+                    width={panelWidth}
+                    onWidthChange={setPanelWidth}
                 />
             )}
         </div>

--- a/ui/src/components/assistant/AssistantChatPanel.tsx
+++ b/ui/src/components/assistant/AssistantChatPanel.tsx
@@ -497,6 +497,23 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
         });
     }, []);
 
+    const [highlightedCardId, setHighlightedCardId] = useState<string | null>(null);
+    const [highlightedAgentBlockId, setHighlightedAgentBlockId] = useState<string | null>(null);
+
+    const handleSubagentClick = useCallback((toolUseId: string) => {
+        setHighlightedCardId(toolUseId);
+        setTimeout(() => setHighlightedCardId(null), 2000);
+    }, []);
+
+    const handleNavigateToAgent = useCallback((toolUseId: string) => {
+        const el = document.querySelector(`[data-tool-use-id="${CSS.escape(toolUseId)}"]`);
+        if (el) {
+            el.scrollIntoView({ behavior: "smooth", block: "center" });
+        }
+        setHighlightedAgentBlockId(toolUseId);
+        setTimeout(() => setHighlightedAgentBlockId(null), 2000);
+    }, []);
+
     const visibleCards = Array.from(subagentCards.values()).filter(c => !c.dismissed);
 
     return (
@@ -518,6 +535,8 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
                     onCreateAutoApproval={handleCreateAutoApproval}
                     isProcessing={isProcessing}
                     processingText={processingText}
+                    onSubagentClick={handleSubagentClick}
+                    highlightedAgentBlockId={highlightedAgentBlockId}
                 />
                 <AssistantMessageInput
                     onSend={handleSend}
@@ -530,6 +549,8 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
                     cards={visibleCards}
                     onDismiss={handleDismissSubagent}
                     onDismissAllCompleted={handleDismissAllCompleted}
+                    onNavigateToAgent={handleNavigateToAgent}
+                    highlightedCardId={highlightedCardId}
                 />
             )}
         </div>

--- a/ui/src/components/assistant/AssistantChatPanel.tsx
+++ b/ui/src/components/assistant/AssistantChatPanel.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { AssistantMessageList, type ChatMessage } from "./AssistantMessageList";
 import { AssistantMessageInput } from "./AssistantMessageInput";
+import { AssistantSubagentPanel } from "./AssistantSubagentPanel";
+import type { SubagentCardData, SubagentActivityEntry } from "./AssistantSubagentCard";
 import {
     sendAssistantMessage,
     respondToAssistantPermission,
@@ -29,6 +31,7 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
     const [isProcessing, setIsProcessing] = useState(false);
     const [processingText, setProcessingText] = useState("");
     const [slashCommands, setSlashCommands] = useState<string[]>([]);
+    const [subagentCards, setSubagentCards] = useState<Map<string, SubagentCardData>>(new Map());
     const sessionEndedRef = useRef(false);
     const lastSeenIndexRef = useRef(-1);
 
@@ -203,6 +206,7 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
                     type: "system",
                     content: "Conversation cleared.",
                 }]);
+                setSubagentCards(new Map());
                 setIsProcessing(false);
                 break;
 
@@ -218,6 +222,77 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
 
             case "allow_all_changed":
                 onAllowAllChangedRef.current?.(data.enabled as boolean);
+                break;
+
+            case "subagent_started":
+                setSubagentCards((prev) => {
+                    const next = new Map(prev);
+                    next.set(data.toolUseId as string, {
+                        id: data.toolUseId as string,
+                        taskId: data.taskId as string,
+                        description: data.description as string,
+                        subagentType: data.subagentType as string,
+                        status: "running",
+                        toolCount: 0,
+                        durationMs: 0,
+                        activityLog: [],
+                        dismissed: false,
+                    });
+                    return next;
+                });
+                break;
+
+            case "subagent_progress":
+                setSubagentCards((prev) => {
+                    const card = prev.get(data.toolUseId as string);
+                    if (!card) return prev;
+                    const entry: SubagentActivityEntry = {
+                        id: String(++messageIdCounter),
+                        toolName: data.lastToolName as string,
+                        description: data.description as string,
+                    };
+                    const next = new Map(prev);
+                    next.set(card.id, {
+                        ...card,
+                        currentActivity: data.description as string,
+                        lastToolName: data.lastToolName as string,
+                        toolCount: data.toolCount as number,
+                        durationMs: data.durationMs as number,
+                        activityLog: [...card.activityLog, entry],
+                    });
+                    return next;
+                });
+                break;
+
+            case "subagent_status":
+                setSubagentCards((prev) => {
+                    for (const [id, card] of prev) {
+                        if (card.taskId === (data.taskId as string)) {
+                            const next = new Map(prev);
+                            next.set(id, {
+                                ...card,
+                                status: (data.status as string) === "completed"
+                                    ? "completed" : card.status,
+                            });
+                            return next;
+                        }
+                    }
+                    return prev;
+                });
+                break;
+
+            case "subagent_completed":
+                setSubagentCards((prev) => {
+                    const card = prev.get(data.toolUseId as string);
+                    if (!card) return prev;
+                    const next = new Map(prev);
+                    next.set(card.id, {
+                        ...card,
+                        status: "completed",
+                        summary: data.summary as string,
+                    });
+                    return next;
+                });
                 break;
 
             case "unhandled_event":
@@ -400,21 +475,63 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
         }
     }, [sessionId, onAutoApprovalCountChange, addMessage]);
 
+    const handleDismissSubagent = useCallback((id: string) => {
+        setSubagentCards((prev) => {
+            const card = prev.get(id);
+            if (!card) return prev;
+            const next = new Map(prev);
+            next.set(id, { ...card, dismissed: true });
+            return next;
+        });
+    }, []);
+
+    const handleDismissAllCompleted = useCallback(() => {
+        setSubagentCards((prev) => {
+            const next = new Map(prev);
+            for (const [id, card] of next) {
+                if (card.status === "completed") {
+                    next.set(id, { ...card, dismissed: true });
+                }
+            }
+            return next;
+        });
+    }, []);
+
+    const visibleCards = Array.from(subagentCards.values()).filter(c => !c.dismissed);
+
     return (
         <div style={{
             display: "flex",
-            flexDirection: "column",
             flex: "1 1 0",
             minHeight: 0,
         }}>
-            <AssistantMessageList
-                messages={messages}
-                onPermissionRespond={handlePermissionRespond}
-                onCreateAutoApproval={handleCreateAutoApproval}
-                isProcessing={isProcessing}
-                processingText={processingText}
-            />
-            <AssistantMessageInput onSend={handleSend} disabled={isProcessing} slashCommands={slashCommands} />
+            <div style={{
+                display: "flex",
+                flexDirection: "column",
+                flex: "1 1 0",
+                minWidth: 0,
+                minHeight: 0,
+            }}>
+                <AssistantMessageList
+                    messages={messages}
+                    onPermissionRespond={handlePermissionRespond}
+                    onCreateAutoApproval={handleCreateAutoApproval}
+                    isProcessing={isProcessing}
+                    processingText={processingText}
+                />
+                <AssistantMessageInput
+                    onSend={handleSend}
+                    disabled={isProcessing}
+                    slashCommands={slashCommands}
+                />
+            </div>
+            {visibleCards.length > 0 && (
+                <AssistantSubagentPanel
+                    cards={visibleCards}
+                    onDismiss={handleDismissSubagent}
+                    onDismissAllCompleted={handleDismissAllCompleted}
+                />
+            )}
         </div>
     );
 }

--- a/ui/src/components/assistant/AssistantChatPanel.tsx
+++ b/ui/src/components/assistant/AssistantChatPanel.tsx
@@ -417,6 +417,7 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
                 type: "system",
                 content: "Conversation cleared.",
             }]);
+            setSubagentCards(new Map());
             setIsProcessing(false);
         } else {
             addMessage({ type: "user", content: message });

--- a/ui/src/components/assistant/AssistantMessageList.tsx
+++ b/ui/src/components/assistant/AssistantMessageList.tsx
@@ -77,9 +77,11 @@ interface AssistantMessageListProps {
         pattern: string | undefined, permissionId: string) => void;
     isProcessing?: boolean;
     processingText?: string;
+    onSubagentClick?: (toolUseId: string) => void;
+    highlightedAgentBlockId?: string;
 }
 
-export function AssistantMessageList({ messages, onPermissionRespond, onCreateAutoApproval, isProcessing, processingText }: AssistantMessageListProps) {
+export function AssistantMessageList({ messages, onPermissionRespond, onCreateAutoApproval, isProcessing, processingText, onSubagentClick, highlightedAgentBlockId }: AssistantMessageListProps) {
     const endRef = useRef<HTMLDivElement>(null);
     const [copiedId, setCopiedId] = useState<string | null>(null);
     const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
@@ -166,19 +168,23 @@ export function AssistantMessageList({ messages, onPermissionRespond, onCreateAu
 
                     case "tool_use":
                         return (
-                            <AssistantToolUseBlock
-                                key={msg.id}
-                                toolName={msg.toolName || "unknown"}
-                                input={msg.toolInput}
-                                result={msg.toolResult}
-                                isError={msg.isError}
-                                elapsedSeconds={msg.elapsedSeconds}
-                                permissionId={msg.permissionId}
-                                permissionResolved={msg.permissionResolved}
-                                permissionAllowed={msg.permissionAllowed}
-                                onPermissionRespond={onPermissionRespond}
-                                onCreateAutoApproval={onCreateAutoApproval}
-                            />
+                            <div key={msg.id} data-tool-use-id={msg.toolUseId}>
+                                <AssistantToolUseBlock
+                                    toolName={msg.toolName || "unknown"}
+                                    toolUseId={msg.toolUseId}
+                                    input={msg.toolInput}
+                                    result={msg.toolResult}
+                                    isError={msg.isError}
+                                    elapsedSeconds={msg.elapsedSeconds}
+                                    permissionId={msg.permissionId}
+                                    permissionResolved={msg.permissionResolved}
+                                    permissionAllowed={msg.permissionAllowed}
+                                    onPermissionRespond={onPermissionRespond}
+                                    onCreateAutoApproval={onCreateAutoApproval}
+                                    onSubagentClick={onSubagentClick}
+                                    highlighted={msg.toolUseId === highlightedAgentBlockId}
+                                />
+                            </div>
                         );
 
                     case "thinking":

--- a/ui/src/components/assistant/AssistantSubagentCard.css
+++ b/ui/src/components/assistant/AssistantSubagentCard.css
@@ -1,0 +1,126 @@
+/* Card container */
+.axiom-subagent-card {
+    border: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
+    border-radius: 6px;
+    margin-bottom: 8px;
+    overflow: hidden;
+    background-color: var(--pf-t--global--background--color--primary--default, #fff);
+}
+
+.axiom-subagent-card--highlighted {
+    border-color: var(--pf-t--global--color--status--info--default, #2b9af3);
+    box-shadow: 0 0 8px var(--pf-t--global--color--status--info--default, #2b9af3);
+    animation: axiom-subagent-card-highlight-fade 2s ease-out forwards;
+}
+
+@keyframes axiom-subagent-card-highlight-fade {
+    from {
+        border-color: var(--pf-t--global--color--status--info--default, #2b9af3);
+        box-shadow: 0 0 8px var(--pf-t--global--color--status--info--default, #2b9af3);
+    }
+    to {
+        border-color: var(--pf-t--global--border--color--default, #d2d2d2);
+        box-shadow: none;
+    }
+}
+
+/* Header section */
+.axiom-subagent-card__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 12px;
+    background-color: var(--pf-t--global--background--color--secondary--default, #f0f0f0);
+    gap: 8px;
+}
+
+.axiom-subagent-card__title-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    flex: 1 1 0;
+}
+
+.axiom-subagent-card__description {
+    font-size: 13px;
+    color: var(--pf-t--global--text--color--regular, #151515);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.axiom-subagent-card__close-btn {
+    flex-shrink: 0;
+    padding: 2px 6px;
+}
+
+/* Status section */
+.axiom-subagent-card__status {
+    padding: 8px 12px;
+    background-color: var(--pf-t--global--background--color--secondary--default, #f0f0f0);
+    font-size: 12px;
+}
+
+.axiom-subagent-card__completed {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--pf-t--global--color--status--success--default, #3e8635);
+}
+
+.axiom-subagent-card__running {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--pf-t--global--text--color--subtle, #6a6e73);
+}
+
+.axiom-subagent-card__activity {
+    flex: 1 1 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+}
+
+.axiom-subagent-card__stats {
+    font-family: var(--pf-t--global--font--family--mono, monospace);
+    font-size: 11px;
+    flex-shrink: 0;
+}
+
+/* Activity section */
+.axiom-subagent-card__activity-section {
+    padding: 0 12px 8px;
+}
+
+.axiom-subagent-card__activity-log {
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+.axiom-subagent-card__activity-entry {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 3px 0;
+}
+
+.axiom-subagent-card__tool-badge {
+    flex-shrink: 0;
+}
+
+.axiom-subagent-card__activity-desc {
+    font-size: 12px;
+    color: var(--pf-t--global--text--color--subtle, #6a6e73);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* Navigate button */
+.axiom-subagent-card__navigate {
+    padding: 8px 12px;
+    font-size: 12px;
+}

--- a/ui/src/components/assistant/AssistantSubagentCard.tsx
+++ b/ui/src/components/assistant/AssistantSubagentCard.tsx
@@ -1,0 +1,137 @@
+import { useState } from "react";
+import {
+    Button,
+    ExpandableSection,
+    Label,
+    Spinner,
+} from "@patternfly/react-core";
+import TimesIcon from "@patternfly/react-icons/dist/esm/icons/times-icon";
+import CheckCircleIcon from "@patternfly/react-icons/dist/esm/icons/check-circle-icon";
+import "./AssistantSubagentCard.css";
+
+export interface SubagentActivityEntry {
+    id: string;
+    toolName: string;
+    description: string;
+}
+
+export interface SubagentCardData {
+    id: string;
+    taskId: string;
+    description: string;
+    subagentType: string;
+    status: "running" | "completed";
+    currentActivity?: string;
+    lastToolName?: string;
+    toolCount: number;
+    durationMs: number;
+    summary?: string;
+    activityLog: SubagentActivityEntry[];
+    dismissed: boolean;
+}
+
+interface AssistantSubagentCardProps {
+    card: SubagentCardData;
+    onDismiss: (id: string) => void;
+    onNavigateToAgent?: (toolUseId: string) => void;
+    highlighted?: boolean;
+}
+
+export function AssistantSubagentCard({
+    card, onDismiss, onNavigateToAgent, highlighted,
+}: AssistantSubagentCardProps) {
+    const [isExpanded, setIsExpanded] = useState(false);
+    const isComplete = card.status === "completed";
+
+    return (
+        <div
+            className={`axiom-subagent-card${highlighted ? " axiom-subagent-card--highlighted" : ""}`}
+            data-status={card.status}
+        >
+            <div className="axiom-subagent-card__header">
+                <div className="axiom-subagent-card__title-row">
+                    <Label isCompact color="orange">{card.subagentType}</Label>
+                    <span className="axiom-subagent-card__description">
+                        {card.description}
+                    </span>
+                </div>
+                {isComplete && (
+                    <Button
+                        variant="plain"
+                        size="sm"
+                        aria-label="Dismiss"
+                        className="axiom-subagent-card__close-btn"
+                        onClick={() => onDismiss(card.id)}
+                    >
+                        <TimesIcon />
+                    </Button>
+                )}
+            </div>
+
+            <div className="axiom-subagent-card__status">
+                {isComplete ? (
+                    <span className="axiom-subagent-card__completed">
+                        <CheckCircleIcon />
+                        Completed in {formatDuration(card.durationMs)}
+                        {" · "}{card.toolCount} tools used
+                    </span>
+                ) : (
+                    <span className="axiom-subagent-card__running">
+                        <Spinner size="sm" />
+                        <span className="axiom-subagent-card__activity">
+                            {card.currentActivity || "Starting..."}
+                        </span>
+                        <span className="axiom-subagent-card__stats">
+                            {formatDuration(card.durationMs)} · {card.toolCount} tools
+                        </span>
+                    </span>
+                )}
+            </div>
+
+            {card.activityLog.length > 0 && (
+                <ExpandableSection
+                    toggleText={isExpanded
+                        ? "Hide activity"
+                        : `Show activity (${card.activityLog.length})`}
+                    isExpanded={isExpanded}
+                    onToggle={(_e, expanded) => setIsExpanded(expanded)}
+                    isIndented
+                    className="axiom-subagent-card__activity-section"
+                >
+                    <div className="axiom-subagent-card__activity-log">
+                        {card.activityLog.map((entry) => (
+                            <div key={entry.id} className="axiom-subagent-card__activity-entry">
+                                <Label isCompact color="blue"
+                                    className="axiom-subagent-card__tool-badge">
+                                    {entry.toolName}
+                                </Label>
+                                <span className="axiom-subagent-card__activity-desc">
+                                    {entry.description}
+                                </span>
+                            </div>
+                        ))}
+                    </div>
+                </ExpandableSection>
+            )}
+
+            {onNavigateToAgent && (
+                <Button
+                    variant="link"
+                    size="sm"
+                    className="axiom-subagent-card__navigate"
+                    onClick={() => onNavigateToAgent(card.id)}
+                >
+                    Show in conversation
+                </Button>
+            )}
+        </div>
+    );
+}
+
+function formatDuration(ms: number): string {
+    const seconds = Math.round(ms / 1000);
+    if (seconds < 60) return `${seconds}s`;
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return secs > 0 ? `${mins}m ${secs}s` : `${mins}m`;
+}

--- a/ui/src/components/assistant/AssistantSubagentPanel.css
+++ b/ui/src/components/assistant/AssistantSubagentPanel.css
@@ -1,0 +1,28 @@
+.axiom-subagent-panel {
+    width: 320px;
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: column;
+    border-left: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
+    background-color: var(--pf-t--global--background--color--primary--default, #fff);
+}
+
+.axiom-subagent-panel__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
+    flex-shrink: 0;
+}
+
+.axiom-subagent-panel__title {
+    font-weight: 600;
+    font-size: 14px;
+}
+
+.axiom-subagent-panel__cards {
+    flex: 1 1 0;
+    overflow-y: auto;
+    padding: 8px;
+}

--- a/ui/src/components/assistant/AssistantSubagentPanel.css
+++ b/ui/src/components/assistant/AssistantSubagentPanel.css
@@ -1,10 +1,26 @@
 .axiom-subagent-panel {
-    width: 320px;
     flex-shrink: 0;
     display: flex;
     flex-direction: column;
     border-left: 1px solid var(--pf-t--global--border--color--default, #d2d2d2);
     background-color: var(--pf-t--global--background--color--primary--default, #fff);
+    position: relative;
+}
+
+.axiom-subagent-panel__resize-handle {
+    position: absolute;
+    top: 0;
+    left: -3px;
+    width: 6px;
+    height: 100%;
+    cursor: col-resize;
+    z-index: 10;
+}
+
+.axiom-subagent-panel__resize-handle:hover,
+.axiom-subagent-panel__resize-handle:active {
+    background-color: var(--pf-t--global--color--brand--default, #0066cc);
+    opacity: 0.4;
 }
 
 .axiom-subagent-panel__header {

--- a/ui/src/components/assistant/AssistantSubagentPanel.tsx
+++ b/ui/src/components/assistant/AssistantSubagentPanel.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useRef } from "react";
 import { Button } from "@patternfly/react-core";
 import {
     AssistantSubagentCard,
@@ -11,15 +12,56 @@ interface AssistantSubagentPanelProps {
     onDismissAllCompleted: () => void;
     onNavigateToAgent?: (toolUseId: string) => void;
     highlightedCardId?: string;
+    width: number;
+    onWidthChange: (width: number) => void;
 }
+
+const MIN_WIDTH = 200;
+const MAX_WIDTH = 500;
 
 export function AssistantSubagentPanel({
     cards, onDismiss, onDismissAllCompleted, onNavigateToAgent, highlightedCardId,
+    width, onWidthChange,
 }: AssistantSubagentPanelProps) {
     const hasCompleted = cards.some((c) => c.status === "completed");
+    const draggingRef = useRef(false);
+    const startXRef = useRef(0);
+    const startWidthRef = useRef(0);
+
+    const onMouseMove = useCallback((e: MouseEvent) => {
+        if (!draggingRef.current) return;
+        const delta = startXRef.current - e.clientX;
+        const newWidth = Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, startWidthRef.current + delta));
+        onWidthChange(newWidth);
+    }, [onWidthChange]);
+
+    const onMouseUp = useCallback(() => {
+        draggingRef.current = false;
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+    }, []);
+
+    useEffect(() => {
+        document.addEventListener("mousemove", onMouseMove);
+        document.addEventListener("mouseup", onMouseUp);
+        return () => {
+            document.removeEventListener("mousemove", onMouseMove);
+            document.removeEventListener("mouseup", onMouseUp);
+        };
+    }, [onMouseMove, onMouseUp]);
+
+    const handleMouseDown = useCallback((e: React.MouseEvent) => {
+        e.preventDefault();
+        draggingRef.current = true;
+        startXRef.current = e.clientX;
+        startWidthRef.current = width;
+        document.body.style.cursor = "col-resize";
+        document.body.style.userSelect = "none";
+    }, [width]);
 
     return (
-        <div className="axiom-subagent-panel">
+        <div className="axiom-subagent-panel" style={{ width }}>
+            <div className="axiom-subagent-panel__resize-handle" onMouseDown={handleMouseDown} />
             <div className="axiom-subagent-panel__header">
                 <span className="axiom-subagent-panel__title">Subagents</span>
                 {hasCompleted && (

--- a/ui/src/components/assistant/AssistantSubagentPanel.tsx
+++ b/ui/src/components/assistant/AssistantSubagentPanel.tsx
@@ -1,0 +1,44 @@
+import { Button } from "@patternfly/react-core";
+import {
+    AssistantSubagentCard,
+    type SubagentCardData,
+} from "./AssistantSubagentCard";
+import "./AssistantSubagentPanel.css";
+
+interface AssistantSubagentPanelProps {
+    cards: SubagentCardData[];
+    onDismiss: (id: string) => void;
+    onDismissAllCompleted: () => void;
+    onNavigateToAgent?: (toolUseId: string) => void;
+    highlightedCardId?: string;
+}
+
+export function AssistantSubagentPanel({
+    cards, onDismiss, onDismissAllCompleted, onNavigateToAgent, highlightedCardId,
+}: AssistantSubagentPanelProps) {
+    const hasCompleted = cards.some((c) => c.status === "completed");
+
+    return (
+        <div className="axiom-subagent-panel">
+            <div className="axiom-subagent-panel__header">
+                <span className="axiom-subagent-panel__title">Subagents</span>
+                {hasCompleted && (
+                    <Button variant="link" size="sm" onClick={onDismissAllCompleted}>
+                        Close All
+                    </Button>
+                )}
+            </div>
+            <div className="axiom-subagent-panel__cards">
+                {cards.map((card) => (
+                    <AssistantSubagentCard
+                        key={card.id}
+                        card={card}
+                        onDismiss={onDismiss}
+                        onNavigateToAgent={onNavigateToAgent}
+                        highlighted={highlightedCardId === card.id}
+                    />
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/ui/src/components/assistant/AssistantToolUseBlock.css
+++ b/ui/src/components/assistant/AssistantToolUseBlock.css
@@ -17,6 +17,16 @@
     border: 2px solid var(--pf-t--global--color--nonstatus--orange--default, #f0ab00);
 }
 
+.axiom-tool-use[data-highlighted] {
+    border: 2px solid var(--pf-t--global--color--brand--default, #0066cc);
+    animation: axiom-tool-highlight 2s ease-out forwards;
+}
+
+@keyframes axiom-tool-highlight {
+    0% { box-shadow: 0 0 0 3px rgba(0, 102, 204, 0.3); }
+    100% { box-shadow: none; }
+}
+
 /* Expandable header */
 .axiom-tool-use__header {
     padding: 8px 12px;

--- a/ui/src/components/assistant/AssistantToolUseBlock.tsx
+++ b/ui/src/components/assistant/AssistantToolUseBlock.tsx
@@ -40,6 +40,7 @@ function getToolColor(toolName: string): LabelColor {
 
 interface AssistantToolUseBlockProps {
     toolName: string;
+    toolUseId?: string;
     input?: Record<string, unknown>;
     result?: string;
     isError?: boolean;
@@ -50,12 +51,14 @@ interface AssistantToolUseBlockProps {
     onPermissionRespond?: (permissionId: string, allow: boolean, toolInput?: Record<string, unknown>) => void;
     onCreateAutoApproval?: (toolName: string, fieldName: string | undefined,
         pattern: string | undefined, permissionId: string) => void;
+    onSubagentClick?: (toolUseId: string) => void;
+    highlighted?: boolean;
 }
 
 export function AssistantToolUseBlock({
-    toolName, input, result, isError, elapsedSeconds,
+    toolName, toolUseId, input, result, isError, elapsedSeconds,
     permissionId, permissionResolved, permissionAllowed, onPermissionRespond,
-    onCreateAutoApproval,
+    onCreateAutoApproval, onSubagentClick, highlighted,
 }: AssistantToolUseBlockProps) {
     const effectiveTheme = useEffectiveTheme();
     const syntaxStyle = effectiveTheme === "dark" ? stackoverflowDark : stackoverflowLight;
@@ -78,12 +81,20 @@ export function AssistantToolUseBlock({
     const contextSummary = getContextSummary(toolName, input);
 
     return (
-        <div className="axiom-tool-use" data-border={borderVariant || undefined}>
+        <div className="axiom-tool-use" data-border={borderVariant || undefined}
+            data-highlighted={highlighted || undefined}>
             <div className="axiom-tool-use__header">
                 <ExpandableSection
                     toggleContent={
                         <span>
-                            <Label isCompact color={isError ? "red" : getToolColor(toolName)}>
+                            <Label
+                                isCompact
+                                color={isError ? "red" : getToolColor(toolName)}
+                                onClick={toolName === "Agent" && onSubagentClick && toolUseId
+                                    ? (e) => { e.stopPropagation(); onSubagentClick(toolUseId); }
+                                    : undefined}
+                                style={toolName === "Agent" && onSubagentClick ? { cursor: "pointer" } : undefined}
+                            >
                                 {toolName}
                             </Label>
                             {!result && elapsedSeconds != null && (


### PR DESCRIPTION
Fixes #198

## Summary

- **Backend**: `AssistantEventParser` now parses Claude Code's subagent lifecycle events
  (`task_started`, `task_progress`, `task_updated`, `task_notification`) into four new SSE
  event types (`subagent_started`, `subagent_progress`, `subagent_status`,
  `subagent_completed`). Subagent-scoped `assistant`/`user` events (with non-null
  `parent_tool_use_id`) are suppressed to keep the chat timeline clean.
- **Frontend**: A right-side panel appears when subagents are active, showing one card per
  agent with live status (current activity, tool count, elapsed time), expandable activity
  log, and completion summary. Cards can be individually dismissed or cleared all at once.
- **Cross-linking**: Clicking an Agent tool_use block in the chat highlights its card in the
  panel; clicking a panel card scrolls to the corresponding Agent block in the conversation.

## Test plan

- [ ] Start an AI Assistant session and trigger a prompt that spawns Agent subagents
- [ ] Verify the subagent panel appears on the right with a card per agent
- [ ] Verify live status updates (activity description, tool count) appear on running cards
- [ ] Verify completed cards show duration, tool count, and a close button
- [ ] Verify "Close All" dismisses only completed cards
- [ ] Verify clicking an Agent block in the chat highlights its panel card
- [ ] Verify clicking "Show in conversation" on a card scrolls to the Agent block
- [ ] Verify `/clear` clears both the chat and the subagent panel
- [ ] Verify panel disappears when all cards are dismissed
- [ ] Run `mvn test -pl app -Dtest=AssistantEventParserTest` to verify backend tests pass