### PR TITLE
Add tab support to custom Dashboards (#192)

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/rest/DashboardsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/DashboardsResourceImpl.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.apitomy.axiom.api.DashboardsResource;
 import io.apitomy.axiom.api.beans.Dashboard;
-import io.apitomy.axiom.api.beans.DashboardWidget;
+import io.apitomy.axiom.api.beans.DashboardTab;
 import io.apitomy.axiom.api.beans.NewDashboard;
 import io.apitomy.axiom.core.entities.DashboardEntity;
 import io.smallrye.common.annotation.RunOnVirtualThread;
@@ -30,7 +30,7 @@ public class DashboardsResourceImpl implements DashboardsResource {
 
     private static final Logger LOG = Logger.getLogger(DashboardsResourceImpl.class);
 
-    private static final TypeReference<List<DashboardWidget>> WIDGET_LIST_TYPE =
+    private static final TypeReference<List<DashboardTab>> TAB_LIST_TYPE =
             new TypeReference<>() {};
 
     @Inject
@@ -112,7 +112,7 @@ public class DashboardsResourceImpl implements DashboardsResource {
         entity.name = data.getName();
         entity.description = data.getDescription();
         entity.isDefault = data.getIsDefault() != null ? data.getIsDefault() : false;
-        entity.widgets = serializeWidgets(data.getWidgets());
+        entity.tabs = serializeTabs(data.getTabs());
         entity.labels.clear();
         if (data.getLabels() != null) {
             entity.labels.addAll(data.getLabels());
@@ -134,32 +134,32 @@ public class DashboardsResourceImpl implements DashboardsResource {
         bean.setDescription(entity.description);
         bean.setIsDefault(entity.isDefault);
         bean.setLabels(entity.labels);
-        bean.setWidgets(deserializeWidgets(entity.widgets));
+        bean.setTabs(deserializeTabs(entity.tabs));
         bean.setCreatedOn(Date.from(entity.createdOn));
         bean.setUpdatedOn(Date.from(entity.updatedOn));
         return bean;
     }
 
-    private String serializeWidgets(List<DashboardWidget> widgets) {
-        if (widgets == null || widgets.isEmpty()) {
+    private String serializeTabs(List<DashboardTab> tabs) {
+        if (tabs == null || tabs.isEmpty()) {
             return "[]";
         }
         try {
-            return objectMapper.writeValueAsString(widgets);
+            return objectMapper.writeValueAsString(tabs);
         } catch (JsonProcessingException e) {
-            throw new WebApplicationException("Failed to serialize widgets", 500);
+            throw new WebApplicationException("Failed to serialize tabs", 500);
         }
     }
 
-    private List<DashboardWidget> deserializeWidgets(String json) {
+    private List<DashboardTab> deserializeTabs(String json) {
         if (json == null || json.isBlank()) {
             return new ArrayList<>();
         }
         try {
-            return objectMapper.readValue(json, WIDGET_LIST_TYPE);
+            return objectMapper.readValue(json, TAB_LIST_TYPE);
         } catch (JsonProcessingException e) {
-            LOG.warnf("Failed to deserialize widgets JSON: %s", e.getMessage());
-            throw new WebApplicationException("Failed to deserialize dashboard widgets", 500);
+            LOG.warnf("Failed to deserialize tabs JSON: %s", e.getMessage());
+            throw new WebApplicationException("Failed to deserialize dashboard tabs", 500);
         }
     }
 }

--- a/app/src/main/resources/db/migration/V41__dashboard_add_tabs.sql
+++ b/app/src/main/resources/db/migration/V41__dashboard_add_tabs.sql
@@ -1,0 +1,7 @@
+-- Rename the widgets column to tabs
+ALTER TABLE dashboard RENAME COLUMN widgets TO tabs;
+
+-- Migrate existing data: wrap each widgets JSON array in a single "Default" tab
+UPDATE dashboard
+SET tabs = CONCAT('[{"id":"00000000-0000-0000-0000-000000000000","name":"Default","widgets":', COALESCE(tabs, '[]'), '}]')
+WHERE tabs IS NULL OR tabs NOT LIKE '[{"id"%';

--- a/app/src/main/resources/db/migration/V41__dashboard_add_tabs.sql
+++ b/app/src/main/resources/db/migration/V41__dashboard_add_tabs.sql
@@ -3,5 +3,4 @@ ALTER TABLE dashboard RENAME COLUMN widgets TO tabs;
 
 -- Migrate existing data: wrap each widgets JSON array in a single "Default" tab
 UPDATE dashboard
-SET tabs = CONCAT('[{"id":"00000000-0000-0000-0000-000000000000","name":"Default","widgets":', COALESCE(tabs, '[]'), '}]')
-WHERE tabs IS NULL OR tabs NOT LIKE '[{"id"%';
+SET tabs = CONCAT('[{"id":"00000000-0000-0000-0000-000000000000","name":"Default","widgets":', COALESCE(tabs, '[]'), '}]');

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -8065,7 +8065,7 @@
           "name",
           "labels",
           "isDefault",
-          "widgets",
+          "tabs",
           "createdOn",
           "updatedOn"
         ],
@@ -8095,13 +8095,6 @@
             "description": "Whether this is the default dashboard",
             "type": "boolean"
           },
-          "widgets": {
-            "description": "Widgets on this dashboard",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/DashboardWidget"
-            }
-          },
           "createdOn": {
             "format": "date-time",
             "description": "Creation timestamp",
@@ -8111,6 +8104,13 @@
             "format": "date-time",
             "description": "Last update timestamp",
             "type": "string"
+          },
+          "tabs": {
+            "description": "Tabs containing widgets on this dashboard",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DashboardTab"
+            }
           }
         }
       },
@@ -8119,7 +8119,7 @@
           "name",
           "labels",
           "isDefault",
-          "widgets"
+          "tabs"
         ],
         "type": "object",
         "properties": {
@@ -8142,11 +8142,11 @@
             "description": "Whether this is the default dashboard",
             "type": "boolean"
           },
-          "widgets": {
-            "description": "Widgets on this dashboard",
+          "tabs": {
+            "description": "Tabs containing widgets on this dashboard",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DashboardWidget"
+              "$ref": "#/components/schemas/DashboardTab"
             }
           }
         }
@@ -8561,6 +8561,31 @@
           },
           "limit": {
             "type": "integer"
+          }
+        }
+      },
+      "DashboardTab": {
+        "required": [
+          "id",
+          "name",
+          "widgets"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "Unique tab identifier",
+            "type": "string"
+          },
+          "name": {
+            "description": "Display name of the tab",
+            "type": "string"
+          },
+          "widgets": {
+            "description": "Widgets on this tab",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DashboardWidget"
+            }
           }
         }
       }

--- a/core/src/main/java/io/apitomy/axiom/core/entities/DashboardEntity.java
+++ b/core/src/main/java/io/apitomy/axiom/core/entities/DashboardEntity.java
@@ -29,8 +29,8 @@ public class DashboardEntity extends PanacheEntity {
     @Column(name = "is_default")
     public boolean isDefault;
 
-    @Column(columnDefinition = "TEXT")
-    public String widgets;
+    @Column(name = "tabs", columnDefinition = "TEXT")
+    public String tabs;
 
     @Column(name = "created_on", nullable = false)
     public Instant createdOn;

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -1812,13 +1812,19 @@ export interface DashboardWidget {
     layout: DashboardWidgetLayout;
 }
 
+export interface DashboardTab {
+    id: string;
+    name: string;
+    widgets: DashboardWidget[];
+}
+
 export interface Dashboard {
     id: number;
     name: string;
     description?: string;
     labels: string[];
     isDefault: boolean;
-    widgets: DashboardWidget[];
+    tabs: DashboardTab[];
     createdOn: string;
     updatedOn: string;
 }

--- a/ui/src/pages/DashboardViewPage.tsx
+++ b/ui/src/pages/DashboardViewPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { Responsive, WidthProvider } from "react-grid-layout";
 import type { Layout } from "react-grid-layout";
@@ -14,6 +14,9 @@ import {
     FormGroup,
     Label,
     PageSection,
+    Tab,
+    Tabs,
+    TabTitleText,
     TextArea,
     TextInput,
     Title,
@@ -28,6 +31,7 @@ import TimesIcon from "@patternfly/react-icons/dist/esm/icons/times-icon";
 import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
 import {
     type Dashboard,
+    type DashboardTab,
     type DashboardWidget,
     type NewDashboard,
     fetchDashboard,
@@ -59,34 +63,65 @@ export function DashboardViewPage() {
     const [editName, setEditName] = useState("");
     const [editDescription, setEditDescription] = useState("");
     const [editLabels, setEditLabels] = useState<string[]>([]);
-    const [editWidgets, setEditWidgets] = useState<DashboardWidget[]>([]);
+    const [editTabs, setEditTabs] = useState<DashboardTab[]>([]);
+
+    const [activeTabId, setActiveTabId] = useState<string>("");
+    const [renamingTabId, setRenamingTabId] = useState<string | null>(null);
+    const [renameValue, setRenameValue] = useState("");
+    const renameInputRef = useRef<HTMLInputElement>(null);
 
     const [addWidgetOpen, setAddWidgetOpen] = useState(false);
     const [deleteOpen, setDeleteOpen] = useState(false);
+    const [deleteTabTarget, setDeleteTabTarget] = useState<string | null>(null);
     const [refreshKey, setRefreshKey] = useState(0);
 
     const load = useCallback(() => {
         if (!dashboardId) return;
         setLoading(true);
         fetchDashboard(Number(dashboardId))
-            .then(setDashboard)
+            .then((d) => {
+                setDashboard(d);
+                if (d.tabs.length > 0 && !activeTabId) {
+                    setActiveTabId(d.tabs[0].id);
+                }
+            })
             .catch(console.error)
             .finally(() => setLoading(false));
     }, [dashboardId]);
 
     useEffect(() => { load(); }, [load]);
 
+    useEffect(() => {
+        if (renamingTabId && renameInputRef.current) {
+            renameInputRef.current.focus();
+            renameInputRef.current.select();
+        }
+    }, [renamingTabId]);
+
+    const activeTabs = isEditing ? editTabs : (dashboard?.tabs ?? []);
+    const activeTab = activeTabs.find(t => t.id === activeTabId);
+    const activeWidgets = activeTab?.widgets ?? [];
+    const activeLabels = isEditing ? editLabels : (dashboard?.labels ?? []);
+    const showTabBar = activeTabs.length > 1 || isEditing;
+
     const enterEditMode = () => {
         if (!dashboard) return;
         setEditName(dashboard.name);
         setEditDescription(dashboard.description ?? "");
         setEditLabels([...dashboard.labels]);
-        setEditWidgets(structuredClone(dashboard.widgets));
+        setEditTabs(structuredClone(dashboard.tabs));
+        if (dashboard.tabs.length > 0) {
+            setActiveTabId(dashboard.tabs[0].id);
+        }
         setIsEditing(true);
     };
 
     const cancelEdit = () => {
         setIsEditing(false);
+        setRenamingTabId(null);
+        if (dashboard && dashboard.tabs.length > 0) {
+            setActiveTabId(dashboard.tabs[0].id);
+        }
     };
 
     const handleSave = () => {
@@ -96,12 +131,19 @@ export function DashboardViewPage() {
             description: editDescription || undefined,
             labels: editLabels,
             isDefault: dashboard.isDefault,
-            widgets: editWidgets,
+            tabs: editTabs,
         };
         updateDashboard(dashboard.id, data)
             .then((updated) => {
                 setDashboard(updated);
                 setIsEditing(false);
+                setRenamingTabId(null);
+                if (updated.tabs.length > 0) {
+                    const stillExists = updated.tabs.find(t => t.id === activeTabId);
+                    if (!stillExists) {
+                        setActiveTabId(updated.tabs[0].id);
+                    }
+                }
             })
             .catch(console.error);
     };
@@ -120,7 +162,7 @@ export function DashboardViewPage() {
             description: dashboard.description,
             labels: dashboard.labels,
             isDefault: true,
-            widgets: dashboard.widgets,
+            tabs: dashboard.tabs,
         };
         updateDashboard(dashboard.id, data)
             .then(setDashboard)
@@ -141,33 +183,95 @@ export function DashboardViewPage() {
                 h: entry.defaultSize.h,
             },
         };
-        setEditWidgets(prev => [...prev, newWidget]);
+        setEditTabs(prev => prev.map(t =>
+            t.id === activeTabId
+                ? { ...t, widgets: [...t.widgets, newWidget] }
+                : t
+        ));
         setAddWidgetOpen(false);
     };
 
     const handleRemoveWidget = (widgetId: string) => {
-        setEditWidgets(prev => prev.filter(w => w.id !== widgetId));
+        setEditTabs(prev => prev.map(t =>
+            t.id === activeTabId
+                ? { ...t, widgets: t.widgets.filter(w => w.id !== widgetId) }
+                : t
+        ));
     };
 
     const handleWidgetConfigChange = (widgetId: string, config: Record<string, unknown>) => {
-        setEditWidgets(prev => prev.map(w =>
-            w.id === widgetId ? { ...w, config } : w
+        setEditTabs(prev => prev.map(t =>
+            t.id === activeTabId
+                ? { ...t, widgets: t.widgets.map(w => w.id === widgetId ? { ...w, config } : w) }
+                : t
         ));
     };
 
     const onGridLayoutChange = (layout: Layout[]) => {
-        setEditWidgets(prev => prev.map(w => {
-            const item = layout.find(l => l.i === w.id);
-            if (!item) return w;
+        setEditTabs(prev => prev.map(t => {
+            if (t.id !== activeTabId) return t;
             return {
-                ...w,
-                layout: { x: item.x, y: item.y, w: item.w, h: item.h },
+                ...t,
+                widgets: t.widgets.map(w => {
+                    const item = layout.find(l => l.i === w.id);
+                    if (!item) return w;
+                    return {
+                        ...w,
+                        layout: { x: item.x, y: item.y, w: item.w, h: item.h },
+                    };
+                }),
             };
         }));
     };
 
-    const activeWidgets = isEditing ? editWidgets : (dashboard?.widgets ?? []);
-    const activeLabels = isEditing ? editLabels : (dashboard?.labels ?? []);
+    // Tab management (edit mode)
+    const handleAddTab = () => {
+        const newTab: DashboardTab = {
+            id: crypto.randomUUID(),
+            name: "New Tab",
+            widgets: [],
+        };
+        setEditTabs(prev => [...prev, newTab]);
+        setActiveTabId(newTab.id);
+    };
+
+    const handleDeleteTab = (tabId: string) => {
+        const tab = editTabs.find(t => t.id === tabId);
+        if (tab && tab.widgets.length > 0) {
+            setDeleteTabTarget(tabId);
+            return;
+        }
+        removeTab(tabId);
+    };
+
+    const removeTab = (tabId: string) => {
+        setEditTabs(prev => {
+            const updated = prev.filter(t => t.id !== tabId);
+            if (activeTabId === tabId && updated.length > 0) {
+                setActiveTabId(updated[0].id);
+            }
+            return updated;
+        });
+        setDeleteTabTarget(null);
+    };
+
+    const startRenameTab = (tabId: string) => {
+        const tab = editTabs.find(t => t.id === tabId);
+        if (!tab) return;
+        setRenamingTabId(tabId);
+        setRenameValue(tab.name);
+    };
+
+    const commitRename = () => {
+        if (!renamingTabId) return;
+        const trimmed = renameValue.trim();
+        if (trimmed) {
+            setEditTabs(prev => prev.map(t =>
+                t.id === renamingTabId ? { ...t, name: trimmed } : t
+            ));
+        }
+        setRenamingTabId(null);
+    };
 
     const gridItems: Layout[] = activeWidgets.map(w => {
         const entry = getWidget(w.type);
@@ -314,6 +418,81 @@ export function DashboardViewPage() {
                 </div>
             )}
 
+            {/* Tab bar */}
+            {showTabBar && (
+                <Flex alignItems={{ default: "alignItemsCenter" }}
+                      style={{ marginBottom: "16px" }}>
+                    <FlexItem grow={{ default: "grow" }}>
+                        <Tabs activeKey={activeTabId}
+                              onSelect={(_e, tabId) => setActiveTabId(String(tabId))}>
+                            {activeTabs.map(tab => (
+                                <Tab key={tab.id} eventKey={tab.id}
+                                     title={
+                                         <Flex alignItems={{ default: "alignItemsCenter" }}
+                                               gap={{ default: "gapSm" }}
+                                               flexWrap={{ default: "nowrap" }}>
+                                             <FlexItem>
+                                                 {isEditing && renamingTabId === tab.id ? (
+                                                     <input
+                                                         ref={renamingTabId === tab.id ? renameInputRef : undefined}
+                                                         value={renameValue}
+                                                         onChange={(e) => setRenameValue(e.target.value)}
+                                                         onBlur={commitRename}
+                                                         onKeyDown={(e) => {
+                                                             if (e.key === "Enter") commitRename();
+                                                             if (e.key === "Escape") setRenamingTabId(null);
+                                                         }}
+                                                         style={{
+                                                             border: "1px solid var(--pf-t--global--border--color--default)",
+                                                             borderRadius: "3px",
+                                                             padding: "2px 6px",
+                                                             fontSize: "inherit",
+                                                             width: `${Math.max(renameValue.length, 4) + 2}ch`,
+                                                         }}
+                                                         onClick={(e) => e.stopPropagation()}
+                                                     />
+                                                 ) : (
+                                                     <TabTitleText>
+                                                         <span onDoubleClick={(e) => {
+                                                             if (isEditing) {
+                                                                 e.stopPropagation();
+                                                                 startRenameTab(tab.id);
+                                                             }
+                                                         }}>
+                                                             {tab.name}
+                                                         </span>
+                                                     </TabTitleText>
+                                                 )}
+                                             </FlexItem>
+                                             {isEditing && activeTabs.length > 1 && (
+                                                 <FlexItem>
+                                                     <Button variant="plain" size="sm"
+                                                             aria-label={`Delete tab ${tab.name}`}
+                                                             style={{ padding: 0 }}
+                                                             onClick={(e) => {
+                                                                 e.stopPropagation();
+                                                                 handleDeleteTab(tab.id);
+                                                             }}>
+                                                         <TimesIcon />
+                                                     </Button>
+                                                 </FlexItem>
+                                             )}
+                                         </Flex>
+                                     }
+                                />
+                            ))}
+                        </Tabs>
+                    </FlexItem>
+                    {isEditing && (
+                        <FlexItem>
+                            <Button variant="link" icon={<PlusCircleIcon />}
+                                    onClick={handleAddTab}>
+                                Add Tab
+                            </Button>
+                        </FlexItem>
+                    )}
+                </Flex>
+            )}
 
             {/* Widget grid */}
             {activeWidgets.length === 0 ? (
@@ -326,6 +505,7 @@ export function DashboardViewPage() {
                 </EmptyState>
             ) : (
                 <ResponsiveGridLayout
+                    key={activeTabId}
                     className="layout"
                     layouts={{ lg: gridItems }}
                     breakpoints={{ lg: 1200, md: 996, sm: 768 }}
@@ -367,6 +547,17 @@ export function DashboardViewPage() {
                 onCancel={() => setDeleteOpen(false)}
             >
                 Permanently delete <strong>{dashboard.name}</strong> and all its widgets?
+            </ConfirmDeleteModal>
+
+            <ConfirmDeleteModal
+                isOpen={deleteTabTarget !== null}
+                title="Delete Tab"
+                onConfirm={() => deleteTabTarget && removeTab(deleteTabTarget)}
+                onCancel={() => setDeleteTabTarget(null)}
+            >
+                This tab contains widgets. Delete <strong>
+                    {editTabs.find(t => t.id === deleteTabTarget)?.name}
+                </strong> and all its widgets?
             </ConfirmDeleteModal>
         </PageSection>
     );

--- a/ui/src/pages/DashboardsPage.tsx
+++ b/ui/src/pages/DashboardsPage.tsx
@@ -58,7 +58,7 @@ export function DashboardsPage() {
             description: newDescription || undefined,
             labels: newLabels,
             isDefault: dashboards.length === 0,
-            widgets: [],
+            tabs: [{ id: crypto.randomUUID(), name: "Default", widgets: [] }],
         };
         createDashboard(data)
             .then((created) => {
@@ -79,7 +79,7 @@ export function DashboardsPage() {
             description: dashboard.description,
             labels: dashboard.labels,
             isDefault: true,
-            widgets: dashboard.widgets,
+            tabs: dashboard.tabs,
         };
         updateDashboard(dashboard.id, data).then(load).catch(console.error);
     };
@@ -160,7 +160,7 @@ export function DashboardsPage() {
                                         ))}
                                         {d.labels.length === 0 && "—"}
                                     </Td>
-                                    <Td>{d.widgets.length}</Td>
+                                    <Td>{d.tabs.reduce((n, t) => n + t.widgets.length, 0)}</Td>
                                     <Td>{formatDate(d.updatedOn)}</Td>
                                     <Td>
                                         <Flex gap={{ default: "gapSm" }}


### PR DESCRIPTION
## Summary

- Adds `DashboardTab` schema to the OpenAPI spec and replaces the flat `widgets` array on
  `Dashboard` / `NewDashboard` with a `tabs` array, each tab containing its own widgets
- Includes Flyway migration (V41) to rename the `widgets` column to `tabs` and wrap existing
  widget data in a single "Default" tab for seamless migration
- Updates the backend entity and REST resource serialization to handle tabs
- Adds a PatternFly tab bar to DashboardViewPage with full CRUD in edit mode: create, rename
  (double-click), and delete tabs (with confirmation when tab has widgets)
- Single-tab dashboards hide the tab bar entirely, preserving the current visual experience

## Related Issue

Fixes #192

## Test Plan

- [ ] Build backend (`./build.sh`) — confirms codegen produces `DashboardTab` bean and all
      layers compile
- [ ] Start the app — verify V41 Flyway migration runs cleanly
- [ ] Existing dashboards load correctly (single tab, no tab bar visible)
- [ ] Create a new dashboard — starts with one "Default" tab
- [ ] Edit mode: add a second tab — tab bar appears with "Add Tab" button
- [ ] Switch between tabs, add/remove widgets per tab independently
- [ ] Double-click tab name to rename, press Enter to commit or Escape to cancel
- [ ] Delete a tab without widgets (no confirmation)
- [ ] Delete a tab with widgets (confirmation modal appears)
- [ ] Save and reload — tabs and widgets persist correctly
- [ ] Dashboard list page shows total widget count across all tabs
- [ ] Delete dashboard still works