### PR TITLE
feat: add GitHub Copilot CLI as a pluggable AI engine

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -47,6 +47,10 @@
         </dependency>
         <dependency>
             <groupId>io.apitomy</groupId>
+            <artifactId>apitomy-axiom-engine-copilot</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.apitomy</groupId>
             <artifactId>apitomy-axiom-actors-human</artifactId>
         </dependency>
         <dependency>

--- a/app/src/main/java/io/apitomy/axiom/app/McpConfigGenerator.java
+++ b/app/src/main/java/io/apitomy/axiom/app/McpConfigGenerator.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.apitomy.axiom.actors.claudecode.ClaudeCodeMcpManager;
 import io.apitomy.axiom.core.entities.McpServerEntity;
 import io.apitomy.axiom.core.entities.ToolDefinitionEntity;
+import io.apitomy.axiom.engine.copilot.CopilotMcpManager;
 import io.apitomy.axiom.engine.opencode.OpenCodeMcpManager;
 import io.apitomy.axiom.engine.opencode.OpenCodeMcpManager.McpServerConfig;
 import jakarta.annotation.PostConstruct;
@@ -40,9 +41,10 @@ import java.util.Map;
  * dependencies. Subsequent invocations reuse the installed project.</p>
  *
  * <p>This class also implements {@link io.apitomy.axiom.engine.spi.AiEngineMcpManager}
- * for the Claude Code engine, via the {@link io.apitomy.axiom.actors.claudecode.ClaudeCodeMcpManager}
- * delegate pattern. On initialization, it registers itself as the MCP config delegate
- * for the active Claude Code engine.</p>
+ * for the Claude Code and Copilot engines, via the {@link io.apitomy.axiom.actors.claudecode.ClaudeCodeMcpManager}
+ * / {@link io.apitomy.axiom.engine.copilot.CopilotMcpManager} delegate pattern. On
+ * initialization, it registers itself as the MCP config delegate for both engines
+ * (both consume the same {@code mcpServers} JSON config format).</p>
  */
 @ApplicationScoped
 public class McpConfigGenerator {
@@ -65,6 +67,9 @@ public class McpConfigGenerator {
     @Inject
     OpenCodeMcpManager openCodeMcpManager;
 
+    @Inject
+    CopilotMcpManager copilotMcpManager;
+
     /** Lazily resolved path to the installed MCP server project directory. */
     private volatile Path mcpServerDir;
 
@@ -78,6 +83,9 @@ public class McpConfigGenerator {
 
         openCodeMcpManager.setDelegate(this::getMcpServersForOpenCode);
         LOG.info("Registered McpConfigGenerator as OpenCodeMcpManager delegate");
+
+        copilotMcpManager.setDelegate(this::generateMcpConfig);
+        LOG.info("Registered McpConfigGenerator as CopilotMcpManager delegate");
     }
 
     /** Prefix for script tools provided by the axiom-tools MCP server. */

--- a/app/src/main/java/io/apitomy/axiom/app/rest/SystemResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/SystemResourceImpl.java
@@ -47,6 +47,10 @@ public class SystemResourceImpl implements SystemResource {
             defaultValue = "anthropic/claude-sonnet-4-6,anthropic/claude-opus-4-6,anthropic/claude-haiku-4-5-20251001,openai/gpt-4o,openai/o3-mini")
     String openCodeAvailableModels;
 
+    @ConfigProperty(name = "axiom.copilot.available-models",
+            defaultValue = "claude-sonnet-5,claude-opus-5,claude-haiku-4.5,gpt-5.4,gpt-5-mini,auto")
+    String copilotAvailableModels;
+
     @Inject
     AiEngine aiEngine;
 
@@ -113,9 +117,11 @@ public class SystemResourceImpl implements SystemResource {
     @Override
     public List<String> listModels(String engine) {
         String engineType = (engine != null && !engine.isBlank()) ? engine : aiEngine.getType();
-        String models = "opencode".equals(engineType)
-                ? openCodeAvailableModels
-                : claudeAvailableModels;
+        String models = switch (engineType) {
+            case "opencode" -> openCodeAvailableModels;
+            case "copilot" -> copilotAvailableModels;
+            default -> claudeAvailableModels;
+        };
 
         return Arrays.stream(models.split(","))
                 .map(String::trim)

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -35,7 +35,7 @@ axiom.github.poll-interval=60s
 # GitHub token is now managed via Configuration > Secrets (GH_TOKEN)
 
 # --- AI Engine ---
-# Pluggable AI engine: "claude-code" or "opencode" (default: claude-code)
+# Pluggable AI engine: "claude-code", "opencode", or "copilot"
 axiom.ai-engine=claude-code
 
 # --- Manager ---
@@ -74,6 +74,16 @@ axiom.opencode.available-models=anthropic/claude-sonnet-4-6,anthropic/claude-opu
 axiom.opencode.max-steps=50
 # HTTP request timeout in seconds
 axiom.opencode.timeout-seconds=600
+
+# --- GitHub Copilot CLI ---
+# Path to the copilot CLI executable (defaults to "copilot" on PATH)
+# axiom.copilot.executable=/usr/local/bin/copilot
+# Model to use (optional, defaults to Copilot CLI's default/auto selection)
+# axiom.copilot.model=claude-sonnet-5
+# Available models for the UI model picker (comma-separated)
+axiom.copilot.available-models=claude-sonnet-5,claude-opus-5,claude-haiku-4.5,gpt-5.4,gpt-5-mini,auto
+# Subprocess timeout in seconds
+axiom.copilot.timeout-seconds=600
 
 # --- AI Assistant ---
 # Maximum concurrent interactive assistant sessions

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -71,7 +71,7 @@
           {
             "name": "engine",
             "in": "query",
-            "description": "Engine type to list models for (e.g. opencode, claude-code). Defaults to the active engine.",
+            "description": "Engine type to list models for (e.g. opencode, claude-code, copilot). Defaults to the active engine.",
             "required": false,
             "schema": {
               "type": "string"
@@ -100,7 +100,7 @@
           "System"
         ],
         "summary": "List available AI engines",
-        "description": "Returns the list of AI engine types that are available (e.g. claude-code, opencode).",
+        "description": "Returns the list of AI engine types that are available (e.g. claude-code, opencode, copilot).",
         "operationId": "listEngines",
         "responses": {
           "200": {
@@ -5067,7 +5067,7 @@
             "type": "string"
           },
           "engine": {
-            "description": "The active AI engine type (e.g. claude-code, opencode)",
+            "description": "The active AI engine type (e.g. claude-code, opencode, copilot)",
             "type": "string"
           },
           "features": {
@@ -5508,7 +5508,7 @@
             }
           },
           "engine": {
-            "description": "AI engine override for this action type (e.g. opencode, claude-code). When empty, the global default engine is used.",
+            "description": "AI engine override for this action type (e.g. opencode, claude-code, copilot). When empty, the global default engine is used.",
             "type": "string"
           },
           "maxSteps": {
@@ -5589,7 +5589,7 @@
             }
           },
           "engine": {
-            "description": "AI engine override for this action type (e.g. opencode, claude-code). When empty, the global default engine is used.",
+            "description": "AI engine override for this action type (e.g. opencode, claude-code, copilot). When empty, the global default engine is used.",
             "type": "string"
           },
           "maxSteps": {

--- a/docs/developer-guide/building-axiom.md
+++ b/docs/developer-guide/building-axiom.md
@@ -11,7 +11,7 @@ This guide covers how to build, run, and develop Axiom locally.
 | Java | 25+ | Backend compilation and runtime |
 | Maven | 3.9+ | Build system |
 | Node.js | 22+ | UI build (auto-installed by Maven in release builds) |
-| AI engine CLI | Latest | One of `claude` or `opencode` for AI features |
+| AI engine CLI | Latest | One of `claude`, `opencode`, or `copilot` for AI features |
 | API key | — | `ANTHROPIC_API_KEY` or provider-specific key |
 
 ---

--- a/docs/developer-guide/extending-axiom.md
+++ b/docs/developer-guide/extending-axiom.md
@@ -26,7 +26,7 @@ configuration.
 ## Adding an AI Engine
 
 An AI engine provides the ability to invoke an LLM for manager evaluations and task
-execution. Axiom ships with two engines: Claude Code and OpenCode.
+execution. Axiom ships with three engines: Claude Code, OpenCode, and GitHub Copilot CLI.
 
 ### Interface: `AiEngine`
 
@@ -34,7 +34,7 @@ Location: `engine/spi/src/main/java/io/apitomy/axiom/engine/spi/AiEngine.java`
 
 | Method | Purpose |
 |--------|---------|
-| `String getType()` | Engine identifier (e.g. `"claude-code"`, `"opencode"`) |
+| `String getType()` | Engine identifier (e.g. `"claude-code"`, `"opencode"`, `"copilot"`) |
 | `CompletableFuture<AiEngineResult> prompt(AiEngineConfig config, String prompt)` | Invoke the AI with a text prompt |
 | `CompletableFuture<AiEngineResult> promptWithSchema(AiEngineConfig config, String prompt, String jsonSchema)` | Invoke with structured output (JSON schema constraint) |
 | `List<AiEngineCheckResult> healthCheck()` | Startup health checks |
@@ -97,6 +97,8 @@ Register it via `AiEngineProvider.getMcpManager()`.
   subprocess-based, launches `claude` CLI
 - **OpenCode**: `engine/opencode/src/main/java/.../OpenCodeEngine.java` —
   HTTP client against a running OpenCode server
+- **GitHub Copilot CLI**: `engine/copilot/src/main/java/.../CopilotEngine.java` —
+  subprocess-based, launches `copilot` CLI
 
 ---
 
@@ -179,6 +181,8 @@ public class MyActor implements Actor {
   launches `claude` CLI as a subprocess
 - **OpenCode**: `engine/opencode/src/main/java/.../OpenCodeActor.java` — invokes
   OpenCode server via HTTP
+- **GitHub Copilot CLI**: `engine/copilot/src/main/java/.../CopilotActor.java` —
+  launches `copilot` CLI as a subprocess
 - **Human**: `actors/human/` — sends notifications, waits for human response
 
 ---

--- a/docs/developer-guide/how-to-contribute.md
+++ b/docs/developer-guide/how-to-contribute.md
@@ -37,6 +37,7 @@ When making changes, use this guide to find the right module:
 | Manager behavior | `manager/` |
 | Claude Code engine/actor | `actors/claude-code/` |
 | OpenCode engine/actor | `engine/opencode/` |
+| GitHub Copilot CLI engine/actor | `engine/copilot/` |
 | GitHub polling | `events/github/` |
 | Jira polling | `events/jira/` |
 | Pipeline orchestration | `app/` (PipelineOrchestrator, TaskExecutionService, etc.) |

--- a/docs/developer-guide/stack-and-architecture.md
+++ b/docs/developer-guide/stack-and-architecture.md
@@ -18,7 +18,7 @@ and runtime architecture.
 | Build (frontend) | Vite 6.4 |
 | Build (backend) | Maven 3.9+ |
 | API | Contract-first OpenAPI with Apitomy Codegen |
-| AI Engines | Claude Code CLI, OpenCode (pluggable) |
+| AI Engines | Claude Code CLI, OpenCode, GitHub Copilot CLI (pluggable) |
 
 ---
 
@@ -32,7 +32,8 @@ apitomy-axiom/
 ├── core/                Domain entities, lifecycle state machine, services
 ├── engine/
 │   ├── spi/             AI engine abstraction (AiEngine, AiEngineRegistry)
-│   └── opencode/        OpenCode engine + actor implementation
+│   ├── opencode/        OpenCode engine + actor implementation
+│   └── copilot/         GitHub Copilot CLI engine + actor implementation
 ├── manager/             AI Manager — event triage and decision-making
 ├── actors/
 │   ├── spi/             Actor interface (Actor, ActorContext, TaskResult)
@@ -60,10 +61,10 @@ common/api ◄── core ◄── manager
               engine/spi ◄┘
                  ▲
                  │
-           ┌─────┴──────┐
-     engine/opencode  actors/claude-code
-                         ▲
-                         │
+       ┌─────────┼──────────┐
+engine/opencode  engine/copilot  actors/claude-code
+                                       ▲
+                                       │
                     actors/spi ◄── actors/human
                          ▲
                          │

--- a/docs/getting-started/configuring-axiom.md
+++ b/docs/getting-started/configuring-axiom.md
@@ -41,7 +41,7 @@ Axiom supports multiple AI engines. Set the active engine with:
 
 | Property | Default | Description |
 |----------|---------|-------------|
-| `axiom.ai-engine` | `claude-code` | AI engine to use (`claude-code` or `opencode`) |
+| `axiom.ai-engine` | `claude-code` | AI engine to use (`claude-code`, `opencode`, or `copilot`) |
 
 #### Claude Code Settings
 
@@ -61,6 +61,14 @@ Axiom supports multiple AI engines. Set the active engine with:
 | `axiom.opencode.server.port` | `4096` | OpenCode server port |
 | `axiom.opencode.max-steps` | `50` | Maximum agent steps per task |
 | `axiom.opencode.timeout-seconds` | `600` | HTTP request timeout |
+
+#### GitHub Copilot CLI Settings
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `axiom.copilot.executable` | `copilot` | Path to the Copilot CLI binary |
+| `axiom.copilot.model` | *(engine default)* | AI model override |
+| `axiom.copilot.timeout-seconds` | `600` | Subprocess timeout |
 
 ### Manager
 

--- a/docs/getting-started/running-axiom.md
+++ b/docs/getting-started/running-axiom.md
@@ -13,6 +13,7 @@ downloads and runs the latest release automatically.
 |--------|-------------|--------|---------|
 | Claude Code | `claude-code` (default) | `claude` | `npm install -g @anthropic-ai/claude-code` |
 | OpenCode | `opencode` | `opencode` | `curl -fsSL https://opencode.ai/install \| bash` |
+| GitHub Copilot CLI | `copilot` | `copilot` | `npm install -g @github/copilot` |
 
 - An API key for your LLM provider (e.g., `ANTHROPIC_API_KEY` environment variable)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,14 +6,14 @@ long-lived projects around them, and delegates work to human and AI actors.
 ## Key Features
 
 - **AI-Powered Triage** — an AI Manager triages incoming events and decides what actions to take
-- **Human + AI Actors** — pluggable actor system supports Claude Code, OpenCode, and human actors
+- **Human + AI Actors** — pluggable actor system supports Claude Code, OpenCode, GitHub Copilot CLI, and human actors
 - **Project Lifecycle** — long-lived projects track work from triage through completion
 - **Event Sources** — watches GitHub and Jira repositories via webhooks or polling
 - **Scheduled Jobs** — CRON-style automation with AI actor or script execution modes
 - **Web Dashboard** — React + PatternFly UI with real-time SSE updates
 - **AI Assistant** — interactive conversational interface with customizable session templates,
   real-time tool permission management, and plan mode
-- **Pluggable AI Engines** — swap between Claude Code CLI and OpenCode without code changes
+- **Pluggable AI Engines** — swap between Claude Code CLI, OpenCode, and GitHub Copilot CLI without code changes
 
 ## Quick Links
 
@@ -29,7 +29,7 @@ long-lived projects around them, and delegates work to human and AI actors.
 | Frontend | TypeScript / React 19 / PatternFly 6 |
 | Database | H2 (in-memory dev, file-based prod) |
 | Migrations | Flyway (automatic on startup) |
-| AI Engines | Claude Code CLI, OpenCode (pluggable) |
+| AI Engines | Claude Code CLI, OpenCode, GitHub Copilot CLI (pluggable) |
 | API | Contract-first OpenAPI + Apitomy Codegen |
 
 ## Community

--- a/docs/user-guide/concepts.md
+++ b/docs/user-guide/concepts.md
@@ -138,7 +138,7 @@ automatically copied to the new project.
 ### AI Manager
 
 The Manager receives events and produces structured decisions. It uses the configured AI
-engine (Claude Code or OpenCode) to analyze each event in context.
+engine (Claude Code, OpenCode, or GitHub Copilot CLI) to analyze each event in context.
 
 The Manager's behavior is controlled by two editable templates:
 
@@ -285,7 +285,7 @@ duration. Task statuses:
 
 An Actor is an entity that performs tasks. Axiom supports two types:
 
-**AI Agent** — uses the configured AI engine (Claude Code or OpenCode) as a subprocess.
+**AI Agent** — uses the configured AI engine (Claude Code, OpenCode, or GitHub Copilot CLI) as a subprocess.
 The agent receives the action type's prompt template, runs with the allowed tools, and
 reports back with results.
 
@@ -495,6 +495,7 @@ for Manager evaluations and actor task execution:
 |--------|-----|-------------|
 | **Claude Code** | `claude` | Anthropic's Claude Code CLI (default) |
 | **OpenCode** | `opencode` | OpenCode CLI with multi-provider support |
+| **GitHub Copilot CLI** | `copilot` | GitHub's Copilot CLI |
 
 Individual action types can override the global engine and model selection, allowing you
 to use different models for different types of work.
@@ -588,7 +589,7 @@ The diagram below shows how the concepts relate:
 │    ├─ allowed tools ────────┼──► Tools / @Toolsets / MCP Servers     │
 │    └─ environment ──────────┼──► Secrets                             │
 │                             │                                       │
-│                         AI Engine (Claude Code / OpenCode)           │
+│                    AI Engine (Claude Code / OpenCode / Copilot)      │
 │                                                                     │
 ├─────────────────────────────────────────────────────────────────────┤
 │                   EVENT-DRIVEN AUTOMATION                            │
@@ -605,7 +606,7 @@ The diagram below shows how the concepts relate:
 │                             Tools / @Toolsets / MCP Servers ◄──┘     │
 │                             Secrets ◄──────────────────────────┘     │
 │                                                                     │
-│                         AI Engine (Claude Code / OpenCode)           │
+│                    AI Engine (Claude Code / OpenCode / Copilot)      │
 │                                                                     │
 ├─────────────────────────────────────────────────────────────────────┤
 │                      SCHEDULED JOBS                                  │
@@ -616,7 +617,7 @@ The diagram below shows how the concepts relate:
 │    ├─ allowed tools ───────┼──► Tools / @Toolsets / MCP Servers       │
 │    └─ environment ─────────┼──► Secrets                               │
 │                            │                                         │
-│                        AI Engine (Claude Code / OpenCode)             │
+│                   AI Engine (Claude Code / OpenCode / Copilot)        │
 └─────────────────────────────────────────────────────────────────────┘
 ```
 

--- a/engine/copilot/pom.xml
+++ b/engine/copilot/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.apitomy</groupId>
+        <artifactId>apitomy-axiom</artifactId>
+        <version>2.5.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>apitomy-axiom-engine-copilot</artifactId>
+    <name>Apitomy Axiom - Engine - GitHub Copilot CLI</name>
+    <description>GitHub Copilot CLI AI engine implementation</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.apitomy</groupId>
+            <artifactId>apitomy-axiom-engine-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.apitomy</groupId>
+            <artifactId>apitomy-axiom-actors-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/engine/copilot/src/main/java/io/apitomy/axiom/engine/copilot/CopilotActor.java
+++ b/engine/copilot/src/main/java/io/apitomy/axiom/engine/copilot/CopilotActor.java
@@ -1,0 +1,136 @@
+package io.apitomy.axiom.engine.copilot;
+
+import io.apitomy.axiom.actors.spi.Actor;
+import io.apitomy.axiom.actors.spi.ActorContext;
+import io.apitomy.axiom.actors.spi.TaskResult;
+import io.apitomy.axiom.core.entities.TaskEntity;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Actor implementation that executes tasks by launching the GitHub Copilot
+ * CLI ({@code copilot}) as a subprocess. Each task gets its own subprocess,
+ * scoped to the project's working directory.
+ */
+@ApplicationScoped
+public class CopilotActor implements Actor {
+
+    private static final Logger LOG = Logger.getLogger(CopilotActor.class);
+
+    @ConfigProperty(name = "axiom.copilot.executable", defaultValue = "copilot")
+    String executable;
+
+    @ConfigProperty(name = "axiom.copilot.model")
+    Optional<String> model;
+
+    @ConfigProperty(name = "axiom.copilot.timeout-seconds", defaultValue = "600")
+    int timeoutSeconds;
+
+    private final Map<Long, CopilotSubprocess> runningProcesses = new ConcurrentHashMap<>();
+
+    @Override
+    public String getType() {
+        return "copilot";
+    }
+
+    @Override
+    public CompletableFuture<TaskResult> execute(TaskEntity task, ActorContext context) {
+        LOG.infof("Executing task %d (action: %s) via GitHub Copilot CLI", task.id, task.actionType);
+
+        String prompt = buildPrompt(task, context);
+        if (context.getSystemPrompt() != null && !context.getSystemPrompt().isBlank()) {
+            prompt = context.getSystemPrompt() + "\n\n" + prompt;
+        }
+
+        CopilotCommandBuilder cmdBuilder = CopilotCommandBuilder
+                .fromContext(prompt, context)
+                .executable(executable);
+
+        // Per-action-type model takes priority over the global default
+        if (context.getModel() != null && !context.getModel().isBlank()) {
+            cmdBuilder.model(context.getModel());
+        } else {
+            model.ifPresent(cmdBuilder::model);
+        }
+
+        List<String> command = cmdBuilder.build();
+
+        java.io.File workDir = context.getWorkingDirectory() != null
+                ? context.getWorkingDirectory().toFile() : null;
+
+        CopilotSubprocess subprocess = new CopilotSubprocess(
+                command,
+                workDir,
+                context.getEnvironment() != null ? context.getEnvironment() : Map.of(),
+                Duration.ofSeconds(timeoutSeconds)
+        );
+
+        runningProcesses.put(task.id, subprocess);
+
+        return subprocess.execute()
+                .thenApply(result -> {
+                    runningProcesses.remove(task.id);
+                    return toTaskResult(result);
+                })
+                .exceptionally(throwable -> {
+                    runningProcesses.remove(task.id);
+                    LOG.errorf(throwable, "Task %d execution failed", task.id);
+                    return TaskResult.failure("Execution error: " + throwable.getMessage()).build();
+                });
+    }
+
+    @Override
+    public void cancel(TaskEntity task) {
+        CopilotSubprocess subprocess = runningProcesses.remove(task.id);
+        if (subprocess != null) {
+            LOG.infof("Cancelling task %d", task.id);
+            subprocess.kill();
+        }
+    }
+
+    /**
+     * Builds the prompt for Copilot. If the context has a resolved prompt template,
+     * uses it. Otherwise falls back to a generic prompt.
+     */
+    private String buildPrompt(TaskEntity task, ActorContext context) {
+        String template = context.getPromptTemplate();
+        if (template != null && !template.isBlank()) {
+            return template;
+        }
+
+        StringBuilder prompt = new StringBuilder();
+        prompt.append("You are performing the following action: ").append(task.actionType).append("\n\n");
+        if (task.input != null && !task.input.isEmpty()) {
+            prompt.append("Task context:\n").append(task.input).append("\n");
+        }
+        return prompt.toString();
+    }
+
+    private TaskResult toTaskResult(CopilotResult result) {
+        if (result.isSuccess()) {
+            return TaskResult.success(result.result())
+                    .sessionId(result.sessionId())
+                    .costUsd(result.costUsd())
+                    .inputTokens(result.inputTokens())
+                    .outputTokens(result.outputTokens())
+                    .executionLog(result.executionLog())
+                    .build();
+        } else {
+            return TaskResult.failure(result.result())
+                    .sessionId(result.sessionId())
+                    .costUsd(result.costUsd())
+                    .inputTokens(result.inputTokens())
+                    .outputTokens(result.outputTokens())
+                    .executionLog(result.executionLog())
+                    .build();
+        }
+    }
+}

--- a/engine/copilot/src/main/java/io/apitomy/axiom/engine/copilot/CopilotCommandBuilder.java
+++ b/engine/copilot/src/main/java/io/apitomy/axiom/engine/copilot/CopilotCommandBuilder.java
@@ -1,0 +1,160 @@
+package io.apitomy.axiom.engine.copilot;
+
+import io.apitomy.axiom.actors.spi.ActorContext;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Builds the command line for launching a GitHub Copilot CLI ({@code copilot})
+ * subprocess in non-interactive mode.
+ *
+ * <p>Note: Copilot CLI's built-in tool names (e.g. {@code view}, {@code bash},
+ * {@code edit}) do not match the Claude Code-style tool identifiers used
+ * elsewhere in Axiom (e.g. {@code Read}, {@code Bash(git log *)}). Passing an
+ * unrecognized name to {@code --allow-tool}/{@code --available-tools} is
+ * harmless (Copilot logs a warning and ignores it), so when an action type
+ * restricts tools we still forward the base names best-effort, but we always
+ * additionally allow all tools so that the subprocess never blocks waiting
+ * for interactive confirmation. See
+ * https://github.com/Apitomy/apitomy-axiom/issues/224 for the tracked
+ * follow-up on first-class Copilot tool-name mapping.</p>
+ */
+public class CopilotCommandBuilder {
+
+    private String executable = "copilot";
+    private String prompt;
+    private String model;
+    private List<String> allowedTools = List.of();
+    private List<String> disallowedTools = List.of();
+    private String sessionId;
+    private Path mcpConfigFile;
+
+    /**
+     * Creates a builder from an ActorContext and prompt.
+     *
+     * @param prompt the prompt to send to Copilot
+     * @param context the actor context
+     * @return a pre-configured builder
+     */
+    public static CopilotCommandBuilder fromContext(String prompt, ActorContext context) {
+        CopilotCommandBuilder builder = new CopilotCommandBuilder();
+        builder.prompt = prompt;
+        builder.allowedTools = context.getAllowedTools();
+        builder.disallowedTools = context.getDisallowedTools();
+        builder.mcpConfigFile = context.getMcpConfigFile();
+        return builder;
+    }
+
+    public CopilotCommandBuilder executable(String executable) {
+        this.executable = executable;
+        return this;
+    }
+
+    public CopilotCommandBuilder prompt(String prompt) {
+        this.prompt = prompt;
+        return this;
+    }
+
+    public CopilotCommandBuilder model(String model) {
+        this.model = model;
+        return this;
+    }
+
+    public CopilotCommandBuilder allowedTools(List<String> allowedTools) {
+        this.allowedTools = allowedTools;
+        return this;
+    }
+
+    public CopilotCommandBuilder disallowedTools(List<String> disallowedTools) {
+        this.disallowedTools = disallowedTools;
+        return this;
+    }
+
+    public CopilotCommandBuilder sessionId(String sessionId) {
+        this.sessionId = sessionId;
+        return this;
+    }
+
+    public CopilotCommandBuilder mcpConfigFile(Path mcpConfigFile) {
+        this.mcpConfigFile = mcpConfigFile;
+        return this;
+    }
+
+    /**
+     * Builds the command line as a list of strings suitable for ProcessBuilder.
+     *
+     * @return the command line arguments
+     */
+    public List<String> build() {
+        List<String> cmd = new ArrayList<>();
+        cmd.add(executable);
+        cmd.add("-p");
+        cmd.add(prompt);
+
+        cmd.add("--output-format");
+        cmd.add("json");
+        cmd.add("--no-color");
+
+        // Disable Copilot's own built-in GitHub MCP server — Axiom manages
+        // GitHub integration separately and this keeps the available tool
+        // surface predictable/consistent with the other engines.
+        cmd.add("--disable-builtin-mcps");
+
+        if (model != null) {
+            cmd.add("--model");
+            cmd.add(model);
+        }
+
+        if (allowedTools != null && !allowedTools.isEmpty()) {
+            String baseTools = deriveBaseToolNames(allowedTools);
+            for (String tool : baseTools.split(",")) {
+                cmd.add("--allow-tool");
+                cmd.add(tool);
+            }
+        }
+        // Non-interactive mode requires blanket tool approval; fine-grained
+        // restriction above is best-effort (see class Javadoc).
+        cmd.add("--allow-all-tools");
+
+        if (disallowedTools != null && !disallowedTools.isEmpty()) {
+            for (String tool : disallowedTools) {
+                cmd.add("--deny-tool");
+                cmd.add(tool);
+            }
+        }
+
+        if (sessionId != null) {
+            cmd.add("--session-id");
+            cmd.add(sessionId);
+        }
+
+        if (mcpConfigFile != null) {
+            cmd.add("--additional-mcp-config");
+            cmd.add("@" + mcpConfigFile.toAbsolutePath());
+        }
+
+        return cmd;
+    }
+
+    /**
+     * Derives comma-separated base tool names from a list of allowed tool
+     * patterns, stripping any parenthesized pattern suffix
+     * (e.g. {@code "Bash(git log *)"} becomes {@code "Bash"}) and
+     * deduplicating the result.
+     *
+     * @param allowedTools the list of tool patterns
+     * @return comma-separated base tool names
+     */
+    public static String deriveBaseToolNames(List<String> allowedTools) {
+        return allowedTools.stream()
+                .map(tool -> {
+                    int parenIdx = tool.indexOf('(');
+                    return parenIdx > 0 ? tool.substring(0, parenIdx) : tool;
+                })
+                .distinct()
+                .collect(Collectors.joining(","));
+    }
+}

--- a/engine/copilot/src/main/java/io/apitomy/axiom/engine/copilot/CopilotEngine.java
+++ b/engine/copilot/src/main/java/io/apitomy/axiom/engine/copilot/CopilotEngine.java
@@ -1,0 +1,184 @@
+package io.apitomy.axiom.engine.copilot;
+
+import io.apitomy.axiom.actors.spi.ActorContext;
+import io.apitomy.axiom.engine.spi.AiEngine;
+import io.apitomy.axiom.engine.spi.AiEngineCheckResult;
+import io.apitomy.axiom.engine.spi.AiEngineConfig;
+import io.apitomy.axiom.engine.spi.AiEngineMcpManager;
+import io.apitomy.axiom.engine.spi.AiEngineProvider;
+import io.apitomy.axiom.engine.spi.AiEngineResult;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Typed;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * GitHub Copilot CLI ({@code copilot}) implementation of the {@link AiEngine}
+ * SPI. Wraps {@link CopilotCommandBuilder} and {@link CopilotSubprocess} to
+ * provide engine-agnostic prompt execution.
+ *
+ * <p>Also serves as the {@link AiEngineProvider} for CDI discovery — the
+ * {@link io.apitomy.axiom.engine.spi.AiEngineProducer} finds this bean via
+ * the provider interface to avoid CDI bean type recursion.</p>
+ */
+@ApplicationScoped
+@Typed({CopilotEngine.class, AiEngineProvider.class})
+public class CopilotEngine implements AiEngine, AiEngineProvider {
+
+    @ConfigProperty(name = "axiom.copilot.executable", defaultValue = "copilot")
+    String executable;
+
+    @Inject
+    CopilotMcpManager mcpManager;
+
+    @Override
+    public String getType() {
+        return "copilot";
+    }
+
+    @Override
+    public CompletableFuture<AiEngineResult> prompt(AiEngineConfig config, String prompt) {
+        return executeInternal(config, prompt, null);
+    }
+
+    @Override
+    public CompletableFuture<AiEngineResult> promptWithSchema(AiEngineConfig config,
+                                                               String prompt,
+                                                               String jsonSchema) {
+        return executeInternal(config, prompt, jsonSchema);
+    }
+
+    @Override
+    public List<AiEngineCheckResult> healthCheck() {
+        List<AiEngineCheckResult> results = new ArrayList<>();
+
+        try {
+            ProcessBuilder pb = new ProcessBuilder(executable, "-p",
+                    "Reply with exactly: AXIOM_OK", "--allow-all-tools",
+                    "--disable-builtin-mcps", "--output-format", "text", "-s");
+            pb.redirectErrorStream(true);
+            Process process = pb.start();
+
+            boolean completed = process.waitFor(30, TimeUnit.SECONDS);
+            if (!completed) {
+                process.destroyForcibly();
+                results.add(new AiEngineCheckResult(
+                        "GitHub Copilot CLI",
+                        "error",
+                        "GitHub Copilot CLI check timed out after 30 seconds. "
+                                + "Ensure that the 'copilot' command is on your PATH and that "
+                                + "you are logged in (run 'copilot login')."
+                ));
+                return results;
+            }
+
+            String output = new String(process.getInputStream().readAllBytes());
+            int exitCode = process.exitValue();
+
+            if (exitCode == 0 && output.contains("AXIOM_OK")) {
+                results.add(new AiEngineCheckResult(
+                        "GitHub Copilot CLI",
+                        "ok",
+                        "GitHub Copilot CLI is available and working."
+                ));
+            } else {
+                results.add(new AiEngineCheckResult(
+                        "GitHub Copilot CLI",
+                        "error",
+                        "GitHub Copilot CLI returned exit code " + exitCode + ". "
+                                + "Ensure that 'copilot' is installed, on your PATH, and that "
+                                + "you are authenticated (run 'copilot login'). "
+                                + "Install: npm install -g @github/copilot"
+                ));
+            }
+        } catch (Exception e) {
+            results.add(new AiEngineCheckResult(
+                    "GitHub Copilot CLI",
+                    "error",
+                    "GitHub Copilot CLI is not available: " + e.getMessage() + ". "
+                            + "Install GitHub Copilot CLI: npm install -g @github/copilot"
+            ));
+        }
+
+        return results;
+    }
+
+    private CompletableFuture<AiEngineResult> executeInternal(AiEngineConfig config,
+                                                               String prompt,
+                                                               String jsonSchema) {
+        ActorContext actorContext = ActorContext.builder()
+                .allowedTools(config.getAllowedTools())
+                .disallowedTools(config.getDisallowedTools())
+                .workingDirectory(config.getWorkingDirectory())
+                .mcpConfigFile(config.getMcpConfigFile())
+                .build();
+
+        String effectivePrompt = prompt;
+        if (config.getSystemPrompt() != null && !config.getSystemPrompt().isBlank()) {
+            effectivePrompt = config.getSystemPrompt() + "\n\n" + prompt;
+        }
+
+        if (jsonSchema != null) {
+            effectivePrompt = effectivePrompt
+                    + "\n\nIMPORTANT: You MUST respond with ONLY a valid JSON object "
+                    + "matching this JSON schema. No other text, no markdown formatting, "
+                    + "no code fences — just the raw JSON.\n\nJSON Schema:\n" + jsonSchema;
+        }
+
+        CopilotCommandBuilder cmdBuilder = CopilotCommandBuilder
+                .fromContext(effectivePrompt, actorContext)
+                .executable(executable);
+
+        if (config.getModel() != null) {
+            cmdBuilder.model(config.getModel());
+        }
+        if (config.getSessionId() != null) {
+            cmdBuilder.sessionId(config.getSessionId());
+        }
+
+        List<String> command = cmdBuilder.build();
+
+        java.io.File workDir = config.getWorkingDirectory() != null
+                ? config.getWorkingDirectory().toFile()
+                : null;
+
+        CopilotSubprocess subprocess = new CopilotSubprocess(
+                command, workDir,
+                config.getEnvironment() != null ? config.getEnvironment() : Map.of(),
+                Duration.ofSeconds(config.getTimeoutSeconds())
+        );
+
+        return subprocess.execute().thenApply(CopilotEngine::toEngineResult);
+    }
+
+    private static AiEngineResult toEngineResult(CopilotResult result) {
+        return new AiEngineResult(
+                result.result(),
+                result.sessionId(),
+                result.costUsd(),
+                result.inputTokens(),
+                result.outputTokens(),
+                result.isSuccess(),
+                result.executionLog()
+        );
+    }
+
+    // --- AiEngineProvider ---
+
+    @Override
+    public AiEngine getEngine() {
+        return this;
+    }
+
+    @Override
+    public AiEngineMcpManager getMcpManager() {
+        return mcpManager;
+    }
+}

--- a/engine/copilot/src/main/java/io/apitomy/axiom/engine/copilot/CopilotMcpManager.java
+++ b/engine/copilot/src/main/java/io/apitomy/axiom/engine/copilot/CopilotMcpManager.java
@@ -1,0 +1,69 @@
+package io.apitomy.axiom.engine.copilot;
+
+import io.apitomy.axiom.engine.spi.AiEngineMcpManager;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Typed;
+import org.jboss.logging.Logger;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Copilot CLI implementation of {@link AiEngineMcpManager}. Delegates to the
+ * existing {@code io.apitomy.axiom.app.McpConfigGenerator} to produce the
+ * {@code mcpServers} JSON config passed to the {@code copilot} CLI via
+ * {@code --additional-mcp-config @<file>}. The config format is identical to
+ * Claude Code's {@code --mcp-config} file, so the same generator is reused
+ * unchanged.
+ *
+ * <p>Note: This is a thin adapter. The actual MCP config generation logic
+ * remains in {@code McpConfigGenerator} (in the app module) and is injected
+ * here. This class exists to satisfy the engine SPI contract so that
+ * consumers can use {@link AiEngineMcpManager} without coupling to
+ * Copilot-specific code.</p>
+ */
+@ApplicationScoped
+@Typed(CopilotMcpManager.class)
+public class CopilotMcpManager implements AiEngineMcpManager {
+
+    private static final Logger LOG = Logger.getLogger(CopilotMcpManager.class);
+
+    /**
+     * Functional interface for the MCP config generation, allowing the app module's
+     * McpConfigGenerator to be injected without creating a circular dependency.
+     */
+    @FunctionalInterface
+    public interface McpConfigDelegate {
+        Path generateMcpConfig(Long taskId, Map<String, String> environment,
+                               List<String> allowedTools);
+    }
+
+    private volatile McpConfigDelegate delegate;
+
+    /**
+     * Sets the delegate that performs the actual MCP config generation.
+     * Called by the app module during initialization.
+     *
+     * @param delegate the MCP config generation delegate
+     */
+    public void setDelegate(McpConfigDelegate delegate) {
+        this.delegate = delegate;
+        LOG.infof("MCP config delegate set on CopilotMcpManager instance@%d",
+                System.identityHashCode(this));
+    }
+
+    @Override
+    public Path configureMcpServers(Long taskId, Map<String, String> environment,
+                                     List<String> allowedTools) {
+        if (delegate != null) {
+            Path result = delegate.generateMcpConfig(taskId, environment, allowedTools);
+            LOG.debugf("MCP config for task %d: %s", taskId, result);
+            return result;
+        }
+        LOG.warnf("MCP config delegate not set on CopilotMcpManager instance@%d — "
+                + "cannot generate MCP config for task %d",
+                System.identityHashCode(this), taskId);
+        return null;
+    }
+}

--- a/engine/copilot/src/main/java/io/apitomy/axiom/engine/copilot/CopilotResult.java
+++ b/engine/copilot/src/main/java/io/apitomy/axiom/engine/copilot/CopilotResult.java
@@ -1,0 +1,42 @@
+package io.apitomy.axiom.engine.copilot;
+
+/**
+ * Parsed result from a GitHub Copilot CLI invocation.
+ *
+ * <p>The {@code copilot} CLI with {@code --output-format json} streams NDJSON
+ * events; the final answer text is extracted from the last
+ * {@code assistant.message} event, and the session identifier and exit code
+ * come from the terminal {@code result} event.</p>
+ *
+ * <p>Copilot CLI does not currently expose a USD cost figure (it reports
+ * "premium requests" and AI-credit usage instead), so {@code costUsd} is
+ * always {@code null} for this engine.</p>
+ */
+public record CopilotResult(
+        String result,
+        String sessionId,
+        Double costUsd,
+        Long inputTokens,
+        Long outputTokens,
+        int exitCode,
+        String executionLog
+) {
+
+    /**
+     * Creates a result representing a failed execution.
+     *
+     * @param errorMessage the error description
+     * @param exitCode the process exit code
+     * @return a failed result
+     */
+    public static CopilotResult failed(String errorMessage, int exitCode) {
+        return new CopilotResult(errorMessage, null, null, null, null, exitCode, null);
+    }
+
+    /**
+     * @return true if the process exited successfully
+     */
+    public boolean isSuccess() {
+        return exitCode == 0;
+    }
+}

--- a/engine/copilot/src/main/java/io/apitomy/axiom/engine/copilot/CopilotSubprocess.java
+++ b/engine/copilot/src/main/java/io/apitomy/axiom/engine/copilot/CopilotSubprocess.java
@@ -1,0 +1,266 @@
+package io.apitomy.axiom.engine.copilot;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jboss.logging.Logger;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Manages a GitHub Copilot CLI ({@code copilot}) subprocess. Handles launching
+ * the process, reading NDJSON streaming output (one JSON object per line,
+ * {@code --output-format json}), extracting the final answer, and enforcing
+ * timeouts.
+ */
+public class CopilotSubprocess {
+
+    private static final Logger LOG = Logger.getLogger(CopilotSubprocess.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final List<String> command;
+    private final java.io.File workingDirectory;
+    private final Map<String, String> environment;
+    private final Duration timeout;
+
+    private volatile Process process;
+
+    // Accumulated from the NDJSON event stream during execution
+    private volatile String lastAssistantMessage;
+    private volatile Long lastOutputTokens;
+    private volatile String resultSessionId;
+    private volatile int resultExitCode = -1;
+    private volatile boolean sawResultEvent;
+
+    private final StringBuilder log = new StringBuilder();
+
+    public CopilotSubprocess(List<String> command, java.io.File workingDirectory,
+                              Map<String, String> environment, Duration timeout) {
+        this.command = command;
+        this.workingDirectory = workingDirectory;
+        this.environment = environment;
+        this.timeout = timeout;
+    }
+
+    /**
+     * Launches the subprocess and returns a future that completes with the result.
+     *
+     * @return a future containing the parsed Copilot result
+     */
+    public CompletableFuture<CopilotResult> execute() {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                return doExecute();
+            } catch (Exception e) {
+                LOG.errorf(e, "Copilot CLI subprocess failed");
+                return CopilotResult.failed("Subprocess error: " + e.getMessage(), -1);
+            }
+        });
+    }
+
+    /**
+     * Kills the running subprocess, if any.
+     */
+    public void kill() {
+        if (process != null && process.isAlive()) {
+            LOG.warn("Killing Copilot CLI subprocess");
+            destroyProcessTree();
+        }
+    }
+
+    private CopilotResult doExecute() throws IOException, InterruptedException {
+        Instant startTime = Instant.now();
+        LOG.infof("Launching Copilot CLI");
+
+        log.append("=== Command ===\n").append(String.join(" ",
+                command.stream().map(a -> a.contains(" ") ? "\"" + a + "\"" : a).toList()))
+                .append("\n\n=== Execution ===\n");
+
+        ProcessBuilder pb = new ProcessBuilder(command);
+        pb.redirectErrorStream(false);
+        pb.redirectInput(ProcessBuilder.Redirect.from(new java.io.File("/dev/null")));
+
+        if (workingDirectory != null) {
+            pb.directory(workingDirectory);
+        }
+
+        if (environment != null) {
+            pb.environment().putAll(environment);
+        }
+
+        process = pb.start();
+
+        StringBuilder stderrContent = new StringBuilder();
+
+        CompletableFuture<Void> stdoutFuture = CompletableFuture.runAsync(() -> {
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    logStreamEvent(line);
+                }
+            } catch (IOException e) {
+                LOG.warnf("Error reading Copilot CLI stdout: %s", e.getMessage());
+            }
+        });
+
+        CompletableFuture<Void> stderrFuture = CompletableFuture.runAsync(() -> {
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(process.getErrorStream(), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    stderrContent.append(line).append("\n");
+                    LOG.debugf("Copilot CLI stderr: %s", line);
+                    log.append(timestamp()).append(" [stderr] ").append(line).append("\n");
+                }
+            } catch (IOException e) {
+                LOG.warnf("Error reading Copilot CLI stderr: %s", e.getMessage());
+            }
+        });
+
+        boolean completed = process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS);
+        if (!completed) {
+            LOG.warnf("Copilot CLI subprocess timed out after %s", timeout);
+            destroyProcessTree();
+            log.append("\n=== Timed Out ===\n");
+            return new CopilotResult("Process timed out after " + timeout,
+                    null, null, null, null, 124, log.toString());
+        }
+
+        destroyProcessTree();
+
+        joinWithTimeout(stdoutFuture, "stdout");
+        joinWithTimeout(stderrFuture, "stderr");
+
+        int exitCode = process.exitValue();
+        LOG.tracef("Copilot CLI subprocess exited with code %d", exitCode);
+
+        Duration duration = Duration.between(startTime, Instant.now());
+
+        if (exitCode != 0) {
+            String error = stderrContent.toString().trim();
+            if (error.isEmpty()) {
+                error = lastAssistantMessage != null ? lastAssistantMessage
+                        : "Process exited with code " + exitCode;
+            }
+            log.append("\n=== Failed (exit ").append(exitCode).append(") ===\n");
+            return new CopilotResult(error, resultSessionId, null, null, lastOutputTokens,
+                    exitCode, log.toString());
+        }
+
+        String result = lastAssistantMessage != null ? lastAssistantMessage : "";
+        // If the process reported success but a "result" event carried a
+        // non-zero exit code, prefer that as the authoritative status.
+        int finalExitCode = sawResultEvent && resultExitCode >= 0 ? resultExitCode : exitCode;
+
+        log.append("\n=== Completed ===\nStatus: ")
+                .append(finalExitCode == 0 ? "Completed" : "Failed")
+                .append("\nDuration: ").append(duration.toSeconds()).append("s\n");
+
+        return new CopilotResult(result, resultSessionId, null, null, lastOutputTokens,
+                finalExitCode, log.toString());
+    }
+
+    /**
+     * Parses an NDJSON event line from the Copilot CLI stream and accumulates
+     * diagnostic information plus the final answer text.
+     */
+    private void logStreamEvent(String line) {
+        if (line == null || line.isBlank()) {
+            return;
+        }
+        try {
+            JsonNode node = MAPPER.readTree(line);
+            String type = node.path("type").asText("");
+
+            switch (type) {
+                case "assistant.message" -> {
+                    JsonNode data = node.path("data");
+                    String content = data.path("content").asText(null);
+                    if (content != null) {
+                        lastAssistantMessage = content;
+                        String preview = content.length() > 150
+                                ? content.substring(0, 147) + "..." : content;
+                        LOG.tracef("  [copilot] Message: %s", preview);
+                        log.append(timestamp()).append(" Message: ").append(content).append("\n");
+                    }
+                    if (data.has("outputTokens")) {
+                        lastOutputTokens = data.get("outputTokens").asLong();
+                    }
+                }
+                case "session.tool_call", "tool.call" -> {
+                    JsonNode data = node.path("data");
+                    String toolName = data.path("name").asText(data.path("toolName").asText("?"));
+                    LOG.tracef("  [copilot] Tool call: %s", toolName);
+                    log.append(timestamp()).append(" Tool call: ").append(toolName).append("\n");
+                }
+                case "result" -> {
+                    // Unlike other event types, "result" carries exitCode and
+                    // sessionId at the top level rather than under "data".
+                    sawResultEvent = true;
+                    resultExitCode = node.path("exitCode").asInt(0);
+                    resultSessionId = node.path("sessionId").asText(null);
+                    LOG.tracef("  [copilot] Result: exitCode=%d, sessionId=%s",
+                            resultExitCode, resultSessionId);
+                    log.append(timestamp()).append(" Result: exitCode=")
+                            .append(resultExitCode).append("\n");
+                }
+                case "session.info" -> {
+                    String message = node.path("data").path("message").asText(null);
+                    if (message != null) {
+                        LOG.tracef("  [copilot] Info: %s", message);
+                    }
+                }
+                default -> LOG.tracef("  [copilot] Stream event type: %s", type);
+            }
+        } catch (Exception e) {
+            LOG.tracef("  [copilot] Raw: %s",
+                    line.substring(0, Math.min(line.length(), 200)));
+        }
+    }
+
+    private void destroyProcessTree() {
+        process.descendants().forEach(ph -> {
+            LOG.tracef("Killing descendant process %d", ph.pid());
+            ph.destroyForcibly();
+        });
+        process.destroyForcibly();
+        try {
+            process.waitFor(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void joinWithTimeout(CompletableFuture<Void> future, String name) {
+        try {
+            future.get(30, TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+            LOG.warnf("%s reader did not finish within 30s after process exit, cancelling", name);
+            future.cancel(true);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            future.cancel(true);
+        } catch (ExecutionException e) {
+            LOG.warnf(e.getCause(), "Error in %s reader", name);
+        }
+    }
+
+    private String timestamp() {
+        return "[" + LocalTime.now(ZoneId.systemDefault())
+                .format(DateTimeFormatter.ofPattern("HH:mm:ss")) + "]";
+    }
+}

--- a/engine/copilot/src/test/java/io/apitomy/axiom/engine/copilot/CopilotCommandBuilderTest.java
+++ b/engine/copilot/src/test/java/io/apitomy/axiom/engine/copilot/CopilotCommandBuilderTest.java
@@ -1,0 +1,145 @@
+package io.apitomy.axiom.engine.copilot;
+
+import io.apitomy.axiom.actors.spi.ActorContext;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for CopilotCommandBuilder. These are pure unit tests that don't
+ * require the Copilot CLI to be installed.
+ */
+class CopilotCommandBuilderTest {
+
+    @Test
+    void testMinimalCommand() {
+        ActorContext context = ActorContext.builder()
+                .workingDirectory(Path.of("/tmp/workspace"))
+                .build();
+
+        List<String> cmd = CopilotCommandBuilder
+                .fromContext("Hello", context)
+                .build();
+
+        assertTrue(cmd.contains("copilot"));
+        assertTrue(cmd.contains("-p"));
+        assertTrue(cmd.contains("Hello"));
+        assertTrue(cmd.contains("--allow-all-tools"),
+                "Non-interactive mode requires blanket tool approval");
+        assertTrue(cmd.contains("--disable-builtin-mcps"));
+        assertFalse(cmd.contains("-C"), "Working dir is set via ProcessBuilder, not CLI flag");
+    }
+
+    @Test
+    void testOutputFormatJson() {
+        ActorContext context = ActorContext.builder().build();
+        List<String> cmd = CopilotCommandBuilder.fromContext("test", context).build();
+
+        int fmtIndex = cmd.indexOf("--output-format");
+        assertTrue(fmtIndex >= 0);
+        assertEquals("json", cmd.get(fmtIndex + 1));
+    }
+
+    @Test
+    void testCustomExecutable() {
+        ActorContext context = ActorContext.builder().build();
+        List<String> cmd = CopilotCommandBuilder.fromContext("test", context)
+                .executable("/usr/local/bin/copilot")
+                .build();
+
+        assertEquals("/usr/local/bin/copilot", cmd.getFirst());
+    }
+
+    @Test
+    void testModelFlag() {
+        ActorContext context = ActorContext.builder().build();
+        List<String> cmd = CopilotCommandBuilder.fromContext("test", context)
+                .model("gpt-5.4")
+                .build();
+
+        int modelIndex = cmd.indexOf("--model");
+        assertTrue(modelIndex >= 0);
+        assertEquals("gpt-5.4", cmd.get(modelIndex + 1));
+    }
+
+    @Test
+    void testAllowedToolsForwardedAsBaseNames() {
+        ActorContext context = ActorContext.builder()
+                .allowedTools(List.of("Read", "Bash(git log *)", "Bash(git diff *)"))
+                .build();
+
+        List<String> cmd = CopilotCommandBuilder.fromContext("test", context).build();
+
+        // --allow-tool should appear once per deduplicated base tool name
+        long allowToolCount = cmd.stream().filter("--allow-tool"::equals).count();
+        assertEquals(2, allowToolCount);
+        assertTrue(cmd.contains("Read"));
+        assertTrue(cmd.contains("Bash"));
+        // --allow-all-tools is still present to avoid blocking on unmapped names
+        assertTrue(cmd.contains("--allow-all-tools"));
+    }
+
+    @Test
+    void testDisallowedTools() {
+        ActorContext context = ActorContext.builder()
+                .disallowedTools(List.of("bash", "edit"))
+                .build();
+
+        List<String> cmd = CopilotCommandBuilder.fromContext("test", context).build();
+
+        long denyToolCount = cmd.stream().filter("--deny-tool"::equals).count();
+        assertEquals(2, denyToolCount);
+        assertTrue(cmd.contains("bash"));
+        assertTrue(cmd.contains("edit"));
+    }
+
+    @Test
+    void testSessionId() {
+        ActorContext context = ActorContext.builder().build();
+        List<String> cmd = CopilotCommandBuilder.fromContext("test", context)
+                .sessionId("axiom-task-42")
+                .build();
+
+        int sessionIndex = cmd.indexOf("--session-id");
+        assertTrue(sessionIndex >= 0);
+        assertEquals("axiom-task-42", cmd.get(sessionIndex + 1));
+    }
+
+    @Test
+    void testMcpConfig() {
+        ActorContext context = ActorContext.builder().build();
+        List<String> cmd = CopilotCommandBuilder.fromContext("test", context)
+                .mcpConfigFile(Path.of("/tmp/mcp.json"))
+                .build();
+
+        int mcpIndex = cmd.indexOf("--additional-mcp-config");
+        assertTrue(mcpIndex >= 0);
+        assertTrue(cmd.get(mcpIndex + 1).startsWith("@"));
+        assertTrue(cmd.get(mcpIndex + 1).endsWith("/tmp/mcp.json"));
+    }
+
+    @Test
+    void testNoAllowedToolsOnlyEmitsAllowAllTools() {
+        ActorContext context = ActorContext.builder()
+                .allowedTools(List.of())
+                .build();
+
+        List<String> cmd = CopilotCommandBuilder.fromContext("test", context).build();
+
+        assertFalse(cmd.contains("--allow-tool"),
+                "Empty allowedTools should not produce --allow-tool flags");
+        assertTrue(cmd.contains("--allow-all-tools"));
+    }
+
+    @Test
+    void testDeriveBaseToolNamesWithPatterns() {
+        String result = CopilotCommandBuilder.deriveBaseToolNames(List.of(
+                "Read", "Bash(git log *)", "Bash(git diff *)"));
+        assertEquals("Read,Bash", result);
+    }
+}

--- a/engine/copilot/src/test/java/io/apitomy/axiom/engine/copilot/CopilotResultTest.java
+++ b/engine/copilot/src/test/java/io/apitomy/axiom/engine/copilot/CopilotResultTest.java
@@ -1,0 +1,46 @@
+package io.apitomy.axiom.engine.copilot;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for CopilotResult parsing and construction.
+ */
+class CopilotResultTest {
+
+    @Test
+    void testSuccessfulResult() {
+        CopilotResult result = new CopilotResult(
+                "Analysis complete", "session-123", null, null, 800L, 0, null);
+
+        assertTrue(result.isSuccess());
+        assertEquals("Analysis complete", result.result());
+        assertEquals("session-123", result.sessionId());
+        assertNull(result.costUsd());
+        assertEquals(800L, result.outputTokens());
+        assertEquals(0, result.exitCode());
+    }
+
+    @Test
+    void testFailedResult() {
+        CopilotResult result = CopilotResult.failed("Process crashed", 1);
+
+        assertFalse(result.isSuccess());
+        assertEquals("Process crashed", result.result());
+        assertNull(result.sessionId());
+        assertNull(result.costUsd());
+        assertEquals(1, result.exitCode());
+    }
+
+    @Test
+    void testTimeoutResult() {
+        CopilotResult result = CopilotResult.failed("Timed out", 124);
+
+        assertFalse(result.isSuccess());
+        assertEquals(124, result.exitCode());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <module>core</module>
         <module>engine/spi</module>
         <module>engine/opencode</module>
+        <module>engine/copilot</module>
         <module>manager</module>
         <module>actors/spi</module>
         <module>actors/claude-code</module>
@@ -92,6 +93,11 @@
             <dependency>
                 <groupId>io.apitomy</groupId>
                 <artifactId>apitomy-axiom-engine-opencode</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.apitomy</groupId>
+                <artifactId>apitomy-axiom-engine-copilot</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/ui/src/components/AppMasthead.tsx
+++ b/ui/src/components/AppMasthead.tsx
@@ -122,6 +122,7 @@ export function AppMasthead({ engineName, appVersion, themeMode, setThemeMode }:
                     <dd>
                         {engineName === "opencode" ? "OpenCode"
                             : engineName === "claude-code" ? "Claude Code"
+                            : engineName === "copilot" ? "GitHub Copilot CLI"
                             : engineName || "—"}
                     </dd>
                     <dt>License</dt>

--- a/ui/src/pages/ActionTypeDetailPage.tsx
+++ b/ui/src/pages/ActionTypeDetailPage.tsx
@@ -409,7 +409,7 @@ function InfoTab({ form, updateForm, availableModels, availableEngines, onEditLa
                     >
                         <FormSelectOption value="" label="Global default" />
                         {availableEngines.map((e) => (
-                            <FormSelectOption key={e} value={e} label={e === "opencode" ? "OpenCode" : e === "claude-code" ? "Claude Code" : e} />
+                            <FormSelectOption key={e} value={e} label={e === "opencode" ? "OpenCode" : e === "claude-code" ? "Claude Code" : e === "copilot" ? "GitHub Copilot CLI" : e} />
                         ))}
                     </FormSelect>
                 </FormGroup>

--- a/ui/src/pages/EngineSettingsPage.tsx
+++ b/ui/src/pages/EngineSettingsPage.tsx
@@ -60,7 +60,7 @@ export function EngineSettingsPage() {
     }
 
     const engineName = config.engine || "unknown";
-    const engineLabel = engineName === "opencode" ? "OpenCode" : engineName === "claude-code" ? "Claude Code" : engineName;
+    const engineLabel = engineName === "opencode" ? "OpenCode" : engineName === "claude-code" ? "Claude Code" : engineName === "copilot" ? "GitHub Copilot CLI" : engineName;
     const engineChecks = (config.checks || []).filter(
         (c) => !["GitHub API Token", "Node.js"].includes(c.name)
     );

--- a/ui/src/pages/ScheduledJobDetailPage.tsx
+++ b/ui/src/pages/ScheduledJobDetailPage.tsx
@@ -425,7 +425,8 @@ function InfoTab({ form, updateForm, labels, onLabelsChange, availableModels, av
                         {availableEngines.map((e) => (
                             <FormSelectOption key={e} value={e}
                                 label={e === "opencode" ? "OpenCode"
-                                    : e === "claude-code" ? "Claude Code" : e} />
+                                    : e === "claude-code" ? "Claude Code"
+                                    : e === "copilot" ? "GitHub Copilot CLI" : e} />
                         ))}
                     </FormSelect>
                 </FormGroup>


### PR DESCRIPTION
Closes #224

## Summary
Adds GitHub Copilot CLI (`copilot`) as a new pluggable AI engine, alongside Claude Code and OpenCode, following the existing engine SPI pattern (`AiEngine` / `AiEngineProvider` / `AiEngineRegistry`).

## New `engine/copilot` module
- `CopilotEngine` / `CopilotActor` — implement `AiEngine` / `AiEngineProvider` / `Actor` (`getType()` = `"copilot"`)
- `CopilotCommandBuilder` — builds the `copilot` CLI invocation: always passes `--allow-all-tools` (required for non-interactive mode), `--output-format json`, `--disable-builtin-mcps`; forwards allowed/denied tools best-effort via `--allow-tool`/`--deny-tool`; supports `--model`, `--session-id`, `--additional-mcp-config`
- `CopilotSubprocess` — launches the CLI and parses its NDJSON streaming output (extracts final answer, token counts, exit code/session id from the terminal `result` event)
- `CopilotMcpManager` — reuses the existing MCP config generator unchanged via the same delegate pattern as `ClaudeCodeMcpManager` (Copilot CLI accepts the same `{"mcpServers": {...}}` JSON shape)
- `CopilotResult` plus unit tests for the result record and command builder (`costUsd`/`inputTokens` are always `null` for this engine — Copilot CLI has no USD-based cost reporting)

## Wiring
- Registered `engine/copilot` in the root `pom.xml` and `app/pom.xml`
- Registered `CopilotMcpManager` with `McpConfigGenerator`
- Added `axiom.copilot.*` config properties (`executable`, `model`, `available-models`, `timeout-seconds`) to `application.properties`
- Added a `copilot` branch to `SystemResourceImpl.listModels()`
- Added "GitHub Copilot CLI" labels to engine selectors in `EngineSettingsPage`, `AppMasthead`, `ActionTypeDetailPage`, `ScheduledJobDetailPage`
- Updated OpenAPI description strings and documentation (`docs/getting-started`, `docs/developer-guide`, `docs/user-guide`) to mention the new engine

## Testing
- `engine/copilot` unit tests pass in isolation
- Full `mvn clean package` build succeeds for all modules including the new `apitomy-axiom-engine-copilot`
- Verified locally end-to-end: launched Axiom with `AXIOM_AI_ENGINE=copilot`; startup health check passed (`GitHub Copilot CLI is available and working`) and `/api/v1/system/config` reports `"engine":"copilot"`
- The 3 failures in `PackManagerConfigImportTest` seen in a full build are **pre-existing and unrelated** to this change — confirmed via `git stash` (they fail identically against `main` without any of these changes)

Note: fine-grained mapping between Axiom's Claude-Code-style tool identifiers and Copilot CLI's native tool names (`view`, `bash`, `edit`, ...) is intentionally out of scope for this first pass, per the open questions raised in #224; `--allow-all-tools` is always added as a safety net.