### PR TITLE
fix: complete inbox items directly from DB state after a restart

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/TaskExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/TaskExecutionService.java
@@ -431,8 +431,19 @@ public class TaskExecutionService {
         }
     }
 
+    /**
+     * Completes a task and records its result. The database is the source of
+     * truth for task state, so this can be called directly (e.g. from
+     * {@code InboxResourceImpl}) even when no in-memory {@code Actor} future
+     * is tracking the task — this happens for human tasks left in
+     * {@code AwaitingInput} across an application restart, since
+     * {@code HumanActor}'s pending-future map does not survive restarts.
+     *
+     * @param taskId the task ID
+     * @param result the task result
+     */
     @Transactional
-    void onTaskCompleted(Long taskId, TaskResult result) {
+    public void onTaskCompleted(Long taskId, TaskResult result) {
         TaskEntity task = TaskEntity.findById(taskId);
         if (task == null) {
             return;

--- a/app/src/main/java/io/apitomy/axiom/app/rest/InboxResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/InboxResourceImpl.java
@@ -3,6 +3,7 @@ package io.apitomy.axiom.app.rest;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.apitomy.axiom.actors.human.HumanActor;
+import io.apitomy.axiom.actors.spi.TaskResult;
 import io.apitomy.axiom.api.InboxResource;
 import io.apitomy.axiom.api.beans.HumanContext;
 import io.apitomy.axiom.api.beans.HumanContextReference;
@@ -214,7 +215,13 @@ public class InboxResourceImpl implements InboxResource {
             String responseJson = objectMapper.writeValueAsString(responseMap);
             boolean accepted = humanActor.submitResponse(tid, responseJson);
             if (!accepted) {
-                throw new WebApplicationException("Task is not pending a human response", 409);
+                // The in-memory pending-future used by HumanActor does not survive an
+                // application restart. The database status (AwaitingInput, checked above)
+                // is the real source of truth, so complete the task directly rather than
+                // failing just because no in-memory future is tracking it.
+                LOG.infof("No in-memory pending future for task %d (likely due to a restart); "
+                        + "completing directly from database state", tid);
+                taskExecutionService.onTaskCompleted(tid, TaskResult.success(responseJson).build());
             }
 
             LOG.infof("Inbox item %d completed with structured response", tid);


### PR DESCRIPTION
## Problem
`HumanActor` tracks tasks awaiting human response only in an in-memory `ConcurrentHashMap<Long, CompletableFuture<TaskResult>>`, populated when a human task is first assigned. This map is **never rebuilt on application startup**, so any task left in `AwaitingInput` status from a previous JVM run has no matching in-memory future after a restart — even though the database still correctly reports the task as `AwaitingInput` and it still shows up in the inbox UI.

Completing such an item via `POST /inbox/{id}/complete` called `humanActor.submitResponse()`, which returned `false` because the map entry was missing. This caused the endpoint to throw an (empty-bodied) `409`, surfaced in the UI as:

```
Failed to complete inbox item:
```

with no further detail, since the error body was empty.

## Fix
Make the **database the actual source of truth** for inbox completion instead of relying solely on the in-memory future:

- `TaskExecutionService.onTaskCompleted()` is now `public` (previously package-private), since it already does the DB-authoritative work of completing a task (updates status/output, records usage, fires SSE events, completes the trace).
- `InboxResourceImpl.completeInboxItem()` still tries `humanActor.submitResponse()` first (the fast path for same-JVM in-flight tasks), but if that returns `false`, it now falls back to calling `taskExecutionService.onTaskCompleted()` directly — since the endpoint has already verified via the DB that the task is in `AwaitingInput` status, so it's a legitimately pending human task regardless of whether the current JVM process ever assigned it.

## Testing
- Reproduced the bug: left a task `AwaitingInput` in the DB across a backend restart, confirmed `POST /inbox/{id}/complete` returned `409` with an empty body.
- Applied the fix, confirmed the same request now returns `204`, the task transitions to `Completed`, and it correctly disappears from the inbox (`GET /inbox/{id}` → `404`, since that endpoint only returns awaiting-input items).
- `mvn -pl app test` passes (excluding the pre-existing, unrelated `PackManagerConfigImportTest` failures already present on `main`).
