### PR TITLE
feat: Workflow Definition Management and Visual Editor (Phase 1)

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>io.apitomy</groupId>
             <artifactId>apitomy-flow-engine</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
         </dependency>
 
         <!-- Quarkus -->

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -77,6 +77,11 @@
             <groupId>io.apitomy</groupId>
             <artifactId>apitomy-axiom-notifications-telegram</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.apitomy</groupId>
+            <artifactId>apitomy-flow-engine</artifactId>
+            <version>1.0.1-SNAPSHOT</version>
+        </dependency>
 
         <!-- Quarkus -->
         <dependency>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>io.apitomy</groupId>
             <artifactId>apitomy-flow-engine</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.0.0</version>
         </dependency>
 
         <!-- Quarkus -->

--- a/app/src/main/java/io/apitomy/axiom/app/rest/WorkflowDefinitionsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/WorkflowDefinitionsResourceImpl.java
@@ -1,0 +1,346 @@
+package io.apitomy.axiom.app.rest;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.apitomy.axiom.api.WorkflowDefinitionsResource;
+import io.apitomy.axiom.api.beans.*;
+import io.apitomy.axiom.core.entities.WorkflowDefinitionEntity;
+import io.apitomy.axiom.core.entities.WorkflowDefinitionVersionEntity;
+import io.apitomy.flow.model.Workflow;
+import io.apitomy.flow.validation.ValidationProblem;
+import io.apitomy.flow.validation.ValidationSeverity;
+import io.apitomy.flow.validation.WorkflowValidator;
+import io.quarkus.hibernate.orm.panache.PanacheQuery;
+import io.quarkus.panache.common.Page;
+import io.quarkus.panache.common.Sort;
+import io.smallrye.common.annotation.RunOnVirtualThread;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.*;
+
+/**
+ * Implementation of the Workflow Definitions REST API.
+ */
+@ApplicationScoped
+@RunOnVirtualThread
+public class WorkflowDefinitionsResourceImpl implements WorkflowDefinitionsResource {
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    // ── List ────────────────────────────────────────────────────────
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public WorkflowDefinitionSearchResults listWorkflowDefinitions(
+            BigInteger page, BigInteger limit, String filterName) {
+        int pageNum = page != null ? page.intValue() : 1;
+        int pageSize = limit != null ? limit.intValue() : 20;
+
+        StringBuilder hql = new StringBuilder("1=1");
+        Map<String, Object> params = new HashMap<>();
+
+        if (filterName != null && !filterName.isBlank()) {
+            hql.append(" and lower(name) like :name");
+            params.put("name", "%" + filterName.toLowerCase() + "%");
+        }
+
+        PanacheQuery<WorkflowDefinitionEntity> query = WorkflowDefinitionEntity
+                .find(hql.toString(), Sort.ascending("name"), params)
+                .page(Page.of(pageNum - 1, pageSize));
+
+        WorkflowDefinitionSearchResults results = new WorkflowDefinitionSearchResults();
+        results.setItems(query.list().stream().map(this::toBean).toList());
+        results.setTotalCount(query.count());
+        results.setPage(pageNum);
+        results.setLimit(pageSize);
+        return results;
+    }
+
+    // ── Create ──────────────────────────────────────────────────────
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Transactional
+    public WorkflowDefinition createWorkflowDefinition(NewWorkflowDefinition data) {
+        checkDuplicateName(data.getName(), null);
+
+        WorkflowDefinitionEntity entity = new WorkflowDefinitionEntity();
+        entity.name = data.getName();
+        entity.description = data.getDescription();
+        entity.content = createEmptyWorkflowContent(data.getName());
+        entity.createdOn = Instant.now();
+        entity.updatedOn = Instant.now();
+        entity.persist();
+
+        return toBean(entity);
+    }
+
+    // ── Get ─────────────────────────────────────────────────────────
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public WorkflowDefinition getWorkflowDefinition(long workflowDefinitionId) {
+        return toBean(findOrThrow(workflowDefinitionId));
+    }
+
+    // ── Update metadata ─────────────────────────────────────────────
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Transactional
+    public WorkflowDefinition updateWorkflowDefinition(
+            long workflowDefinitionId, UpdateWorkflowDefinition data) {
+        WorkflowDefinitionEntity entity = findOrThrow(workflowDefinitionId);
+
+        if (data.getName() != null) {
+            checkDuplicateName(data.getName(), entity.id);
+            entity.name = data.getName();
+        }
+        if (data.getDescription() != null) {
+            entity.description = data.getDescription();
+        }
+        entity.updatedOn = Instant.now();
+
+        return toBean(entity);
+    }
+
+    // ── Delete ──────────────────────────────────────────────────────
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Transactional
+    public void deleteWorkflowDefinition(long workflowDefinitionId) {
+        WorkflowDefinitionEntity entity = findOrThrow(workflowDefinitionId);
+        // Versions cascade-deleted via FK ON DELETE CASCADE
+        entity.delete();
+    }
+
+    // ── Update content ──────────────────────────────────────────────
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Transactional
+    public void updateWorkflowDefinitionContent(long workflowDefinitionId, Object content) {
+        WorkflowDefinitionEntity entity = findOrThrow(workflowDefinitionId);
+        try {
+            entity.content = objectMapper.writeValueAsString(content);
+        } catch (JsonProcessingException e) {
+            throw new WebApplicationException("Invalid workflow content", 400);
+        }
+        entity.updatedOn = Instant.now();
+    }
+
+    // ── Publish ─────────────────────────────────────────────────────
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Transactional
+    public WorkflowDefinitionVersion publishWorkflowDefinition(long workflowDefinitionId) {
+        WorkflowDefinitionEntity entity = findOrThrow(workflowDefinitionId);
+
+        if (entity.content == null || entity.content.isBlank()) {
+            throw new WebApplicationException("No draft content to publish", 400);
+        }
+
+        // Deserialize and validate
+        Workflow workflow;
+        try {
+            workflow = objectMapper.readValue(entity.content, Workflow.class);
+        } catch (JsonProcessingException e) {
+            throw new WebApplicationException("Invalid workflow JSON: " + e.getMessage(), 400);
+        }
+
+        List<ValidationProblem> problems = WorkflowValidator.validate(workflow);
+        List<ValidationProblem> errors = problems.stream()
+                .filter(p -> p.severity() == ValidationSeverity.ERROR)
+                .toList();
+        if (!errors.isEmpty()) {
+            throw new WebApplicationException(
+                    Response.status(400).entity(errors).build());
+        }
+
+        // Create version
+        int newVersion = entity.currentVersion != null ? entity.currentVersion + 1 : 1;
+
+        WorkflowDefinitionVersionEntity version = new WorkflowDefinitionVersionEntity();
+        version.definitionId = entity.id;
+        version.version = newVersion;
+        version.content = entity.content;
+        version.createdOn = Instant.now();
+        version.persist();
+
+        entity.currentVersion = newVersion;
+        entity.updatedOn = Instant.now();
+
+        return toVersionBean(version);
+    }
+
+    // ── List versions ───────────────────────────────────────────────
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<WorkflowDefinitionVersion> listWorkflowDefinitionVersions(
+            long workflowDefinitionId) {
+        findOrThrow(workflowDefinitionId);
+        List<WorkflowDefinitionVersionEntity> versions = WorkflowDefinitionVersionEntity
+                .find("definitionId", Sort.descending("version"), workflowDefinitionId)
+                .list();
+        return versions.stream().map(this::toVersionBean).toList();
+    }
+
+    // ── Get version ─────────────────────────────────────────────────
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public WorkflowDefinitionVersion getWorkflowDefinitionVersion(
+            long workflowDefinitionId, int version) {
+        findOrThrow(workflowDefinitionId);
+        WorkflowDefinitionVersionEntity entity = WorkflowDefinitionVersionEntity
+                .find("definitionId = ?1 and version = ?2", workflowDefinitionId, version)
+                .firstResult();
+        if (entity == null) {
+            throw new WebApplicationException(404);
+        }
+        return toVersionBean(entity);
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────
+
+    /**
+     * Finds a workflow definition by ID or throws a 404 exception.
+     *
+     * @param id the workflow definition ID
+     * @return the entity
+     * @throws WebApplicationException if not found
+     */
+    private WorkflowDefinitionEntity findOrThrow(long id) {
+        WorkflowDefinitionEntity entity = WorkflowDefinitionEntity.findById(id);
+        if (entity == null) {
+            throw new WebApplicationException(404);
+        }
+        return entity;
+    }
+
+    /**
+     * Checks if a workflow definition name is already in use.
+     *
+     * @param name the name to check
+     * @param excludeId optional ID to exclude from the check (for updates)
+     * @throws WebApplicationException if a duplicate is found
+     */
+    private void checkDuplicateName(String name, Long excludeId) {
+        WorkflowDefinitionEntity existing = WorkflowDefinitionEntity
+                .find("name", name).firstResult();
+        if (existing != null && (excludeId == null || !existing.id.equals(excludeId))) {
+            throw new WebApplicationException("Workflow definition name already exists", 409);
+        }
+    }
+
+    /**
+     * Converts a WorkflowDefinitionEntity to a bean.
+     *
+     * @param entity the entity
+     * @return the bean
+     */
+    private WorkflowDefinition toBean(WorkflowDefinitionEntity entity) {
+        WorkflowDefinition bean = new WorkflowDefinition();
+        bean.setId(entity.id);
+        bean.setName(entity.name);
+        bean.setDescription(entity.description);
+        if (entity.content != null) {
+            try {
+                bean.setContent(objectMapper.readValue(entity.content, Object.class));
+            } catch (JsonProcessingException e) {
+                bean.setContent(null);
+            }
+        }
+        bean.setCurrentVersion(entity.currentVersion);
+        bean.setCreatedOn(Date.from(entity.createdOn));
+        bean.setUpdatedOn(Date.from(entity.updatedOn));
+        return bean;
+    }
+
+    /**
+     * Converts a WorkflowDefinitionVersionEntity to a bean.
+     *
+     * @param entity the entity
+     * @return the bean
+     */
+    private WorkflowDefinitionVersion toVersionBean(WorkflowDefinitionVersionEntity entity) {
+        WorkflowDefinitionVersion bean = new WorkflowDefinitionVersion();
+        bean.setId(entity.id);
+        bean.setDefinitionId(entity.definitionId);
+        bean.setVersion(entity.version);
+        if (entity.content != null) {
+            try {
+                bean.setContent(objectMapper.readValue(entity.content, Object.class));
+            } catch (JsonProcessingException e) {
+                bean.setContent(null);
+            }
+        }
+        bean.setCreatedOn(Date.from(entity.createdOn));
+        return bean;
+    }
+
+    /**
+     * Creates an empty workflow with start and end nodes.
+     *
+     * @param name the workflow name
+     * @return the workflow JSON string
+     */
+    private String createEmptyWorkflowContent(String name) {
+        Map<String, Object> startNode = Map.of(
+                "id", "start-1",
+                "type", "start",
+                "name", "Start",
+                "config", Map.of(),
+                "position", Map.of("x", 250, "y", 100));
+        Map<String, Object> endNode = Map.of(
+                "id", "end-1",
+                "type", "end",
+                "name", "End",
+                "config", Map.of(),
+                "position", Map.of("x", 250, "y", 400));
+        Map<String, Object> edge = Map.of(
+                "id", "edge-1",
+                "source", "start-1",
+                "target", "end-1",
+                "priority", 0,
+                "isDefault", true);
+        Map<String, Object> workflow = Map.of(
+                "id", UUID.randomUUID().toString(),
+                "name", name,
+                "nodes", List.of(startNode, endNode),
+                "edges", List.of(edge));
+        try {
+            return objectMapper.writeValueAsString(workflow);
+        } catch (JsonProcessingException e) {
+            return "{}";
+        }
+    }
+}

--- a/app/src/main/java/io/apitomy/axiom/app/rest/WorkflowDefinitionsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/WorkflowDefinitionsResourceImpl.java
@@ -2,8 +2,13 @@ package io.apitomy.axiom.app.rest;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.apitomy.axiom.api.WorkflowDefinitionsResource;
-import io.apitomy.axiom.api.beans.*;
+import io.apitomy.axiom.api.WorkflowResource;
+import io.apitomy.axiom.api.beans.Content;
+import io.apitomy.axiom.api.beans.NewWorkflowDefinition;
+import io.apitomy.axiom.api.beans.UpdateWorkflowDefinition;
+import io.apitomy.axiom.api.beans.WorkflowDefinition;
+import io.apitomy.axiom.api.beans.WorkflowDefinitionSearchResults;
+import io.apitomy.axiom.api.beans.WorkflowDefinitionVersion;
 import io.apitomy.axiom.core.entities.WorkflowDefinitionEntity;
 import io.apitomy.axiom.core.entities.WorkflowDefinitionVersionEntity;
 import io.apitomy.flow.model.Workflow;
@@ -20,16 +25,20 @@ import jakarta.transaction.Transactional;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 
-import java.math.BigInteger;
+import java.io.InputStream;
 import java.time.Instant;
-import java.util.*;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 /**
  * Implementation of the Workflow Definitions REST API.
  */
 @ApplicationScoped
 @RunOnVirtualThread
-public class WorkflowDefinitionsResourceImpl implements WorkflowDefinitionsResource {
+public class WorkflowDefinitionsResourceImpl implements WorkflowResource {
 
     @Inject
     ObjectMapper objectMapper;
@@ -41,9 +50,9 @@ public class WorkflowDefinitionsResourceImpl implements WorkflowDefinitionsResou
      */
     @Override
     public WorkflowDefinitionSearchResults listWorkflowDefinitions(
-            BigInteger page, BigInteger limit, String filterName) {
-        int pageNum = page != null ? page.intValue() : 1;
-        int pageSize = limit != null ? limit.intValue() : 20;
+            Integer page, Integer limit, String filterName) {
+        int pageNum = page != null ? page : 1;
+        int pageSize = limit != null ? limit : 20;
 
         StringBuilder hql = new StringBuilder("1=1");
         Map<String, Object> params = new HashMap<>();
@@ -128,7 +137,6 @@ public class WorkflowDefinitionsResourceImpl implements WorkflowDefinitionsResou
     @Transactional
     public void deleteWorkflowDefinition(long workflowDefinitionId) {
         WorkflowDefinitionEntity entity = findOrThrow(workflowDefinitionId);
-        // Versions cascade-deleted via FK ON DELETE CASCADE
         entity.delete();
     }
 
@@ -139,11 +147,11 @@ public class WorkflowDefinitionsResourceImpl implements WorkflowDefinitionsResou
      */
     @Override
     @Transactional
-    public void updateWorkflowDefinitionContent(long workflowDefinitionId, Object content) {
+    public void updateWorkflowDefinitionContent(long workflowDefinitionId, InputStream data) {
         WorkflowDefinitionEntity entity = findOrThrow(workflowDefinitionId);
         try {
-            entity.content = objectMapper.writeValueAsString(content);
-        } catch (JsonProcessingException e) {
+            entity.content = new String(data.readAllBytes());
+        } catch (Exception e) {
             throw new WebApplicationException("Invalid workflow content", 400);
         }
         entity.updatedOn = Instant.now();
@@ -163,7 +171,6 @@ public class WorkflowDefinitionsResourceImpl implements WorkflowDefinitionsResou
             throw new WebApplicationException("No draft content to publish", 400);
         }
 
-        // Deserialize and validate
         Workflow workflow;
         try {
             workflow = objectMapper.readValue(entity.content, Workflow.class);
@@ -171,7 +178,8 @@ public class WorkflowDefinitionsResourceImpl implements WorkflowDefinitionsResou
             throw new WebApplicationException("Invalid workflow JSON: " + e.getMessage(), 400);
         }
 
-        List<ValidationProblem> problems = WorkflowValidator.validate(workflow);
+        WorkflowValidator validator = new WorkflowValidator();
+        List<ValidationProblem> problems = validator.validate(workflow);
         List<ValidationProblem> errors = problems.stream()
                 .filter(p -> p.severity() == ValidationSeverity.ERROR)
                 .toList();
@@ -180,7 +188,6 @@ public class WorkflowDefinitionsResourceImpl implements WorkflowDefinitionsResou
                     Response.status(400).entity(errors).build());
         }
 
-        // Create version
         int newVersion = entity.currentVersion != null ? entity.currentVersion + 1 : 1;
 
         WorkflowDefinitionVersionEntity version = new WorkflowDefinitionVersionEntity();
@@ -233,10 +240,6 @@ public class WorkflowDefinitionsResourceImpl implements WorkflowDefinitionsResou
 
     /**
      * Finds a workflow definition by ID or throws a 404 exception.
-     *
-     * @param id the workflow definition ID
-     * @return the entity
-     * @throws WebApplicationException if not found
      */
     private WorkflowDefinitionEntity findOrThrow(long id) {
         WorkflowDefinitionEntity entity = WorkflowDefinitionEntity.findById(id);
@@ -248,10 +251,6 @@ public class WorkflowDefinitionsResourceImpl implements WorkflowDefinitionsResou
 
     /**
      * Checks if a workflow definition name is already in use.
-     *
-     * @param name the name to check
-     * @param excludeId optional ID to exclude from the check (for updates)
-     * @throws WebApplicationException if a duplicate is found
      */
     private void checkDuplicateName(String name, Long excludeId) {
         WorkflowDefinitionEntity existing = WorkflowDefinitionEntity
@@ -262,10 +261,7 @@ public class WorkflowDefinitionsResourceImpl implements WorkflowDefinitionsResou
     }
 
     /**
-     * Converts a WorkflowDefinitionEntity to a bean.
-     *
-     * @param entity the entity
-     * @return the bean
+     * Converts a WorkflowDefinitionEntity to a response bean.
      */
     private WorkflowDefinition toBean(WorkflowDefinitionEntity entity) {
         WorkflowDefinition bean = new WorkflowDefinition();
@@ -274,7 +270,7 @@ public class WorkflowDefinitionsResourceImpl implements WorkflowDefinitionsResou
         bean.setDescription(entity.description);
         if (entity.content != null) {
             try {
-                bean.setContent(objectMapper.readValue(entity.content, Object.class));
+                bean.setContent(objectMapper.readValue(entity.content, Content.class));
             } catch (JsonProcessingException e) {
                 bean.setContent(null);
             }
@@ -286,10 +282,7 @@ public class WorkflowDefinitionsResourceImpl implements WorkflowDefinitionsResou
     }
 
     /**
-     * Converts a WorkflowDefinitionVersionEntity to a bean.
-     *
-     * @param entity the entity
-     * @return the bean
+     * Converts a WorkflowDefinitionVersionEntity to a response bean.
      */
     private WorkflowDefinitionVersion toVersionBean(WorkflowDefinitionVersionEntity entity) {
         WorkflowDefinitionVersion bean = new WorkflowDefinitionVersion();
@@ -298,7 +291,7 @@ public class WorkflowDefinitionsResourceImpl implements WorkflowDefinitionsResou
         bean.setVersion(entity.version);
         if (entity.content != null) {
             try {
-                bean.setContent(objectMapper.readValue(entity.content, Object.class));
+                bean.setContent(objectMapper.readValue(entity.content, Content.class));
             } catch (JsonProcessingException e) {
                 bean.setContent(null);
             }
@@ -308,10 +301,7 @@ public class WorkflowDefinitionsResourceImpl implements WorkflowDefinitionsResou
     }
 
     /**
-     * Creates an empty workflow with start and end nodes.
-     *
-     * @param name the workflow name
-     * @return the workflow JSON string
+     * Creates an empty workflow JSON with start and end nodes.
      */
     private String createEmptyWorkflowContent(String name) {
         Map<String, Object> startNode = Map.of(

--- a/app/src/main/resources/db/migration/V43__create_workflow_definitions.sql
+++ b/app/src/main/resources/db/migration/V43__create_workflow_definitions.sql
@@ -1,0 +1,20 @@
+CREATE TABLE workflow_definition (
+    id BIGSERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL UNIQUE,
+    description TEXT,
+    content TEXT,
+    current_version INT,
+    created_on TIMESTAMP NOT NULL,
+    updated_on TIMESTAMP NOT NULL
+);
+
+CREATE TABLE workflow_definition_version (
+    id BIGSERIAL PRIMARY KEY,
+    definition_id BIGINT NOT NULL REFERENCES workflow_definition(id) ON DELETE CASCADE,
+    version INT NOT NULL,
+    content TEXT NOT NULL,
+    created_on TIMESTAMP NOT NULL,
+    CONSTRAINT uq_definition_version UNIQUE (definition_id, version)
+);
+
+CREATE INDEX idx_wf_def_version_def_id ON workflow_definition_version(definition_id);

--- a/app/src/test/java/io/apitomy/axiom/app/WorkflowDefinitionsResourceTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/WorkflowDefinitionsResourceTest.java
@@ -1,0 +1,340 @@
+package io.apitomy.axiom.app;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+class WorkflowDefinitionsResourceTest {
+
+    private static final String BASE_PATH = "/api/v1/workflow-definitions";
+
+    @Test
+    void testCreateAndGetWorkflowDefinition() {
+        int id = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                    {
+                        "name": "Test Workflow",
+                        "description": "A test workflow"
+                    }
+                    """)
+                .when()
+                    .post(BASE_PATH)
+                .then()
+                    .statusCode(200)
+                    .body("name", equalTo("Test Workflow"))
+                    .body("description", equalTo("A test workflow"))
+                    .body("id", notNullValue())
+                    .body("content", notNullValue())
+                    .body("currentVersion", nullValue())
+                    .body("createdOn", notNullValue())
+                    .body("updatedOn", notNullValue())
+                    .extract().path("id");
+
+        given()
+                .when()
+                    .get(BASE_PATH + "/" + id)
+                .then()
+                    .statusCode(200)
+                    .body("name", equalTo("Test Workflow"))
+                    .body("content.nodes.size()", equalTo(2))
+                    .body("content.edges.size()", equalTo(1));
+    }
+
+    @Test
+    void testListWorkflowDefinitions() {
+        createDefinition("List Test WF 1");
+        createDefinition("List Test WF 2");
+
+        given()
+                .when()
+                    .get(BASE_PATH)
+                .then()
+                    .statusCode(200)
+                    .body("items.size()", greaterThanOrEqualTo(2))
+                    .body("totalCount", greaterThanOrEqualTo(2))
+                    .body("page", equalTo(1))
+                    .body("limit", equalTo(20));
+    }
+
+    @Test
+    void testFilterByName() {
+        createDefinition("Unique Filter WF Name");
+
+        given()
+                .queryParam("filterName", "Unique Filter WF")
+                .when()
+                    .get(BASE_PATH)
+                .then()
+                    .statusCode(200)
+                    .body("items.size()", greaterThanOrEqualTo(1))
+                    .body("items.name", hasItem(containsString("Unique Filter WF")));
+    }
+
+    @Test
+    void testUpdateMetadata() {
+        int id = createDefinition("Update Meta WF");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                    {
+                        "name": "Updated WF Name",
+                        "description": "Updated description"
+                    }
+                    """)
+                .when()
+                    .put(BASE_PATH + "/" + id)
+                .then()
+                    .statusCode(200)
+                    .body("name", equalTo("Updated WF Name"))
+                    .body("description", equalTo("Updated description"));
+    }
+
+    @Test
+    void testUpdateContent() {
+        int id = createDefinition("Content Update WF");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                    {
+                        "id": "wf-test",
+                        "name": "Content Update WF",
+                        "nodes": [
+                            {"id": "s1", "type": "start", "name": "Start",
+                             "config": {}, "position": {"x": 100, "y": 100}},
+                            {"id": "e1", "type": "end", "name": "End",
+                             "config": {}, "position": {"x": 100, "y": 300}}
+                        ],
+                        "edges": [
+                            {"id": "edge1", "source": "s1", "target": "e1",
+                             "priority": 0, "isDefault": true}
+                        ]
+                    }
+                    """)
+                .when()
+                    .put(BASE_PATH + "/" + id + "/content")
+                .then()
+                    .statusCode(204);
+
+        given()
+                .when()
+                    .get(BASE_PATH + "/" + id)
+                .then()
+                    .statusCode(200)
+                    .body("content.id", equalTo("wf-test"));
+    }
+
+    @Test
+    void testPublishValidWorkflow() {
+        int id = createDefinition("Publish WF");
+
+        // Update with valid content
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                    {
+                        "id": "wf-pub",
+                        "name": "Publish WF",
+                        "nodes": [
+                            {"id": "s1", "type": "start", "name": "Start",
+                             "config": {}, "position": {"x": 100, "y": 100}},
+                            {"id": "e1", "type": "end", "name": "End",
+                             "config": {}, "position": {"x": 100, "y": 300}}
+                        ],
+                        "edges": [
+                            {"id": "edge1", "source": "s1", "target": "e1",
+                             "priority": 0, "isDefault": true}
+                        ]
+                    }
+                    """)
+                .when()
+                    .put(BASE_PATH + "/" + id + "/content")
+                .then()
+                    .statusCode(204);
+
+        // Publish
+        given()
+                .when()
+                    .post(BASE_PATH + "/" + id + "/publish")
+                .then()
+                    .statusCode(200)
+                    .body("version", equalTo(1))
+                    .body("definitionId", equalTo(id))
+                    .body("content", notNullValue())
+                    .body("createdOn", notNullValue());
+
+        // Verify currentVersion updated
+        given()
+                .when()
+                    .get(BASE_PATH + "/" + id)
+                .then()
+                    .statusCode(200)
+                    .body("currentVersion", equalTo(1));
+
+        // Publish again — version increments
+        given()
+                .when()
+                    .post(BASE_PATH + "/" + id + "/publish")
+                .then()
+                    .statusCode(200)
+                    .body("version", equalTo(2));
+    }
+
+    @Test
+    void testPublishInvalidWorkflowReturns400() {
+        int id = createDefinition("Invalid Publish WF");
+
+        // Update with invalid content (no start node)
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                    {
+                        "id": "wf-invalid",
+                        "name": "Invalid",
+                        "nodes": [
+                            {"id": "e1", "type": "end", "name": "End",
+                             "config": {}, "position": {"x": 100, "y": 300}}
+                        ],
+                        "edges": []
+                    }
+                    """)
+                .when()
+                    .put(BASE_PATH + "/" + id + "/content")
+                .then()
+                    .statusCode(204);
+
+        // Publish should fail
+        given()
+                .when()
+                    .post(BASE_PATH + "/" + id + "/publish")
+                .then()
+                    .statusCode(400);
+    }
+
+    @Test
+    void testListVersions() {
+        int id = createAndPublishDefinition("Versions List WF");
+
+        given()
+                .when()
+                    .get(BASE_PATH + "/" + id + "/versions")
+                .then()
+                    .statusCode(200)
+                    .body("size()", equalTo(1))
+                    .body("[0].version", equalTo(1));
+    }
+
+    @Test
+    void testGetSpecificVersion() {
+        int id = createAndPublishDefinition("Version Get WF");
+
+        given()
+                .when()
+                    .get(BASE_PATH + "/" + id + "/versions/1")
+                .then()
+                    .statusCode(200)
+                    .body("version", equalTo(1))
+                    .body("content", notNullValue());
+    }
+
+    @Test
+    void testDeleteWorkflowDefinition() {
+        int id = createDefinition("Delete WF");
+
+        given()
+                .when()
+                    .delete(BASE_PATH + "/" + id)
+                .then()
+                    .statusCode(204);
+
+        given()
+                .when()
+                    .get(BASE_PATH + "/" + id)
+                .then()
+                    .statusCode(404);
+    }
+
+    @Test
+    void testGetNotFound() {
+        given()
+                .when()
+                    .get(BASE_PATH + "/99999")
+                .then()
+                    .statusCode(404);
+    }
+
+    @Test
+    void testDuplicateNameReturns409() {
+        createDefinition("Dup Name WF");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                    {
+                        "name": "Dup Name WF"
+                    }
+                    """)
+                .when()
+                    .post(BASE_PATH)
+                .then()
+                    .statusCode(409);
+    }
+
+    // -- Helpers --
+
+    private int createDefinition(String name) {
+        return given()
+                .contentType(ContentType.JSON)
+                .body(String.format("""
+                    {
+                        "name": "%s"
+                    }
+                    """, name))
+                .when()
+                    .post(BASE_PATH)
+                .then()
+                    .statusCode(200)
+                    .extract().path("id");
+    }
+
+    private int createAndPublishDefinition(String name) {
+        int id = createDefinition(name);
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                    {
+                        "id": "wf-test",
+                        "name": "Test",
+                        "nodes": [
+                            {"id": "s1", "type": "start", "name": "Start",
+                             "config": {}, "position": {"x": 100, "y": 100}},
+                            {"id": "e1", "type": "end", "name": "End",
+                             "config": {}, "position": {"x": 100, "y": 300}}
+                        ],
+                        "edges": [
+                            {"id": "edge1", "source": "s1", "target": "e1",
+                             "priority": 0, "isDefault": true}
+                        ]
+                    }
+                    """)
+                .when()
+                    .put(BASE_PATH + "/" + id + "/content")
+                .then()
+                    .statusCode(204);
+
+        given()
+                .when()
+                    .post(BASE_PATH + "/" + id + "/publish")
+                .then()
+                    .statusCode(200);
+
+        return id;
+    }
+}

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -8914,7 +8914,8 @@
             "type": "string"
           },
           "content": {
-            "type": "object"
+            "type": "object",
+            "additionalProperties": {}
           },
           "currentVersion": {
             "format": "int32",
@@ -8976,7 +8977,8 @@
             "type": "integer"
           },
           "content": {
-            "type": "object"
+            "type": "object",
+            "additionalProperties": {}
           },
           "createdOn": {
             "format": "date-time",

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -5021,6 +5021,305 @@
           }
         }
       ]
+    },
+    "/workflow-definitions": {
+      "get": {
+        "tags": [
+          "WorkflowDefinitions"
+        ],
+        "summary": "List workflow definitions",
+        "operationId": "listWorkflowDefinitions",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number (1-indexed)",
+            "schema": {
+              "format": "int32",
+              "default": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of items per page",
+            "schema": {
+              "format": "int32",
+              "default": 20,
+              "type": "integer"
+            }
+          },
+          {
+            "name": "filterName",
+            "in": "query",
+            "description": "Filter by name (substring match)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of workflow definitions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowDefinitionSearchResults"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "WorkflowDefinitions"
+        ],
+        "summary": "Create a workflow definition",
+        "operationId": "createWorkflowDefinition",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewWorkflowDefinition"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Workflow definition created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowDefinition"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workflow-definitions/{workflowDefinitionId}": {
+      "get": {
+        "tags": [
+          "WorkflowDefinitions"
+        ],
+        "summary": "Get a workflow definition",
+        "operationId": "getWorkflowDefinition",
+        "responses": {
+          "200": {
+            "description": "The workflow definition",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowDefinition"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "WorkflowDefinitions"
+        ],
+        "summary": "Update workflow definition metadata",
+        "operationId": "updateWorkflowDefinition",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateWorkflowDefinition"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Workflow definition updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowDefinition"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "WorkflowDefinitions"
+        ],
+        "summary": "Delete a workflow definition",
+        "operationId": "deleteWorkflowDefinition",
+        "responses": {
+          "204": {
+            "description": "Workflow definition deleted"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/WorkflowDefinitionId"
+        }
+      ]
+    },
+    "/workflow-definitions/{workflowDefinitionId}/content": {
+      "put": {
+        "tags": [
+          "WorkflowDefinitions"
+        ],
+        "summary": "Update draft workflow content",
+        "operationId": "updateWorkflowDefinitionContent",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Content updated"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/WorkflowDefinitionId"
+        }
+      ]
+    },
+    "/workflow-definitions/{workflowDefinitionId}/publish": {
+      "post": {
+        "tags": [
+          "WorkflowDefinitions"
+        ],
+        "summary": "Publish current draft as a new version",
+        "operationId": "publishWorkflowDefinition",
+        "responses": {
+          "200": {
+            "description": "New version published",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowDefinitionVersion"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/WorkflowDefinitionId"
+        }
+      ]
+    },
+    "/workflow-definitions/{workflowDefinitionId}/versions": {
+      "get": {
+        "tags": [
+          "WorkflowDefinitions"
+        ],
+        "summary": "List all published versions",
+        "operationId": "listWorkflowDefinitionVersions",
+        "responses": {
+          "200": {
+            "description": "List of published versions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkflowDefinitionVersion"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/WorkflowDefinitionId"
+        }
+      ]
+    },
+    "/workflow-definitions/{workflowDefinitionId}/versions/{version}": {
+      "get": {
+        "tags": [
+          "WorkflowDefinitions"
+        ],
+        "summary": "Get a specific version",
+        "operationId": "getWorkflowDefinitionVersion",
+        "responses": {
+          "200": {
+            "description": "The workflow definition version",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowDefinitionVersion"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/WorkflowDefinitionId"
+        },
+        {
+          "name": "version",
+          "in": "path",
+          "description": "Version number",
+          "required": true,
+          "schema": {
+            "format": "int32",
+            "type": "integer"
+          }
+        }
+      ]
     }
   },
   "components": {
@@ -8595,6 +8894,118 @@
             "type": "string"
           }
         }
+      },
+      "WorkflowDefinition": {
+        "required": [
+          "name",
+          "createdOn",
+          "updatedOn"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "content": {
+            "type": "object"
+          },
+          "currentVersion": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "createdOn": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "updatedOn": {
+            "format": "date-time",
+            "type": "string"
+          }
+        }
+      },
+      "NewWorkflowDefinition": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        }
+      },
+      "UpdateWorkflowDefinition": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        }
+      },
+      "WorkflowDefinitionVersion": {
+        "required": [
+          "definitionId",
+          "version",
+          "createdOn"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "definitionId": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "version": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "content": {
+            "type": "object"
+          },
+          "createdOn": {
+            "format": "date-time",
+            "type": "string"
+          }
+        }
+      },
+      "WorkflowDefinitionSearchResults": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkflowDefinition"
+            }
+          },
+          "totalCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "page": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "limit": {
+            "format": "int32",
+            "type": "integer"
+          }
+        }
       }
     },
     "responses": {
@@ -8654,6 +9065,16 @@
         "name": "eventSourceId",
         "in": "path",
         "description": "Event Source ID",
+        "required": true,
+        "schema": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "WorkflowDefinitionId": {
+        "name": "workflowDefinitionId",
+        "in": "path",
+        "description": "Workflow Definition ID",
         "required": true,
         "schema": {
           "format": "int64",
@@ -8726,6 +9147,10 @@
     {
       "name": "ScheduledJobs",
       "description": "Scheduled Jobs CRUD and execution"
+    },
+    {
+      "name": "WorkflowDefinitions",
+      "description": "Workflow definition management with versioning"
     }
   ]
 }

--- a/core/src/main/java/io/apitomy/axiom/core/entities/WorkflowDefinitionEntity.java
+++ b/core/src/main/java/io/apitomy/axiom/core/entities/WorkflowDefinitionEntity.java
@@ -1,0 +1,31 @@
+package io.apitomy.axiom.core.entities;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "workflow_definition")
+public class WorkflowDefinitionEntity extends PanacheEntity {
+
+    @Column(nullable = false, unique = true)
+    public String name;
+
+    @Column(columnDefinition = "TEXT")
+    public String description;
+
+    @Column(columnDefinition = "TEXT")
+    public String content;
+
+    @Column(name = "current_version")
+    public Integer currentVersion;
+
+    @Column(name = "created_on", nullable = false)
+    public Instant createdOn;
+
+    @Column(name = "updated_on", nullable = false)
+    public Instant updatedOn;
+}

--- a/core/src/main/java/io/apitomy/axiom/core/entities/WorkflowDefinitionVersionEntity.java
+++ b/core/src/main/java/io/apitomy/axiom/core/entities/WorkflowDefinitionVersionEntity.java
@@ -1,0 +1,27 @@
+package io.apitomy.axiom.core.entities;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "workflow_definition_version",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"definition_id", "version"}))
+public class WorkflowDefinitionVersionEntity extends PanacheEntity {
+
+    @Column(name = "definition_id", nullable = false)
+    public Long definitionId;
+
+    @Column(nullable = false)
+    public int version;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    public String content;
+
+    @Column(name = "created_on", nullable = false)
+    public Instant createdOn;
+}

--- a/docs/superpowers/plans/2026-08-20-workflow-definitions-phase1.md
+++ b/docs/superpowers/plans/2026-08-20-workflow-definitions-phase1.md
@@ -1,0 +1,1479 @@
+# Workflow Definitions (Phase 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add workflow definition CRUD, versioning, and a visual editor to Axiom using Apitomy
+Flow.
+
+**Architecture:** New `workflow_definition` and `workflow_definition_version` database tables
+with Panache entities, a REST API following the contract-first pattern (OpenAPI spec first,
+generated JAX-RS interfaces), and a React UI under the Components section embedding the
+`WorkflowEditor` component from `@apitomy/flow-ui`.
+
+**Tech Stack:** Java 25 / Quarkus 3.38 / Panache / Flyway / H2+PostgreSQL (backend), React 19
+/ PatternFly 6 / @apitomy/flow-ui / @xyflow/react (frontend), Apitomy Flow Engine 1.0.1
+(validation)
+
+**Spec:** `docs/superpowers/specs/2026-08-20-workflow-definitions-phase1-design.md`
+
+**GitHub Issue:** #228
+
+## Global Constraints
+
+- Follow contract-first development: OpenAPI spec changes first, then `mvn install` to
+  generate interfaces, then implement.
+- REST resource impls must implement generated interfaces — no `@Path` on impl classes.
+- Use generated beans from `io.apitomy.axiom.api.beans` for request/response types.
+- Entities use Panache active record style (public fields, extend `PanacheEntity`).
+- Do not run tests or Maven builds automatically — the user handles compilation and testing.
+- Do not include Claude attribution in commit messages.
+
+## Prerequisites
+
+Before starting, ensure:
+1. Apitomy Flow Engine is installed to local Maven repo:
+   `cd ~/git/apitomy/apitomy-flow/engine && mvn install -DskipTests`
+2. Apitomy Flow UI is built and linked:
+   `cd ~/git/apitomy/apitomy-flow/ui && npm install && npm run build && npm link`
+3. Link the Flow UI into Axiom's UI:
+   `cd ~/git/apitomy/apitomy-axiom/ui && npm link @apitomy/flow-ui`
+
+---
+
+### Task 1: OpenAPI Spec — Workflow Definition Schemas and Endpoints
+
+**Files:**
+- Modify: `common/api/src/main/resources/openapi.json`
+
+**Interfaces:**
+- Produces: Generated `WorkflowDefinitionsResource` interface,
+  `WorkflowDefinition` / `NewWorkflowDefinition` / `UpdateWorkflowDefinition` /
+  `WorkflowDefinitionVersion` / `WorkflowDefinitionSearchResults` beans in
+  `io.apitomy.axiom.api.beans`
+
+- [ ] **Step 1: Add the `WorkflowDefinition` schema**
+
+Add to the `components.schemas` section of `openapi.json`:
+
+```json
+"WorkflowDefinition": {
+    "required": [
+        "name",
+        "createdOn",
+        "updatedOn"
+    ],
+    "type": "object",
+    "properties": {
+        "id": {
+            "format": "int64",
+            "type": "integer"
+        },
+        "name": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "content": {
+            "type": "object"
+        },
+        "currentVersion": {
+            "format": "int32",
+            "type": "integer"
+        },
+        "createdOn": {
+            "format": "date-time",
+            "type": "string"
+        },
+        "updatedOn": {
+            "format": "date-time",
+            "type": "string"
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add the `NewWorkflowDefinition` schema**
+
+```json
+"NewWorkflowDefinition": {
+    "required": [
+        "name"
+    ],
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Add the `UpdateWorkflowDefinition` schema**
+
+```json
+"UpdateWorkflowDefinition": {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Add the `WorkflowDefinitionVersion` schema**
+
+```json
+"WorkflowDefinitionVersion": {
+    "required": [
+        "definitionId",
+        "version",
+        "createdOn"
+    ],
+    "type": "object",
+    "properties": {
+        "id": {
+            "format": "int64",
+            "type": "integer"
+        },
+        "definitionId": {
+            "format": "int64",
+            "type": "integer"
+        },
+        "version": {
+            "format": "int32",
+            "type": "integer"
+        },
+        "content": {
+            "type": "object"
+        },
+        "createdOn": {
+            "format": "date-time",
+            "type": "string"
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Add the `WorkflowDefinitionSearchResults` schema**
+
+```json
+"WorkflowDefinitionSearchResults": {
+    "type": "object",
+    "properties": {
+        "items": {
+            "type": "array",
+            "items": {
+                "$ref": "#/components/schemas/WorkflowDefinition"
+            }
+        },
+        "totalCount": {
+            "format": "int64",
+            "type": "integer"
+        },
+        "page": {
+            "format": "int32",
+            "type": "integer"
+        },
+        "limit": {
+            "format": "int32",
+            "type": "integer"
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Add the collection path `/workflow-definitions`**
+
+Add to the `paths` section. Tag: `"WorkflowDefinitions"`. Operations:
+
+**GET** — List workflow definitions. Query parameters: `page` (int32, default 1), `limit`
+(int32, default 20), `filterName` (string, optional). Returns `WorkflowDefinitionSearchResults`.
+
+**POST** — Create a workflow definition. Request body: `NewWorkflowDefinition`. Response: 200
+with `WorkflowDefinition`.
+
+- [ ] **Step 7: Add the item path `/workflow-definitions/{workflowDefinitionId}`**
+
+Path parameter: `workflowDefinitionId` (int64). Operations:
+
+**GET** — Get a workflow definition. Response: 200 with `WorkflowDefinition`, 404 `NotFound`.
+
+**PUT** — Update metadata. Request body: `UpdateWorkflowDefinition`. Response: 200 with
+`WorkflowDefinition`, 404 `NotFound`.
+
+**DELETE** — Delete a workflow definition. Response: 204, 404 `NotFound`.
+
+- [ ] **Step 8: Add the content path `/workflow-definitions/{workflowDefinitionId}/content`**
+
+**PUT** — Update draft workflow content. Request body: free-form JSON object (`type: object`).
+Response: 204 (no content). 404 `NotFound`.
+
+- [ ] **Step 9: Add the publish path `/workflow-definitions/{workflowDefinitionId}/publish`**
+
+**POST** — Publish current draft as a new version. No request body. Response: 200 with
+`WorkflowDefinitionVersion`. 400 if validation fails (return array of validation problem
+objects). 404 `NotFound`.
+
+- [ ] **Step 10: Add the versions collection path
+`/workflow-definitions/{workflowDefinitionId}/versions`**
+
+**GET** — List all published versions. Response: 200 with array of `WorkflowDefinitionVersion`.
+
+- [ ] **Step 11: Add the version item path
+`/workflow-definitions/{workflowDefinitionId}/versions/{version}`**
+
+Path parameter: `version` (int32). Operations:
+
+**GET** — Get a specific version. Response: 200 with `WorkflowDefinitionVersion`. 404
+`NotFound`.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add common/api/src/main/resources/openapi.json
+git commit -m "feat(api): add workflow definition OpenAPI schemas and endpoints"
+```
+
+After this commit, run `mvn install` to generate the Java interfaces and beans. The generated
+`WorkflowDefinitionsResource` interface and bean classes in `io.apitomy.axiom.api.beans` will
+be used in subsequent tasks.
+
+---
+
+### Task 2: Database Migration and Entities
+
+**Files:**
+- Create: `app/src/main/resources/db/migration/V43__create_workflow_definitions.sql`
+- Create: `core/src/main/java/io/apitomy/axiom/core/entities/WorkflowDefinitionEntity.java`
+- Create: `core/src/main/java/io/apitomy/axiom/core/entities/WorkflowDefinitionVersionEntity.java`
+
+**Interfaces:**
+- Produces: `WorkflowDefinitionEntity` and `WorkflowDefinitionVersionEntity` Panache entities
+  used by the REST resource in Task 3
+
+- [ ] **Step 1: Create the Flyway migration**
+
+Create `app/src/main/resources/db/migration/V43__create_workflow_definitions.sql`:
+
+```sql
+CREATE TABLE workflow_definition (
+    id BIGSERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL UNIQUE,
+    description TEXT,
+    content TEXT,
+    current_version INT,
+    created_on TIMESTAMP NOT NULL,
+    updated_on TIMESTAMP NOT NULL
+);
+
+CREATE TABLE workflow_definition_version (
+    id BIGSERIAL PRIMARY KEY,
+    definition_id BIGINT NOT NULL REFERENCES workflow_definition(id) ON DELETE CASCADE,
+    version INT NOT NULL,
+    content TEXT NOT NULL,
+    created_on TIMESTAMP NOT NULL,
+    CONSTRAINT uq_definition_version UNIQUE (definition_id, version)
+);
+
+CREATE INDEX idx_wf_def_version_def_id ON workflow_definition_version(definition_id);
+```
+
+- [ ] **Step 2: Create `WorkflowDefinitionEntity`**
+
+Create `core/src/main/java/io/apitomy/axiom/core/entities/WorkflowDefinitionEntity.java`:
+
+```java
+package io.apitomy.axiom.core.entities;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "workflow_definition")
+public class WorkflowDefinitionEntity extends PanacheEntity {
+
+    @Column(nullable = false, unique = true)
+    public String name;
+
+    @Column(columnDefinition = "TEXT")
+    public String description;
+
+    @Column(columnDefinition = "TEXT")
+    public String content;
+
+    @Column(name = "current_version")
+    public Integer currentVersion;
+
+    @Column(name = "created_on", nullable = false)
+    public Instant createdOn;
+
+    @Column(name = "updated_on", nullable = false)
+    public Instant updatedOn;
+}
+```
+
+- [ ] **Step 3: Create `WorkflowDefinitionVersionEntity`**
+
+Create
+`core/src/main/java/io/apitomy/axiom/core/entities/WorkflowDefinitionVersionEntity.java`:
+
+```java
+package io.apitomy.axiom.core.entities;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "workflow_definition_version",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"definition_id", "version"}))
+public class WorkflowDefinitionVersionEntity extends PanacheEntity {
+
+    @Column(name = "definition_id", nullable = false)
+    public Long definitionId;
+
+    @Column(nullable = false)
+    public int version;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    public String content;
+
+    @Column(name = "created_on", nullable = false)
+    public Instant createdOn;
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/resources/db/migration/V43__create_workflow_definitions.sql \
+       core/src/main/java/io/apitomy/axiom/core/entities/WorkflowDefinitionEntity.java \
+       core/src/main/java/io/apitomy/axiom/core/entities/WorkflowDefinitionVersionEntity.java
+git commit -m "feat: add workflow definition DB migration and entities"
+```
+
+---
+
+### Task 3: REST Resource Implementation
+
+**Files:**
+- Create: `app/src/main/java/io/apitomy/axiom/app/rest/WorkflowDefinitionsResourceImpl.java`
+- Modify: `app/pom.xml` (add `apitomy-flow-engine` dependency)
+
+**Interfaces:**
+- Consumes: Generated `WorkflowDefinitionsResource` interface and beans from Task 1;
+  `WorkflowDefinitionEntity` and `WorkflowDefinitionVersionEntity` from Task 2
+- Produces: Working REST API at `/api/v1/workflow-definitions`
+
+- [ ] **Step 1: Add the Apitomy Flow Engine dependency to `app/pom.xml`**
+
+Add to the `<dependencies>` section of `app/pom.xml`:
+
+```xml
+<dependency>
+    <groupId>io.apitomy</groupId>
+    <artifactId>apitomy-flow-engine</artifactId>
+    <version>1.0.1-SNAPSHOT</version>
+</dependency>
+```
+
+- [ ] **Step 2: Create `WorkflowDefinitionsResourceImpl`**
+
+Create
+`app/src/main/java/io/apitomy/axiom/app/rest/WorkflowDefinitionsResourceImpl.java`.
+
+This is a large file. The key elements:
+
+```java
+package io.apitomy.axiom.app.rest;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.apitomy.axiom.api.WorkflowDefinitionsResource;
+import io.apitomy.axiom.api.beans.*;
+import io.apitomy.axiom.core.entities.WorkflowDefinitionEntity;
+import io.apitomy.axiom.core.entities.WorkflowDefinitionVersionEntity;
+import io.apitomy.flow.model.Workflow;
+import io.apitomy.flow.validation.ValidationProblem;
+import io.apitomy.flow.validation.ValidationSeverity;
+import io.apitomy.flow.validation.WorkflowValidator;
+import io.quarkus.hibernate.orm.panache.PanacheQuery;
+import io.quarkus.panache.common.Page;
+import io.quarkus.panache.common.Sort;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import org.jboss.resteasy.reactive.common.NotImplementedYet;
+
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.*;
+
+@ApplicationScoped
+public class WorkflowDefinitionsResourceImpl implements WorkflowDefinitionsResource {
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    // -- List --
+    @Override
+    public WorkflowDefinitionSearchResults listWorkflowDefinitions(
+            BigInteger page, BigInteger limit, String filterName) {
+        int pageNum = page != null ? page.intValue() : 1;
+        int pageSize = limit != null ? limit.intValue() : 20;
+
+        StringBuilder hql = new StringBuilder("1=1");
+        Map<String, Object> params = new HashMap<>();
+
+        if (filterName != null && !filterName.isBlank()) {
+            hql.append(" and lower(name) like :name");
+            params.put("name", "%" + filterName.toLowerCase() + "%");
+        }
+
+        PanacheQuery<WorkflowDefinitionEntity> query = WorkflowDefinitionEntity
+                .find(hql.toString(), Sort.ascending("name"), params)
+                .page(Page.of(pageNum - 1, pageSize));
+
+        WorkflowDefinitionSearchResults results = new WorkflowDefinitionSearchResults();
+        results.setItems(query.list().stream().map(this::toBean).toList());
+        results.setTotalCount(query.count());
+        results.setPage(pageNum);
+        results.setLimit(pageSize);
+        return results;
+    }
+
+    // -- Create --
+    @Override
+    @Transactional
+    public WorkflowDefinition createWorkflowDefinition(NewWorkflowDefinition data) {
+        checkDuplicateName(data.getName(), null);
+
+        WorkflowDefinitionEntity entity = new WorkflowDefinitionEntity();
+        entity.name = data.getName();
+        entity.description = data.getDescription();
+        entity.content = createEmptyWorkflowContent(data.getName());
+        entity.createdOn = Instant.now();
+        entity.updatedOn = Instant.now();
+        entity.persist();
+
+        return toBean(entity);
+    }
+
+    // -- Get --
+    @Override
+    public WorkflowDefinition getWorkflowDefinition(long workflowDefinitionId) {
+        return toBean(findOrThrow(workflowDefinitionId));
+    }
+
+    // -- Update metadata --
+    @Override
+    @Transactional
+    public WorkflowDefinition updateWorkflowDefinition(
+            long workflowDefinitionId, UpdateWorkflowDefinition data) {
+        WorkflowDefinitionEntity entity = findOrThrow(workflowDefinitionId);
+
+        if (data.getName() != null) {
+            checkDuplicateName(data.getName(), entity.id);
+            entity.name = data.getName();
+        }
+        if (data.getDescription() != null) {
+            entity.description = data.getDescription();
+        }
+        entity.updatedOn = Instant.now();
+
+        return toBean(entity);
+    }
+
+    // -- Delete --
+    @Override
+    @Transactional
+    public void deleteWorkflowDefinition(long workflowDefinitionId) {
+        WorkflowDefinitionEntity entity = findOrThrow(workflowDefinitionId);
+        // Versions cascade-deleted via FK ON DELETE CASCADE
+        entity.delete();
+    }
+
+    // -- Update content --
+    @Override
+    @Transactional
+    public void updateWorkflowDefinitionContent(long workflowDefinitionId, Object content) {
+        WorkflowDefinitionEntity entity = findOrThrow(workflowDefinitionId);
+        try {
+            entity.content = objectMapper.writeValueAsString(content);
+        } catch (JsonProcessingException e) {
+            throw new WebApplicationException("Invalid workflow content", 400);
+        }
+        entity.updatedOn = Instant.now();
+    }
+
+    // -- Publish --
+    @Override
+    @Transactional
+    public WorkflowDefinitionVersion publishWorkflowDefinition(long workflowDefinitionId) {
+        WorkflowDefinitionEntity entity = findOrThrow(workflowDefinitionId);
+
+        if (entity.content == null || entity.content.isBlank()) {
+            throw new WebApplicationException("No draft content to publish", 400);
+        }
+
+        // Deserialize and validate
+        Workflow workflow;
+        try {
+            workflow = objectMapper.readValue(entity.content, Workflow.class);
+        } catch (JsonProcessingException e) {
+            throw new WebApplicationException("Invalid workflow JSON: " + e.getMessage(), 400);
+        }
+
+        List<ValidationProblem> problems = WorkflowValidator.validate(workflow);
+        List<ValidationProblem> errors = problems.stream()
+                .filter(p -> p.severity() == ValidationSeverity.ERROR)
+                .toList();
+        if (!errors.isEmpty()) {
+            throw new WebApplicationException(
+                    Response.status(400).entity(errors).build());
+        }
+
+        // Create version
+        int newVersion = entity.currentVersion != null ? entity.currentVersion + 1 : 1;
+
+        WorkflowDefinitionVersionEntity version = new WorkflowDefinitionVersionEntity();
+        version.definitionId = entity.id;
+        version.version = newVersion;
+        version.content = entity.content;
+        version.createdOn = Instant.now();
+        version.persist();
+
+        entity.currentVersion = newVersion;
+        entity.updatedOn = Instant.now();
+
+        return toVersionBean(version);
+    }
+
+    // -- List versions --
+    @Override
+    public List<WorkflowDefinitionVersion> listWorkflowDefinitionVersions(
+            long workflowDefinitionId) {
+        findOrThrow(workflowDefinitionId);
+        List<WorkflowDefinitionVersionEntity> versions = WorkflowDefinitionVersionEntity
+                .find("definitionId", Sort.descending("version"), workflowDefinitionId)
+                .list();
+        return versions.stream().map(this::toVersionBean).toList();
+    }
+
+    // -- Get version --
+    @Override
+    public WorkflowDefinitionVersion getWorkflowDefinitionVersion(
+            long workflowDefinitionId, int version) {
+        findOrThrow(workflowDefinitionId);
+        WorkflowDefinitionVersionEntity entity = WorkflowDefinitionVersionEntity
+                .find("definitionId = ?1 and version = ?2", workflowDefinitionId, version)
+                .firstResult();
+        if (entity == null) {
+            throw new WebApplicationException(404);
+        }
+        return toVersionBean(entity);
+    }
+
+    // -- Helpers --
+
+    private WorkflowDefinitionEntity findOrThrow(long id) {
+        WorkflowDefinitionEntity entity = WorkflowDefinitionEntity.findById(id);
+        if (entity == null) {
+            throw new WebApplicationException(404);
+        }
+        return entity;
+    }
+
+    private void checkDuplicateName(String name, Long excludeId) {
+        WorkflowDefinitionEntity existing = WorkflowDefinitionEntity
+                .find("name", name).firstResult();
+        if (existing != null && (excludeId == null || !existing.id.equals(excludeId))) {
+            throw new WebApplicationException("Workflow definition name already exists", 409);
+        }
+    }
+
+    private WorkflowDefinition toBean(WorkflowDefinitionEntity entity) {
+        WorkflowDefinition bean = new WorkflowDefinition();
+        bean.setId(entity.id);
+        bean.setName(entity.name);
+        bean.setDescription(entity.description);
+        if (entity.content != null) {
+            try {
+                bean.setContent(objectMapper.readValue(entity.content, Object.class));
+            } catch (JsonProcessingException e) {
+                bean.setContent(null);
+            }
+        }
+        bean.setCurrentVersion(entity.currentVersion);
+        bean.setCreatedOn(Date.from(entity.createdOn));
+        bean.setUpdatedOn(Date.from(entity.updatedOn));
+        return bean;
+    }
+
+    private WorkflowDefinitionVersion toVersionBean(WorkflowDefinitionVersionEntity entity) {
+        WorkflowDefinitionVersion bean = new WorkflowDefinitionVersion();
+        bean.setId(entity.id);
+        bean.setDefinitionId(entity.definitionId);
+        bean.setVersion(entity.version);
+        if (entity.content != null) {
+            try {
+                bean.setContent(objectMapper.readValue(entity.content, Object.class));
+            } catch (JsonProcessingException e) {
+                bean.setContent(null);
+            }
+        }
+        bean.setCreatedOn(Date.from(entity.createdOn));
+        return bean;
+    }
+
+    private String createEmptyWorkflowContent(String name) {
+        Map<String, Object> startNode = Map.of(
+                "id", "start-1",
+                "type", "start",
+                "name", "Start",
+                "config", Map.of(),
+                "position", Map.of("x", 250, "y", 100));
+        Map<String, Object> endNode = Map.of(
+                "id", "end-1",
+                "type", "end",
+                "name", "End",
+                "config", Map.of(),
+                "position", Map.of("x", 250, "y", 400));
+        Map<String, Object> edge = Map.of(
+                "id", "edge-1",
+                "source", "start-1",
+                "target", "end-1",
+                "priority", 0,
+                "isDefault", true);
+        Map<String, Object> workflow = Map.of(
+                "id", UUID.randomUUID().toString(),
+                "name", name,
+                "nodes", List.of(startNode, endNode),
+                "edges", List.of(edge));
+        try {
+            return objectMapper.writeValueAsString(workflow);
+        } catch (JsonProcessingException e) {
+            return "{}";
+        }
+    }
+}
+```
+
+Note: The exact method signatures on the generated `WorkflowDefinitionsResource` interface
+depend on the OpenAPI spec from Task 1. The parameter names and types above match the spec
+design. Adjust if the generated interface differs slightly (e.g., parameter types may be
+`BigInteger` for numeric query params, `long` for path params).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/pom.xml \
+       app/src/main/java/io/apitomy/axiom/app/rest/WorkflowDefinitionsResourceImpl.java
+git commit -m "feat: implement workflow definitions REST resource"
+```
+
+---
+
+### Task 4: Backend Integration Tests
+
+**Files:**
+- Create: `app/src/test/java/io/apitomy/axiom/app/WorkflowDefinitionsResourceTest.java`
+
+**Interfaces:**
+- Consumes: REST API from Task 3
+
+- [ ] **Step 1: Create the integration test**
+
+Create
+`app/src/test/java/io/apitomy/axiom/app/WorkflowDefinitionsResourceTest.java`:
+
+```java
+package io.apitomy.axiom.app;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+class WorkflowDefinitionsResourceTest {
+
+    private static final String BASE_PATH = "/api/v1/workflow-definitions";
+
+    @Test
+    void testCreateAndGetWorkflowDefinition() {
+        int id = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                    {
+                        "name": "Test Workflow",
+                        "description": "A test workflow"
+                    }
+                    """)
+                .when()
+                    .post(BASE_PATH)
+                .then()
+                    .statusCode(200)
+                    .body("name", equalTo("Test Workflow"))
+                    .body("description", equalTo("A test workflow"))
+                    .body("id", notNullValue())
+                    .body("content", notNullValue())
+                    .body("currentVersion", nullValue())
+                    .body("createdOn", notNullValue())
+                    .body("updatedOn", notNullValue())
+                    .extract().path("id");
+
+        given()
+                .when()
+                    .get(BASE_PATH + "/" + id)
+                .then()
+                    .statusCode(200)
+                    .body("name", equalTo("Test Workflow"))
+                    .body("content.nodes.size()", equalTo(2))
+                    .body("content.edges.size()", equalTo(1));
+    }
+
+    @Test
+    void testListWorkflowDefinitions() {
+        createDefinition("List Test WF 1");
+        createDefinition("List Test WF 2");
+
+        given()
+                .when()
+                    .get(BASE_PATH)
+                .then()
+                    .statusCode(200)
+                    .body("items.size()", greaterThanOrEqualTo(2))
+                    .body("totalCount", greaterThanOrEqualTo(2))
+                    .body("page", equalTo(1))
+                    .body("limit", equalTo(20));
+    }
+
+    @Test
+    void testFilterByName() {
+        createDefinition("Unique Filter WF Name");
+
+        given()
+                .queryParam("filterName", "Unique Filter WF")
+                .when()
+                    .get(BASE_PATH)
+                .then()
+                    .statusCode(200)
+                    .body("items.size()", greaterThanOrEqualTo(1))
+                    .body("items.name", hasItem(containsString("Unique Filter WF")));
+    }
+
+    @Test
+    void testUpdateMetadata() {
+        int id = createDefinition("Update Meta WF");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                    {
+                        "name": "Updated WF Name",
+                        "description": "Updated description"
+                    }
+                    """)
+                .when()
+                    .put(BASE_PATH + "/" + id)
+                .then()
+                    .statusCode(200)
+                    .body("name", equalTo("Updated WF Name"))
+                    .body("description", equalTo("Updated description"));
+    }
+
+    @Test
+    void testUpdateContent() {
+        int id = createDefinition("Content Update WF");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                    {
+                        "id": "wf-test",
+                        "name": "Content Update WF",
+                        "nodes": [
+                            {"id": "s1", "type": "start", "name": "Start",
+                             "config": {}, "position": {"x": 100, "y": 100}},
+                            {"id": "e1", "type": "end", "name": "End",
+                             "config": {}, "position": {"x": 100, "y": 300}}
+                        ],
+                        "edges": [
+                            {"id": "edge1", "source": "s1", "target": "e1",
+                             "priority": 0, "isDefault": true}
+                        ]
+                    }
+                    """)
+                .when()
+                    .put(BASE_PATH + "/" + id + "/content")
+                .then()
+                    .statusCode(204);
+
+        given()
+                .when()
+                    .get(BASE_PATH + "/" + id)
+                .then()
+                    .statusCode(200)
+                    .body("content.id", equalTo("wf-test"));
+    }
+
+    @Test
+    void testPublishValidWorkflow() {
+        int id = createDefinition("Publish WF");
+
+        // Update with valid content
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                    {
+                        "id": "wf-pub",
+                        "name": "Publish WF",
+                        "nodes": [
+                            {"id": "s1", "type": "start", "name": "Start",
+                             "config": {}, "position": {"x": 100, "y": 100}},
+                            {"id": "e1", "type": "end", "name": "End",
+                             "config": {}, "position": {"x": 100, "y": 300}}
+                        ],
+                        "edges": [
+                            {"id": "edge1", "source": "s1", "target": "e1",
+                             "priority": 0, "isDefault": true}
+                        ]
+                    }
+                    """)
+                .when()
+                    .put(BASE_PATH + "/" + id + "/content")
+                .then()
+                    .statusCode(204);
+
+        // Publish
+        given()
+                .when()
+                    .post(BASE_PATH + "/" + id + "/publish")
+                .then()
+                    .statusCode(200)
+                    .body("version", equalTo(1))
+                    .body("definitionId", equalTo(id))
+                    .body("content", notNullValue())
+                    .body("createdOn", notNullValue());
+
+        // Verify currentVersion updated
+        given()
+                .when()
+                    .get(BASE_PATH + "/" + id)
+                .then()
+                    .statusCode(200)
+                    .body("currentVersion", equalTo(1));
+
+        // Publish again — version increments
+        given()
+                .when()
+                    .post(BASE_PATH + "/" + id + "/publish")
+                .then()
+                    .statusCode(200)
+                    .body("version", equalTo(2));
+    }
+
+    @Test
+    void testPublishInvalidWorkflowReturns400() {
+        int id = createDefinition("Invalid Publish WF");
+
+        // Update with invalid content (no start node)
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                    {
+                        "id": "wf-invalid",
+                        "name": "Invalid",
+                        "nodes": [
+                            {"id": "e1", "type": "end", "name": "End",
+                             "config": {}, "position": {"x": 100, "y": 300}}
+                        ],
+                        "edges": []
+                    }
+                    """)
+                .when()
+                    .put(BASE_PATH + "/" + id + "/content")
+                .then()
+                    .statusCode(204);
+
+        // Publish should fail
+        given()
+                .when()
+                    .post(BASE_PATH + "/" + id + "/publish")
+                .then()
+                    .statusCode(400);
+    }
+
+    @Test
+    void testListVersions() {
+        int id = createAndPublishDefinition("Versions List WF");
+
+        given()
+                .when()
+                    .get(BASE_PATH + "/" + id + "/versions")
+                .then()
+                    .statusCode(200)
+                    .body("size()", equalTo(1))
+                    .body("[0].version", equalTo(1));
+    }
+
+    @Test
+    void testGetSpecificVersion() {
+        int id = createAndPublishDefinition("Version Get WF");
+
+        given()
+                .when()
+                    .get(BASE_PATH + "/" + id + "/versions/1")
+                .then()
+                    .statusCode(200)
+                    .body("version", equalTo(1))
+                    .body("content", notNullValue());
+    }
+
+    @Test
+    void testDeleteWorkflowDefinition() {
+        int id = createDefinition("Delete WF");
+
+        given()
+                .when()
+                    .delete(BASE_PATH + "/" + id)
+                .then()
+                    .statusCode(204);
+
+        given()
+                .when()
+                    .get(BASE_PATH + "/" + id)
+                .then()
+                    .statusCode(404);
+    }
+
+    @Test
+    void testGetNotFound() {
+        given()
+                .when()
+                    .get(BASE_PATH + "/99999")
+                .then()
+                    .statusCode(404);
+    }
+
+    @Test
+    void testDuplicateNameReturns409() {
+        createDefinition("Dup Name WF");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                    {
+                        "name": "Dup Name WF"
+                    }
+                    """)
+                .when()
+                    .post(BASE_PATH)
+                .then()
+                    .statusCode(409);
+    }
+
+    // -- Helpers --
+
+    private int createDefinition(String name) {
+        return given()
+                .contentType(ContentType.JSON)
+                .body(String.format("""
+                    {
+                        "name": "%s"
+                    }
+                    """, name))
+                .when()
+                    .post(BASE_PATH)
+                .then()
+                    .statusCode(200)
+                    .extract().path("id");
+    }
+
+    private int createAndPublishDefinition(String name) {
+        int id = createDefinition(name);
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                    {
+                        "id": "wf-test",
+                        "name": "Test",
+                        "nodes": [
+                            {"id": "s1", "type": "start", "name": "Start",
+                             "config": {}, "position": {"x": 100, "y": 100}},
+                            {"id": "e1", "type": "end", "name": "End",
+                             "config": {}, "position": {"x": 100, "y": 300}}
+                        ],
+                        "edges": [
+                            {"id": "edge1", "source": "s1", "target": "e1",
+                             "priority": 0, "isDefault": true}
+                        ]
+                    }
+                    """)
+                .when()
+                    .put(BASE_PATH + "/" + id + "/content")
+                .then()
+                    .statusCode(204);
+
+        given()
+                .when()
+                    .post(BASE_PATH + "/" + id + "/publish")
+                .then()
+                    .statusCode(200);
+
+        return id;
+    }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/src/test/java/io/apitomy/axiom/app/WorkflowDefinitionsResourceTest.java
+git commit -m "test: add workflow definitions REST integration tests"
+```
+
+---
+
+### Task 5: UI Foundation — Types, API Client, Navigation, Routes
+
+**Files:**
+- Modify: `ui/package.json` (add `@apitomy/flow-ui` dependency)
+- Modify: `ui/src/config/api.ts` (add types and fetch functions)
+- Modify: `ui/src/components/AppSidebar.tsx` (add Workflows nav item)
+- Modify: `ui/src/App.tsx` (add routes)
+
+**Interfaces:**
+- Produces: TypeScript types `WorkflowDefinition`, `NewWorkflowDefinition`,
+  `WorkflowDefinitionVersion`; fetch functions `fetchWorkflowDefinitions`,
+  `createWorkflowDefinition`, `getWorkflowDefinition`,
+  `updateWorkflowDefinition`, `updateWorkflowDefinitionContent`,
+  `publishWorkflowDefinition`, `deleteWorkflowDefinition`,
+  `listWorkflowDefinitionVersions`, `getWorkflowDefinitionVersion`;
+  navigation and routes for `/components/workflows` and
+  `/components/workflows/:workflowDefinitionId`
+
+- [ ] **Step 1: Add `@apitomy/flow-ui` to `ui/package.json`**
+
+If using npm link (from prerequisites), the dependency is already linked. Otherwise add:
+
+```json
+"@apitomy/flow-ui": "1.0.1-SNAPSHOT"
+```
+
+The peer dependency `@xyflow/react` is already present at version 12.11.3.
+
+- [ ] **Step 2: Add TypeScript interfaces to `ui/src/config/api.ts`**
+
+Add after the existing interface definitions:
+
+```typescript
+export interface WorkflowDefinition {
+    id: number;
+    name: string;
+    description?: string;
+    content?: any;
+    currentVersion?: number;
+    createdOn: string;
+    updatedOn: string;
+}
+
+export interface NewWorkflowDefinition {
+    name: string;
+    description?: string;
+}
+
+export interface UpdateWorkflowDefinition {
+    name?: string;
+    description?: string;
+}
+
+export interface WorkflowDefinitionVersion {
+    id: number;
+    definitionId: number;
+    version: number;
+    content?: any;
+    createdOn: string;
+}
+```
+
+- [ ] **Step 3: Add API client functions to `ui/src/config/api.ts`**
+
+Add after the existing fetch functions:
+
+```typescript
+export async function fetchWorkflowDefinitions(
+    page = 1, limit = 20, filterName?: string
+): Promise<SearchResults<WorkflowDefinition>> {
+    const params = new URLSearchParams();
+    params.set("page", String(page));
+    params.set("limit", String(limit));
+    if (filterName) params.set("filterName", filterName);
+    const response = await fetch(`${API}/workflow-definitions?${params}`);
+    if (!response.ok) throw new Error(`Failed to fetch workflow definitions: ${response.status}`);
+    return response.json();
+}
+
+export async function createWorkflowDefinition(
+    data: NewWorkflowDefinition
+): Promise<WorkflowDefinition> {
+    const response = await fetch(`${API}/workflow-definitions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+    });
+    if (!response.ok) throw new Error(`Failed to create workflow definition: ${response.status}`);
+    return response.json();
+}
+
+export async function getWorkflowDefinition(id: number): Promise<WorkflowDefinition> {
+    const response = await fetch(`${API}/workflow-definitions/${id}`);
+    if (!response.ok) throw new Error(`Failed to get workflow definition: ${response.status}`);
+    return response.json();
+}
+
+export async function updateWorkflowDefinition(
+    id: number, data: UpdateWorkflowDefinition
+): Promise<WorkflowDefinition> {
+    const response = await fetch(`${API}/workflow-definitions/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+    });
+    if (!response.ok) throw new Error(`Failed to update workflow definition: ${response.status}`);
+    return response.json();
+}
+
+export async function updateWorkflowDefinitionContent(
+    id: number, content: any
+): Promise<void> {
+    const response = await fetch(`${API}/workflow-definitions/${id}/content`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(content),
+    });
+    if (!response.ok) throw new Error(`Failed to update workflow content: ${response.status}`);
+}
+
+export async function publishWorkflowDefinition(
+    id: number
+): Promise<WorkflowDefinitionVersion> {
+    const response = await fetch(`${API}/workflow-definitions/${id}/publish`, {
+        method: "POST",
+    });
+    if (!response.ok) throw new Error(`Failed to publish workflow definition: ${response.status}`);
+    return response.json();
+}
+
+export async function deleteWorkflowDefinition(id: number): Promise<void> {
+    const response = await fetch(`${API}/workflow-definitions/${id}`, {
+        method: "DELETE",
+    });
+    if (!response.ok) throw new Error(`Failed to delete workflow definition: ${response.status}`);
+}
+
+export async function listWorkflowDefinitionVersions(
+    id: number
+): Promise<WorkflowDefinitionVersion[]> {
+    const response = await fetch(`${API}/workflow-definitions/${id}/versions`);
+    if (!response.ok) throw new Error(`Failed to list versions: ${response.status}`);
+    return response.json();
+}
+
+export async function getWorkflowDefinitionVersion(
+    id: number, version: number
+): Promise<WorkflowDefinitionVersion> {
+    const response = await fetch(`${API}/workflow-definitions/${id}/versions/${version}`);
+    if (!response.ok) throw new Error(`Failed to get version: ${response.status}`);
+    return response.json();
+}
+```
+
+- [ ] **Step 4: Add "Workflows" to `AppSidebar.tsx`**
+
+In `ui/src/components/AppSidebar.tsx`:
+
+1. Add `"/components/workflows"` to the `COMPONENT_PATHS` array.
+2. Add a `NavItem` inside the Components `NavExpandable`, positioned alphabetically (after
+   "Toolsets"):
+
+```tsx
+<NavItem
+    isActive={location.pathname.startsWith("/components/workflows")}
+    onClick={() => navigate("/components/workflows")}
+>
+    Workflows
+</NavItem>
+```
+
+- [ ] **Step 5: Add routes to `App.tsx`**
+
+In `ui/src/App.tsx`:
+
+1. Import the new page components:
+
+```typescript
+import { WorkflowDefinitionsPage } from "./pages/WorkflowDefinitionsPage";
+import { WorkflowDefinitionDetailPage } from "./pages/WorkflowDefinitionDetailPage";
+```
+
+2. Add routes alongside the other Components routes:
+
+```tsx
+<Route path="/components/workflows" element={<WorkflowDefinitionsPage />} />
+<Route path="/components/workflows/:workflowDefinitionId"
+       element={<WorkflowDefinitionDetailPage />} />
+```
+
+Note: The page components will be created in Tasks 6 and 7. For now, create placeholder files
+so the imports don't break:
+
+Create `ui/src/pages/WorkflowDefinitionsPage.tsx`:
+```tsx
+export function WorkflowDefinitionsPage() {
+    return <div>Workflow Definitions - Coming Soon</div>;
+}
+```
+
+Create `ui/src/pages/WorkflowDefinitionDetailPage.tsx`:
+```tsx
+export function WorkflowDefinitionDetailPage() {
+    return <div>Workflow Definition Detail - Coming Soon</div>;
+}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ui/src/config/api.ts \
+       ui/src/components/AppSidebar.tsx \
+       ui/src/App.tsx \
+       ui/src/pages/WorkflowDefinitionsPage.tsx \
+       ui/src/pages/WorkflowDefinitionDetailPage.tsx
+git commit -m "feat(ui): add workflow definitions types, API client, navigation, and routes"
+```
+
+---
+
+### Task 6: UI — Workflow Definitions List Page
+
+**Files:**
+- Modify: `ui/src/pages/WorkflowDefinitionsPage.tsx` (replace placeholder)
+
+**Interfaces:**
+- Consumes: `fetchWorkflowDefinitions`, `createWorkflowDefinition`,
+  `deleteWorkflowDefinition`, `WorkflowDefinition`, `NewWorkflowDefinition` from Task 5
+
+- [ ] **Step 1: Implement `WorkflowDefinitionsPage.tsx`**
+
+Replace the placeholder with the full implementation. Follow the pattern from
+`ActionTypesPage.tsx`:
+
+- State: `items` (WorkflowDefinition[]), `totalCount`, `isCreateOpen`, `deleteTarget`,
+  pagination state, filter state.
+- `load()` callback calls `fetchWorkflowDefinitions()` with current page/limit/filters.
+- Table columns: Name, Description, Version (show `currentVersion` or "Draft"), Updated.
+- Rows are clickable — navigate to `/components/workflows/${id}`.
+- Create modal with Name and Description fields. On create success, navigate to the new
+  definition's detail page.
+- Delete button per row with `ConfirmDeleteModal`.
+- Search by name using `ChipFilterInput`.
+
+Key UI elements to use (all from existing imports in the codebase):
+- `PageSection`, `Title`, `Toolbar`, `ToolbarContent`, `ToolbarItem` from PatternFly
+- `ChipFilterInput`, `FilterChips`, `ChipFilterCriteria` from `@apitomy/common-ui-components`
+- `Table`, `Thead`, `Tbody`, `Tr`, `Th`, `Td` from `@patternfly/react-table`
+- `Modal`, `ModalHeader`, `ModalBody`, `ModalFooter` from PatternFly
+- `Button`, `TextInput`, `TextArea`, `FormGroup`, `Form`, `Label` from PatternFly
+- `ConfirmDeleteModal` from `../components/ConfirmDeleteModal`
+
+The Version column should display:
+- `v{currentVersion}` with a PatternFly `<Label>` if published
+- "Draft" in a grey `<Label>` if `currentVersion` is null/undefined
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add ui/src/pages/WorkflowDefinitionsPage.tsx
+git commit -m "feat(ui): implement workflow definitions list page"
+```
+
+---
+
+### Task 7: UI — Workflow Definition Detail Page with Editor
+
+**Files:**
+- Modify: `ui/src/pages/WorkflowDefinitionDetailPage.tsx` (replace placeholder)
+- Modify: `ui/src/main.tsx` or the app's CSS entry point (add Flow CSS imports)
+
+**Interfaces:**
+- Consumes: `getWorkflowDefinition`, `updateWorkflowDefinition`,
+  `updateWorkflowDefinitionContent`, `publishWorkflowDefinition`,
+  `deleteWorkflowDefinition`, `listWorkflowDefinitionVersions`,
+  `fetchActionTypes` from Task 5;
+  `WorkflowEditor`, `EditorSpi`, `ActionTypeDescriptor`, `Workflow`,
+  `ValidationProblem` from `@apitomy/flow-ui`
+
+- [ ] **Step 1: Add CSS imports for Flow UI**
+
+In the app's CSS entry point (check where PatternFly CSS is imported — likely `ui/src/main.tsx`
+or `ui/src/index.css`), add:
+
+```typescript
+import "@xyflow/react/dist/style.css";
+import "@apitomy/flow-ui/style.css";
+```
+
+Note: `@xyflow/react/dist/style.css` may already be imported if Axiom uses React Flow
+elsewhere. Check before adding a duplicate.
+
+- [ ] **Step 2: Implement `WorkflowDefinitionDetailPage.tsx`**
+
+Replace the placeholder with the full implementation. Key structure:
+
+```tsx
+import { useParams, useNavigate } from "react-router-dom";
+import { useState, useEffect, useCallback, useRef } from "react";
+import { WorkflowEditor } from "@apitomy/flow-ui";
+import type { Workflow, ValidationProblem, EditorSpi,
+              ActionTypeDescriptor } from "@apitomy/flow-ui";
+import {
+    getWorkflowDefinition, updateWorkflowDefinition,
+    updateWorkflowDefinitionContent, publishWorkflowDefinition,
+    deleteWorkflowDefinition, listWorkflowDefinitionVersions,
+    fetchActionTypes,
+} from "../config/api";
+import type { WorkflowDefinition, WorkflowDefinitionVersion } from "../config/api";
+// PatternFly imports: PageSection, Breadcrumb, BreadcrumbItem, Title,
+// Button, Flex, FlexItem, Label, Modal, TextInput, TextArea, FormGroup,
+// Form, ExpandableSection, DescriptionList, etc.
+```
+
+**State:**
+- `definition: WorkflowDefinition | null` — loaded from API
+- `editorContent: Workflow | null` — current editor state (may differ from saved)
+- `dirty: boolean` — true when editor content differs from last save
+- `saving: boolean` — true during save operation
+- `publishing: boolean` — true during publish operation
+- `validationErrors: ValidationProblem[]` — from the editor's `onValidationChange`
+- `versions: WorkflowDefinitionVersion[]` — published version list
+- `useTheme` — match Axiom's current theme (check how other pages detect dark mode)
+
+**EditorSpi setup:**
+
+```tsx
+const spi: EditorSpi = {
+    actionTypes: async () => {
+        const results = await fetchActionTypes(1, 1000);
+        return results.items.map((at): ActionTypeDescriptor => ({
+            value: at.name,
+            label: at.name,
+            description: at.description,
+        }));
+    },
+};
+```
+
+**Editor integration:**
+
+```tsx
+<div style={{ flex: 1, minHeight: 0 }}>
+    <WorkflowEditor
+        workflow={editorContent}
+        onChange={(updated) => {
+            setEditorContent(updated);
+            setDirty(true);
+        }}
+        onValidationChange={(problems) => {
+            setValidationErrors(problems.filter(p => p.severity === "error"));
+        }}
+        theme={isDarkTheme ? "dark" : "light"}
+        spi={spi}
+    />
+</div>
+```
+
+The outer container must fill the viewport height. Use a flex column layout:
+
+```tsx
+<PageSection isFilled style={{ display: "flex", flexDirection: "column", padding: 0 }}>
+    {/* Header bar with breadcrumb, buttons */}
+    <div style={{ padding: "16px 24px", borderBottom: "1px solid var(--pf-t--global--border--color--default)" }}>
+        {/* Breadcrumb, title, Save/Publish/Delete buttons */}
+    </div>
+    {/* Editor fills remaining space */}
+    <div style={{ flex: 1, minHeight: 0 }}>
+        <WorkflowEditor ... />
+    </div>
+</PageSection>
+```
+
+**Save button logic:**
+- Disabled when: `!dirty || saving`
+- On click: call `updateWorkflowDefinitionContent(id, editorContent)`, then set
+  `dirty = false`
+- Visual: show "Unsaved changes" text or a dot indicator when dirty
+
+**Publish button logic:**
+- Disabled when: `dirty || publishing || validationErrors.length > 0`
+- On click: call `publishWorkflowDefinition(id)`, then reload definition and versions
+- On success, show a brief success alert
+
+**Metadata editing:**
+- Edit name/description via a modal (similar to how other detail pages handle it)
+- Call `updateWorkflowDefinition(id, { name, description })`
+
+**Version history:**
+- `ExpandableSection` below the header or as a sidebar panel
+- List versions with version number and timestamp
+- Load via `listWorkflowDefinitionVersions(id)` on page load and after publish
+
+**beforeunload guard:**
+
+```tsx
+useEffect(() => {
+    const handler = (e: BeforeUnloadEvent) => {
+        if (dirty) {
+            e.preventDefault();
+        }
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+}, [dirty]);
+```
+
+**Loading/not-found states:**
+- Show spinner while loading
+- Show 404 empty state if definition not found
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ui/src/pages/WorkflowDefinitionDetailPage.tsx \
+       ui/src/main.tsx
+git commit -m "feat(ui): implement workflow definition detail page with visual editor"
+```

--- a/docs/superpowers/specs/2026-08-20-workflow-definitions-phase1-design.md
+++ b/docs/superpowers/specs/2026-08-20-workflow-definitions-phase1-design.md
@@ -1,0 +1,298 @@
+# Workflow Definitions — Phase 1 Design
+
+**Date:** 2026-08-20
+**Epic:** Custom Workflow Feature for Axiom
+
+## Summary
+
+Add workflow definition management and a visual editor to Axiom, powered by
+[Apitomy Flow](~/git/apitomy/apitomy-flow). Users create workflow definitions using a
+drag-and-drop editor, save drafts, and publish immutable versioned snapshots. This is Phase 1
+of a multi-phase effort — later phases add execution, human tasks, event correlation, and wait
+node support.
+
+Apitomy Flow provides:
+- **Java engine** (`io.apitomy:apitomy-flow-engine`) — stateless workflow execution engine with
+  validation
+- **React UI** (`@apitomy/flow-ui`) — `WorkflowEditor` (drag-and-drop editor) and
+  `WorkflowViewer` (read-only instance viewer)
+
+Phase 1 uses the engine for server-side validation on publish, and the `WorkflowEditor`
+component for the visual editor UI.
+
+## Data Model
+
+### `workflow_definition` table
+
+Stores the mutable draft and metadata for each workflow definition. Workflow definitions are
+global to Axiom (not project-scoped).
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | `bigint` | PK, auto-generated | |
+| `name` | `varchar` | NOT NULL, UNIQUE | Human-readable name |
+| `description` | `text` | | Optional description |
+| `content` | `text` | | Current draft workflow JSON (nodes, edges, positions) |
+| `current_version` | `int` | | Latest published version number; null if never published |
+| `created_on` | `timestamp` | NOT NULL | |
+| `updated_on` | `timestamp` | NOT NULL | |
+
+### `workflow_definition_version` table
+
+Stores immutable published snapshots. All versions are kept indefinitely.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | `bigint` | PK, auto-generated | |
+| `definition_id` | `bigint` | FK → workflow_definition, NOT NULL | |
+| `version` | `int` | NOT NULL | Version number (1, 2, 3...) |
+| `content` | `text` | NOT NULL | Frozen workflow JSON at publish time |
+| `created_on` | `timestamp` | NOT NULL | When published |
+
+**Constraints:** Unique index on `(definition_id, version)`.
+
+### Versioning model
+
+- Each workflow definition has a single mutable **draft** (the `content` column on
+  `workflow_definition`).
+- The user can **publish** the draft at any time, which copies the current `content` to a new
+  row in `workflow_definition_version` with an incremented version number.
+- Published versions are **immutable** — they cannot be edited or deleted.
+- Running workflow instances (Phase 2) will be pinned to the version they started with.
+
+## API Design
+
+All endpoints follow the contract-first approach: defined in `openapi.json` first, then
+generated interfaces are implemented.
+
+### Workflow Definition endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/v1/workflow-definitions` | List all definitions (paginated, searchable by name) |
+| `POST` | `/api/v1/workflow-definitions` | Create a new definition |
+| `GET` | `/api/v1/workflow-definitions/{id}` | Get a definition (returns draft content) |
+| `PUT` | `/api/v1/workflow-definitions/{id}` | Update definition metadata (name, description) |
+| `DELETE` | `/api/v1/workflow-definitions/{id}` | Delete a definition (reject if instances exist) |
+| `PUT` | `/api/v1/workflow-definitions/{id}/content` | Update draft workflow content |
+| `POST` | `/api/v1/workflow-definitions/{id}/publish` | Publish current draft as a new immutable version |
+
+### Workflow Definition Version endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/v1/workflow-definitions/{id}/versions` | List all published versions |
+| `GET` | `/api/v1/workflow-definitions/{id}/versions/{version}` | Get a specific version's content |
+
+### Request/Response schemas
+
+**WorkflowDefinition** (response):
+```json
+{
+  "id": 1,
+  "name": "CVE Triage",
+  "description": "Standard CVE triage and remediation workflow",
+  "content": { "id": "...", "name": "...", "nodes": [...], "edges": [...] },
+  "currentVersion": 3,
+  "createdOn": "2026-08-20T12:00:00Z",
+  "updatedOn": "2026-08-20T14:30:00Z"
+}
+```
+
+- `content` is the draft workflow JSON (the Apitomy Flow `Workflow` object).
+- `currentVersion` is null if never published.
+
+**NewWorkflowDefinition** (create request):
+```json
+{
+  "name": "CVE Triage",
+  "description": "Standard CVE triage and remediation workflow"
+}
+```
+
+- `content` is not provided on create — the backend initializes an empty workflow containing a
+  single start node and a single end node connected by a default edge, with sensible default
+  positions.
+
+**UpdateWorkflowDefinition** (update metadata request):
+```json
+{
+  "name": "CVE Triage v2",
+  "description": "Updated description"
+}
+```
+
+**WorkflowDefinitionContent** (update content request — `PUT .../content`):
+
+The request body is the raw Apitomy Flow `Workflow` JSON object:
+```json
+{
+  "id": "wf-1",
+  "name": "CVE Triage",
+  "nodes": [...],
+  "edges": [...]
+}
+```
+
+**WorkflowDefinitionVersion** (response):
+```json
+{
+  "id": 10,
+  "definitionId": 1,
+  "version": 3,
+  "content": { "id": "...", "name": "...", "nodes": [...], "edges": [...] },
+  "createdOn": "2026-08-20T14:30:00Z"
+}
+```
+
+### Publish behavior
+
+`POST /api/v1/workflow-definitions/{id}/publish`:
+
+1. Load the definition's current draft `content`.
+2. Run Apitomy Flow's `WorkflowValidator` against the content.
+3. If there are ERROR-level validation problems, return **400** with the validation errors.
+4. Otherwise, create a new `workflow_definition_version` row with `version =
+   currentVersion + 1` (or 1 if never published).
+5. Update `workflow_definition.current_version` to the new version number.
+6. Return the new `WorkflowDefinitionVersion`.
+
+### Delete behavior
+
+`DELETE /api/v1/workflow-definitions/{id}`:
+
+- Returns **409 Conflict** if any workflow instances reference this definition (Phase 2 will
+  add this check). For now, deletes are always allowed.
+- Deleting a definition also deletes all its published versions (cascade).
+
+## Backend Implementation
+
+### Entities
+
+**`WorkflowDefinitionEntity`** — Panache entity in the `core` module:
+- Maps to `workflow_definition` table
+- `content` field is a `String` storing the raw JSON
+
+**`WorkflowDefinitionVersionEntity`** — Panache entity in the `core` module:
+- Maps to `workflow_definition_version` table
+- `content` field is a `String` storing the frozen JSON
+
+### REST Resource
+
+**`WorkflowDefinitionsResourceImpl implements WorkflowDefinitionsResource`** in the `app`
+module's `rest` package. Follows the existing pattern: generated interface from OpenAPI, impl
+class with no `@Path` annotations.
+
+### Validation on publish
+
+The `app` module depends on `io.apitomy:apitomy-flow-engine`. On publish:
+
+1. Deserialize the draft `content` JSON into a Flow `Workflow` object using Jackson.
+2. Call `WorkflowValidator.validate(workflow)`.
+3. Filter for ERROR-severity problems.
+4. If any exist, return 400 with the problems as the response body.
+
+Draft saves (`PUT .../content`) do **not** run server-side validation. The `WorkflowEditor`
+component runs client-side validation in real time.
+
+### Maven dependency
+
+Add to `app/pom.xml`:
+```xml
+<dependency>
+    <groupId>io.apitomy</groupId>
+    <artifactId>apitomy-flow-engine</artifactId>
+    <version>${flow.version}</version>
+</dependency>
+```
+
+## UI Implementation
+
+### Navigation
+
+Add "Workflows" as a new item under the **Components** expandable nav section, alongside
+Action Types, Tools, Toolsets, etc.
+
+### Workflow Definitions List Page
+
+**Route:** `/components/workflows`
+
+- Table with columns: Name, Description, Current Version (show "Draft" if never published),
+  Updated
+- "Create Workflow" button opens a modal with Name and Description fields
+- Click a row to navigate to the detail page
+- Search/filter by name
+
+### Workflow Definition Detail Page
+
+**Route:** `/components/workflows/{id}`
+
+- **Breadcrumb:** Components > Workflows > {name}
+- **Header area:**
+  - Name and description (editable via an edit button/modal)
+  - Current version badge (e.g., "v3" or "Draft")
+  - **Save** button — disabled when content is clean, enabled when dirty. Visual indicator
+    (e.g., dot or "Unsaved changes") when dirty.
+  - **Publish** button — disabled when content is dirty (must save first) or when there are
+    ERROR-level validation problems. Calls `POST .../publish`.
+  - **Delete** button
+- **Main content:** Embedded `WorkflowEditor` component from `@apitomy/flow-ui`
+  - Fills the remaining viewport height (container with explicit dimensions)
+  - `workflow` prop: the current draft content
+  - `onChange` callback: stores updated content in component state and sets dirty flag
+  - `onValidationChange` callback: tracks validation problems to control Publish button state
+  - `spi.actionTypes`: async function that fetches Axiom action types from the existing
+    `GET /api/v1/action-types` endpoint and maps them to `ActionTypeDescriptor` objects. In
+    Phase 1, all action types are provided. In Phase 2, this will be filtered to only those
+    with an `outputSchema`.
+  - `theme`: matched to Axiom's current light/dark mode setting
+- **Version history:** Collapsible section listing published versions with version number and
+  timestamp.
+- **Unsaved changes guard:** Browser `beforeunload` warning if navigating away with dirty
+  content.
+
+### npm dependencies
+
+Add to `ui/package.json`:
+- `@apitomy/flow-ui` — the visual editor and viewer components
+- `@xyflow/react` — peer dependency required by `@apitomy/flow-ui`
+
+Import in the application:
+- `@apitomy/flow-ui/style.css`
+- `@xyflow/react/dist/style.css`
+
+## Testing
+
+### Backend integration tests
+
+**`WorkflowDefinitionsResourceTest`** — REST integration test (Quarkus `@QuarkusTest`),
+following the same pattern as `ProjectsResourceTest`:
+
+- Create a workflow definition — verify 200, returned fields
+- Get a definition by ID — verify content matches
+- List definitions — verify pagination and search by name
+- Update metadata (name, description) — verify fields updated
+- Update draft content — verify content persisted
+- Publish a valid workflow — verify version created, `currentVersion` incremented
+- Publish an invalid workflow — verify 400 with validation errors
+- List versions — verify version history
+- Get a specific version — verify frozen content matches
+- Delete a definition — verify removed
+- Delete cascades versions — verify version rows removed
+
+### Manual browser testing
+
+- Create workflow, add nodes/edges in the editor, save, publish
+- Verify dirty indicator and Save/Publish button states
+- Verify validation problems block publish
+- Verify version history updates after publish
+- Verify light/dark theme consistency
+
+## Future phases
+
+This spec covers Phase 1 only. Subsequent phases will add:
+
+- **Phase 2:** Workflow execution — triggering, action node execution (async), instance viewer
+- **Phase 3:** Human task nodes — inbox integration, task forms
+- **Phase 4:** Event correlation — receive-event nodes, wait nodes
+- **Phase 5:** Polish — audit/history view, error handling, edge cases

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9,6 +9,7 @@
             "version": "2",
             "dependencies": {
                 "@apitomy/common-ui-components": "4.1.2",
+                "@apitomy/flow-ui": "1.0.0",
                 "@patternfly/react-charts": "8.6.1",
                 "@patternfly/react-code-editor": "6.6.1",
                 "@patternfly/react-core": "6.6.1",
@@ -82,6 +83,20 @@
                 "react": "~19",
                 "react-dom": "~19",
                 "react-router": "~7"
+            }
+        },
+        "node_modules/@apitomy/flow-ui": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@apitomy/flow-ui/-/flow-ui-1.0.0.tgz",
+            "integrity": "sha512-X609qbTURhDk5ZGnsS53DjSfZZdv2CatckIW9NOeBjO0ndm4uSPKHUyr0z2/npLuq7GuZab6k/qD4fzSmzaV6g==",
+            "license": "Apache-2.0",
+            "peerDependencies": {
+                "@patternfly/patternfly": "^6.0.0",
+                "@patternfly/react-core": "^6.0.0",
+                "@patternfly/react-icons": "^6.0.0",
+                "@xyflow/react": "^12.0.0",
+                "react": "^19.0.0",
+                "react-dom": "^19.0.0"
             }
         },
         "node_modules/@babel/code-frame": {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9,7 +9,7 @@
             "version": "2",
             "dependencies": {
                 "@apitomy/common-ui-components": "4.1.2",
-                "@apitomy/flow-ui": "1.0.0",
+                "@apitomy/flow-ui": "1.0.1",
                 "@patternfly/react-charts": "8.6.1",
                 "@patternfly/react-code-editor": "6.6.1",
                 "@patternfly/react-core": "6.6.1",
@@ -86,9 +86,9 @@
             }
         },
         "node_modules/@apitomy/flow-ui": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@apitomy/flow-ui/-/flow-ui-1.0.0.tgz",
-            "integrity": "sha512-X609qbTURhDk5ZGnsS53DjSfZZdv2CatckIW9NOeBjO0ndm4uSPKHUyr0z2/npLuq7GuZab6k/qD4fzSmzaV6g==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@apitomy/flow-ui/-/flow-ui-1.0.1.tgz",
+            "integrity": "sha512-Vr72XeQlQp1ymuqtFKshDVEA0laFlIAbJYTrgxDA2pJmoBkfOiyiEQ9FFDnyMM7L3+HfbJWKLEs3y6kGtoXL5g==",
             "license": "Apache-2.0",
             "peerDependencies": {
                 "@patternfly/patternfly": "^6.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,6 +11,7 @@
     },
     "dependencies": {
         "@apitomy/common-ui-components": "4.1.2",
+        "@apitomy/flow-ui": "1.0.0",
         "@patternfly/react-charts": "8.6.1",
         "echarts": "5.6.0",
         "victory-area": "37.3.6",

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,7 @@
     },
     "dependencies": {
         "@apitomy/common-ui-components": "4.1.2",
-        "@apitomy/flow-ui": "1.0.0",
+        "@apitomy/flow-ui": "1.0.1",
         "@patternfly/react-charts": "8.6.1",
         "echarts": "5.6.0",
         "victory-area": "37.3.6",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -47,6 +47,8 @@ import { SessionTemplateDetailPage } from "./pages/SessionTemplateDetailPage";
 import { ScheduledJobsPage } from "./pages/ScheduledJobsPage";
 import { ScheduledJobDetailPage } from "./pages/ScheduledJobDetailPage";
 import { ScheduledJobRunsPage } from "./pages/ScheduledJobRunsPage";
+import { WorkflowDefinitionsPage } from "./pages/WorkflowDefinitionsPage";
+import { WorkflowDefinitionDetailPage } from "./pages/WorkflowDefinitionDetailPage";
 import { type StartupCheck, fetchSystemHealth, fetchSystemConfig } from "./config/api";
 import { sseClient } from "./config/sse";
 
@@ -144,6 +146,8 @@ export function App() {
                         <Route path="/scheduled-jobs/:jobId" element={<ScheduledJobDetailPage />} />
                         <Route path="/session-templates" element={<SessionTemplatesPage />} />
                         <Route path="/session-templates/:templateId" element={<SessionTemplateDetailPage />} />
+                        <Route path="/components/workflows" element={<WorkflowDefinitionsPage />} />
+                        <Route path="/components/workflows/:workflowDefinitionId" element={<WorkflowDefinitionDetailPage />} />
                         <Route path="/assistant" element={<AssistantPage />} />
                         <Route path="/assistant/:sessionId" element={<AssistantSessionPage />} />
                     </Routes>

--- a/ui/src/axiom-theme.css
+++ b/ui/src/axiom-theme.css
@@ -68,3 +68,11 @@
 .axiom-generated-item-card:hover {
     background-color: var(--pf-t--global--background--color--tertiary--default, #f0f0f0);
 }
+
+/* Workflow definition detail page: make editor fill available height */
+.workflow-definition-detail > .pf-v6-c-page__main-body {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 0;
+    min-height: 0;
+}

--- a/ui/src/components/AppSidebar.tsx
+++ b/ui/src/components/AppSidebar.tsx
@@ -12,7 +12,7 @@ import {
 import { fetchInboxCount } from "../config/api";
 import { sseClient, type AxiomSseEvent } from "../config/sse";
 
-const COMPONENT_PATHS = ["/action-types", "/actors", "/session-templates", "/event-sources", "/mcp-servers", "/report-definitions", "/scheduled-jobs", "/secrets", "/tools", "/toolsets"];
+const COMPONENT_PATHS = ["/action-types", "/actors", "/session-templates", "/event-sources", "/mcp-servers", "/report-definitions", "/scheduled-jobs", "/secrets", "/tools", "/toolsets", "/components/workflows"];
 const SETTINGS_PATHS = ["/engine", "/manager", "/data-retention", "/configuration-packs"];
 
 export function AppSidebar() {
@@ -122,6 +122,9 @@ export function AppSidebar() {
                             </NavItem>
                             <NavItem isActive={location.pathname.startsWith("/toolsets")} onClick={() => navigate("/toolsets")}>
                                 Toolsets
+                            </NavItem>
+                            <NavItem isActive={location.pathname.startsWith("/components/workflows")} onClick={() => navigate("/components/workflows")}>
+                                Workflows
                             </NavItem>
                         </NavExpandable>
                         <NavExpandable title="Settings" isActive={isSettingsActive} isExpanded={isSettingsActive}>

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -2021,3 +2021,119 @@ export async function validateScheduledJob(data: NewScheduledJob): Promise<ToolV
     if (!response.ok) throw new Error(`Failed to validate scheduled job: ${response.status}`);
     return response.json();
 }
+
+// ── Workflow Definitions ──────────────────────────────────────────
+
+export interface WorkflowDefinition {
+    id: number;
+    name: string;
+    description?: string;
+    content?: any;
+    currentVersion?: number;
+    createdOn: string;
+    updatedOn: string;
+}
+
+export interface NewWorkflowDefinition {
+    name: string;
+    description?: string;
+}
+
+export interface UpdateWorkflowDefinition {
+    name?: string;
+    description?: string;
+}
+
+export interface WorkflowDefinitionVersion {
+    id: number;
+    definitionId: number;
+    version: number;
+    content?: any;
+    createdOn: string;
+}
+
+export async function fetchWorkflowDefinitions(
+    page = 1, limit = 20, filterName?: string
+): Promise<SearchResults<WorkflowDefinition>> {
+    const params = new URLSearchParams();
+    params.set("page", String(page));
+    params.set("limit", String(limit));
+    if (filterName) params.set("filterName", filterName);
+    const response = await fetch(`${API}/workflow-definitions?${params}`);
+    if (!response.ok) throw new Error(`Failed to fetch workflow definitions: ${response.status}`);
+    return response.json();
+}
+
+export async function createWorkflowDefinition(
+    data: NewWorkflowDefinition
+): Promise<WorkflowDefinition> {
+    const response = await fetch(`${API}/workflow-definitions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+    });
+    if (!response.ok) throw new Error(`Failed to create workflow definition: ${response.status}`);
+    return response.json();
+}
+
+export async function getWorkflowDefinition(id: number): Promise<WorkflowDefinition> {
+    const response = await fetch(`${API}/workflow-definitions/${id}`);
+    if (!response.ok) throw new Error(`Failed to get workflow definition: ${response.status}`);
+    return response.json();
+}
+
+export async function updateWorkflowDefinition(
+    id: number, data: UpdateWorkflowDefinition
+): Promise<WorkflowDefinition> {
+    const response = await fetch(`${API}/workflow-definitions/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+    });
+    if (!response.ok) throw new Error(`Failed to update workflow definition: ${response.status}`);
+    return response.json();
+}
+
+export async function updateWorkflowDefinitionContent(
+    id: number, content: any
+): Promise<void> {
+    const response = await fetch(`${API}/workflow-definitions/${id}/content`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(content),
+    });
+    if (!response.ok) throw new Error(`Failed to update workflow content: ${response.status}`);
+}
+
+export async function publishWorkflowDefinition(
+    id: number
+): Promise<WorkflowDefinitionVersion> {
+    const response = await fetch(`${API}/workflow-definitions/${id}/publish`, {
+        method: "POST",
+    });
+    if (!response.ok) throw new Error(`Failed to publish workflow definition: ${response.status}`);
+    return response.json();
+}
+
+export async function deleteWorkflowDefinition(id: number): Promise<void> {
+    const response = await fetch(`${API}/workflow-definitions/${id}`, {
+        method: "DELETE",
+    });
+    if (!response.ok) throw new Error(`Failed to delete workflow definition: ${response.status}`);
+}
+
+export async function listWorkflowDefinitionVersions(
+    id: number
+): Promise<WorkflowDefinitionVersion[]> {
+    const response = await fetch(`${API}/workflow-definitions/${id}/versions`);
+    if (!response.ok) throw new Error(`Failed to list versions: ${response.status}`);
+    return response.json();
+}
+
+export async function getWorkflowDefinitionVersion(
+    id: number, version: number
+): Promise<WorkflowDefinitionVersion> {
+    const response = await fetch(`${API}/workflow-definitions/${id}/versions/${version}`);
+    if (!response.ok) throw new Error(`Failed to get version: ${response.status}`);
+    return response.json();
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -4,6 +4,8 @@ import { BrowserRouter } from "react-router-dom";
 import { App } from "./App";
 
 import "@patternfly/patternfly/patternfly.css";
+import "@xyflow/react/dist/style.css";
+import "@apitomy/flow-ui/style.css";
 import "./axiom-theme.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/ui/src/pages/WorkflowDefinitionDetailPage.tsx
+++ b/ui/src/pages/WorkflowDefinitionDetailPage.tsx
@@ -47,8 +47,8 @@ import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
 import EditIcon from "@patternfly/react-icons/dist/esm/icons/edit-icon";
 
 export function WorkflowDefinitionDetailPage() {
-    const { workflowDefId } = useParams<{ workflowDefId: string }>();
-    const id = Number(workflowDefId);
+    const { workflowDefinitionId } = useParams<{ workflowDefinitionId: string }>();
+    const id = Number(workflowDefinitionId);
     const navigate = useNavigate();
     const effectiveTheme = useEffectiveTheme();
 

--- a/ui/src/pages/WorkflowDefinitionDetailPage.tsx
+++ b/ui/src/pages/WorkflowDefinitionDetailPage.tsx
@@ -1,3 +1,387 @@
+import { useState, useEffect, useCallback } from "react";
+import { useEffectiveTheme } from "../hooks/useTheme";
+import { useParams, Link, useNavigate } from "react-router-dom";
+import {
+    Breadcrumb,
+    BreadcrumbItem,
+    Button,
+    EmptyState,
+    EmptyStateBody,
+    ExpandableSection,
+    Flex,
+    FlexItem,
+    Form,
+    FormGroup,
+    Label,
+    Modal,
+    ModalBody,
+    ModalFooter,
+    ModalHeader,
+    PageSection,
+    TextArea,
+    TextInput,
+    Title,
+    DescriptionList,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    DescriptionListDescription,
+} from "@patternfly/react-core";
+import { WorkflowEditor } from "@apitomy/flow-ui";
+import type { Workflow, ValidationProblem, EditorSpi, ActionTypeDescriptor } from "@apitomy/flow-ui";
+import {
+    type WorkflowDefinition,
+    type WorkflowDefinitionVersion,
+    type UpdateWorkflowDefinition,
+    getWorkflowDefinition,
+    updateWorkflowDefinition,
+    updateWorkflowDefinitionContent,
+    publishWorkflowDefinition,
+    deleteWorkflowDefinition,
+    listWorkflowDefinitionVersions,
+    fetchActionTypes,
+} from "../config/api";
+import { ConfirmDeleteModal } from "../components/ConfirmDeleteModal";
+import SaveIcon from "@patternfly/react-icons/dist/esm/icons/save-icon";
+import RocketIcon from "@patternfly/react-icons/dist/esm/icons/rocket-icon";
+import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
+import EditIcon from "@patternfly/react-icons/dist/esm/icons/edit-icon";
+
 export function WorkflowDefinitionDetailPage() {
-    return <div>Workflow Definition Detail - Coming Soon</div>;
+    const { workflowDefId } = useParams<{ workflowDefId: string }>();
+    const id = Number(workflowDefId);
+    const navigate = useNavigate();
+    const effectiveTheme = useEffectiveTheme();
+
+    const [definition, setDefinition] = useState<WorkflowDefinition | null>(null);
+    const [editorContent, setEditorContent] = useState<Workflow | null>(null);
+    const [dirty, setDirty] = useState(false);
+    const [saving, setSaving] = useState(false);
+    const [publishing, setPublishing] = useState(false);
+    const [loading, setLoading] = useState(true);
+    const [validationErrors, setValidationErrors] = useState<ValidationProblem[]>([]);
+    const [versions, setVersions] = useState<WorkflowDefinitionVersion[]>([]);
+    const [versionsExpanded, setVersionsExpanded] = useState(false);
+    const [editMetadataOpen, setEditMetadataOpen] = useState(false);
+    const [metadataForm, setMetadataForm] = useState({ name: "", description: "" });
+    const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+
+    // EditorSpi for action types
+    const spi: EditorSpi = {
+        actionTypes: async () => {
+            const results = await fetchActionTypes(1, 1000);
+            return results.items.map((at): ActionTypeDescriptor => ({
+                value: at.name,
+                label: at.name,
+                description: at.description,
+            }));
+        },
+    };
+
+    const loadDefinition = useCallback(() => {
+        if (!id) return;
+        setLoading(true);
+        Promise.all([
+            getWorkflowDefinition(id),
+            listWorkflowDefinitionVersions(id),
+        ])
+            .then(([def, vers]) => {
+                setDefinition(def);
+                setEditorContent(def.content || null);
+                setVersions(vers);
+                setDirty(false);
+            })
+            .catch((err) => {
+                console.error("Failed to load workflow definition:", err);
+            })
+            .finally(() => setLoading(false));
+    }, [id]);
+
+    useEffect(() => {
+        loadDefinition();
+    }, [loadDefinition]);
+
+    // beforeunload guard
+    useEffect(() => {
+        const handler = (e: BeforeUnloadEvent) => {
+            if (dirty) {
+                e.preventDefault();
+            }
+        };
+        window.addEventListener("beforeunload", handler);
+        return () => window.removeEventListener("beforeunload", handler);
+    }, [dirty]);
+
+    const handleEditorChange = (updated: Workflow) => {
+        setEditorContent(updated);
+        setDirty(true);
+    };
+
+    const handleValidationChange = (problems: ValidationProblem[]) => {
+        setValidationErrors(problems.filter((p) => p.severity === "error"));
+    };
+
+    const handleSave = () => {
+        if (!editorContent) return;
+        setSaving(true);
+        updateWorkflowDefinitionContent(id, editorContent)
+            .then(() => {
+                setDirty(false);
+            })
+            .catch((err) => {
+                console.error("Failed to save workflow content:", err);
+            })
+            .finally(() => setSaving(false));
+    };
+
+    const handlePublish = () => {
+        setPublishing(true);
+        publishWorkflowDefinition(id)
+            .then(() => {
+                loadDefinition();
+            })
+            .catch((err) => {
+                console.error("Failed to publish workflow definition:", err);
+            })
+            .finally(() => setPublishing(false));
+    };
+
+    const handleEditMetadata = () => {
+        if (!definition) return;
+        setMetadataForm({
+            name: definition.name,
+            description: definition.description || "",
+        });
+        setEditMetadataOpen(true);
+    };
+
+    const handleSaveMetadata = () => {
+        const updates: UpdateWorkflowDefinition = {
+            name: metadataForm.name,
+            description: metadataForm.description || undefined,
+        };
+        updateWorkflowDefinition(id, updates)
+            .then((updated) => {
+                setDefinition(updated);
+                setEditMetadataOpen(false);
+            })
+            .catch((err) => {
+                console.error("Failed to update metadata:", err);
+            });
+    };
+
+    const handleDelete = () => {
+        deleteWorkflowDefinition(id)
+            .then(() => {
+                navigate("/workflow-definitions");
+            })
+            .catch((err) => {
+                console.error("Failed to delete workflow definition:", err);
+            });
+    };
+
+    if (loading) {
+        return (
+            <PageSection>
+                <EmptyState>
+                    <EmptyStateBody>Loading workflow definition...</EmptyStateBody>
+                </EmptyState>
+            </PageSection>
+        );
+    }
+
+    if (!definition) {
+        return (
+            <PageSection>
+                <EmptyState>
+                    <EmptyStateBody>Workflow definition not found.</EmptyStateBody>
+                </EmptyState>
+            </PageSection>
+        );
+    }
+
+    const hasErrors = validationErrors.length > 0;
+    const canPublish = !dirty && !publishing && !hasErrors;
+
+    return (
+        <PageSection isFilled style={{ display: "flex", flexDirection: "column", padding: 0 }}>
+            {/* Header bar */}
+            <div style={{ padding: "16px 24px", borderBottom: "1px solid var(--pf-t--global--border--color--default)" }}>
+                <Breadcrumb style={{ marginBottom: "16px" }}>
+                    <BreadcrumbItem>
+                        <Link to="/">Components</Link>
+                    </BreadcrumbItem>
+                    <BreadcrumbItem>
+                        <Link to="/workflow-definitions">Workflows</Link>
+                    </BreadcrumbItem>
+                    <BreadcrumbItem isActive>{definition.name}</BreadcrumbItem>
+                </Breadcrumb>
+
+                <Flex
+                    justifyContent={{ default: "justifyContentSpaceBetween" }}
+                    alignItems={{ default: "alignItemsCenter" }}
+                >
+                    <FlexItem>
+                        <Flex alignItems={{ default: "alignItemsCenter" }} spaceItems={{ default: "spaceItemsSm" }}>
+                            <FlexItem>
+                                <Title headingLevel="h1" size="lg">
+                                    {definition.name}
+                                </Title>
+                            </FlexItem>
+                            {definition.currentVersion !== undefined && (
+                                <FlexItem>
+                                    <Label color="blue">v{definition.currentVersion}</Label>
+                                </FlexItem>
+                            )}
+                            {dirty && (
+                                <FlexItem>
+                                    <Label color="orange">Unsaved changes</Label>
+                                </FlexItem>
+                            )}
+                        </Flex>
+                    </FlexItem>
+                    <FlexItem>
+                        <Flex spaceItems={{ default: "spaceItemsSm" }}>
+                            <FlexItem>
+                                <Button
+                                    variant="secondary"
+                                    icon={<EditIcon />}
+                                    onClick={handleEditMetadata}
+                                >
+                                    Edit Info
+                                </Button>
+                            </FlexItem>
+                            <FlexItem>
+                                <Button
+                                    variant="secondary"
+                                    icon={<SaveIcon />}
+                                    onClick={handleSave}
+                                    isDisabled={!dirty || saving}
+                                    isLoading={saving}
+                                >
+                                    {saving ? "Saving..." : "Save"}
+                                </Button>
+                            </FlexItem>
+                            <FlexItem>
+                                <Button
+                                    variant="primary"
+                                    icon={<RocketIcon />}
+                                    onClick={handlePublish}
+                                    isDisabled={!canPublish}
+                                    isLoading={publishing}
+                                >
+                                    {publishing ? "Publishing..." : "Publish"}
+                                </Button>
+                            </FlexItem>
+                            <FlexItem>
+                                <Button
+                                    variant="danger"
+                                    icon={<TrashIcon />}
+                                    onClick={() => setDeleteConfirmOpen(true)}
+                                >
+                                    Delete
+                                </Button>
+                            </FlexItem>
+                        </Flex>
+                    </FlexItem>
+                </Flex>
+
+                {definition.description && (
+                    <p className="axiom-text-subtle" style={{ marginTop: "8px" }}>
+                        {definition.description}
+                    </p>
+                )}
+
+                {/* Version history */}
+                {versions.length > 0 && (
+                    <ExpandableSection
+                        toggleText={`Version History (${versions.length})`}
+                        isExpanded={versionsExpanded}
+                        onToggle={() => setVersionsExpanded(!versionsExpanded)}
+                        style={{ marginTop: "16px" }}
+                    >
+                        <DescriptionList isCompact isHorizontal>
+                            {versions.map((v) => (
+                                <DescriptionListGroup key={v.id}>
+                                    <DescriptionListTerm>Version {v.version}</DescriptionListTerm>
+                                    <DescriptionListDescription>
+                                        {new Date(v.createdOn).toLocaleString()}
+                                    </DescriptionListDescription>
+                                </DescriptionListGroup>
+                            ))}
+                        </DescriptionList>
+                    </ExpandableSection>
+                )}
+            </div>
+
+            {/* Editor fills remaining space */}
+            <div style={{ flex: 1, minHeight: 0 }}>
+                {editorContent ? (
+                    <WorkflowEditor
+                        workflow={editorContent}
+                        onChange={handleEditorChange}
+                        onValidationChange={handleValidationChange}
+                        theme={effectiveTheme === "dark" ? "dark" : "light"}
+                        spi={spi}
+                    />
+                ) : (
+                    <EmptyState>
+                        <EmptyStateBody>
+                            No workflow content. Start by adding nodes to the editor.
+                        </EmptyStateBody>
+                    </EmptyState>
+                )}
+            </div>
+
+            {/* Edit Metadata Modal */}
+            <Modal
+                isOpen={editMetadataOpen}
+                onClose={() => setEditMetadataOpen(false)}
+                variant="small"
+            >
+                <ModalHeader title="Edit Workflow Definition" />
+                <ModalBody>
+                    <Form>
+                        <FormGroup label="Name" isRequired fieldId="name">
+                            <TextInput
+                                id="name"
+                                isRequired
+                                value={metadataForm.name}
+                                onChange={(_e, v) => setMetadataForm({ ...metadataForm, name: v })}
+                            />
+                        </FormGroup>
+                        <FormGroup label="Description" fieldId="description">
+                            <TextArea
+                                id="description"
+                                value={metadataForm.description}
+                                onChange={(_e, v) => setMetadataForm({ ...metadataForm, description: v })}
+                                rows={3}
+                            />
+                        </FormGroup>
+                    </Form>
+                </ModalBody>
+                <ModalFooter>
+                    <Button
+                        variant="primary"
+                        onClick={handleSaveMetadata}
+                        isDisabled={!metadataForm.name.trim()}
+                    >
+                        Save
+                    </Button>
+                    <Button variant="link" onClick={() => setEditMetadataOpen(false)}>
+                        Cancel
+                    </Button>
+                </ModalFooter>
+            </Modal>
+
+            {/* Delete Confirmation Modal */}
+            <ConfirmDeleteModal
+                isOpen={deleteConfirmOpen}
+                title="Delete Workflow Definition"
+                onConfirm={handleDelete}
+                onCancel={() => setDeleteConfirmOpen(false)}
+            >
+                Delete workflow definition &quot;{definition.name}&quot;? This action cannot be undone.
+            </ConfirmDeleteModal>
+        </PageSection>
+    );
 }

--- a/ui/src/pages/WorkflowDefinitionDetailPage.tsx
+++ b/ui/src/pages/WorkflowDefinitionDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useEffectiveTheme } from "../hooks/useTheme";
 import { useParams, Link, useNavigate } from "react-router-dom";
 import {
@@ -65,8 +65,8 @@ export function WorkflowDefinitionDetailPage() {
     const [metadataForm, setMetadataForm] = useState({ name: "", description: "" });
     const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
 
-    // EditorSpi for action types
-    const spi: EditorSpi = {
+    // EditorSpi for action types — memoized to avoid re-renders
+    const spi: EditorSpi = useMemo(() => ({
         actionTypes: async () => {
             const results = await fetchActionTypes(1, 1000);
             return results.items.map((at): ActionTypeDescriptor => ({
@@ -75,7 +75,7 @@ export function WorkflowDefinitionDetailPage() {
                 description: at.description,
             }));
         },
-    };
+    }), []);
 
     const loadDefinition = useCallback(() => {
         if (!id) return;
@@ -111,14 +111,14 @@ export function WorkflowDefinitionDetailPage() {
         return () => window.removeEventListener("beforeunload", handler);
     }, [dirty]);
 
-    const handleEditorChange = (updated: Workflow) => {
+    const handleEditorChange = useCallback((updated: Workflow) => {
         setEditorContent(updated);
         setDirty(true);
-    };
+    }, []);
 
-    const handleValidationChange = (problems: ValidationProblem[]) => {
+    const handleValidationChange = useCallback((problems: ValidationProblem[]) => {
         setValidationErrors(problems.filter((p) => p.severity === "error"));
-    };
+    }, []);
 
     const handleSave = () => {
         if (!editorContent) return;

--- a/ui/src/pages/WorkflowDefinitionDetailPage.tsx
+++ b/ui/src/pages/WorkflowDefinitionDetailPage.tsx
@@ -203,7 +203,7 @@ export function WorkflowDefinitionDetailPage() {
     const canPublish = !dirty && !publishing && !hasErrors;
 
     return (
-        <PageSection isFilled style={{ display: "flex", flexDirection: "column", padding: 0 }}>
+        <PageSection isFilled className="workflow-definition-detail" style={{ padding: 0 }}>
             {/* Header bar */}
             <div style={{ padding: "16px 24px", borderBottom: "1px solid var(--pf-t--global--border--color--default)" }}>
                 <Breadcrumb style={{ marginBottom: "16px" }}>

--- a/ui/src/pages/WorkflowDefinitionDetailPage.tsx
+++ b/ui/src/pages/WorkflowDefinitionDetailPage.tsx
@@ -172,7 +172,7 @@ export function WorkflowDefinitionDetailPage() {
     const handleDelete = () => {
         deleteWorkflowDefinition(id)
             .then(() => {
-                navigate("/workflow-definitions");
+                navigate("/components/workflows");
             })
             .catch((err) => {
                 console.error("Failed to delete workflow definition:", err);
@@ -211,7 +211,7 @@ export function WorkflowDefinitionDetailPage() {
                         <Link to="/">Components</Link>
                     </BreadcrumbItem>
                     <BreadcrumbItem>
-                        <Link to="/workflow-definitions">Workflows</Link>
+                        <Link to="/components/workflows">Workflows</Link>
                     </BreadcrumbItem>
                     <BreadcrumbItem isActive>{definition.name}</BreadcrumbItem>
                 </Breadcrumb>

--- a/ui/src/pages/WorkflowDefinitionDetailPage.tsx
+++ b/ui/src/pages/WorkflowDefinitionDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useEffectiveTheme } from "../hooks/useTheme";
 import { useParams, Link, useNavigate } from "react-router-dom";
 import {

--- a/ui/src/pages/WorkflowDefinitionDetailPage.tsx
+++ b/ui/src/pages/WorkflowDefinitionDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useEffectiveTheme } from "../hooks/useTheme";
 import { useParams, Link, useNavigate } from "react-router-dom";
 import {
@@ -55,6 +55,7 @@ export function WorkflowDefinitionDetailPage() {
     const [definition, setDefinition] = useState<WorkflowDefinition | null>(null);
     const [editorContent, setEditorContent] = useState<Workflow | null>(null);
     const [dirty, setDirty] = useState(false);
+    const savedContentRef = useRef<string>("");
     const [saving, setSaving] = useState(false);
     const [publishing, setPublishing] = useState(false);
     const [loading, setLoading] = useState(true);
@@ -87,6 +88,7 @@ export function WorkflowDefinitionDetailPage() {
             .then(([def, vers]) => {
                 setDefinition(def);
                 setEditorContent(def.content || null);
+                savedContentRef.current = JSON.stringify(def.content || null);
                 setVersions(vers);
                 setDirty(false);
             })
@@ -113,7 +115,8 @@ export function WorkflowDefinitionDetailPage() {
 
     const handleEditorChange = useCallback((updated: Workflow) => {
         setEditorContent(updated);
-        setDirty(true);
+        const isDirty = JSON.stringify(updated) !== savedContentRef.current;
+        setDirty(isDirty);
     }, []);
 
     const handleValidationChange = useCallback((problems: ValidationProblem[]) => {
@@ -125,6 +128,7 @@ export function WorkflowDefinitionDetailPage() {
         setSaving(true);
         updateWorkflowDefinitionContent(id, editorContent)
             .then(() => {
+                savedContentRef.current = JSON.stringify(editorContent);
                 setDirty(false);
             })
             .catch((err) => {

--- a/ui/src/pages/WorkflowDefinitionDetailPage.tsx
+++ b/ui/src/pages/WorkflowDefinitionDetailPage.tsx
@@ -1,0 +1,3 @@
+export function WorkflowDefinitionDetailPage() {
+    return <div>Workflow Definition Detail - Coming Soon</div>;
+}

--- a/ui/src/pages/WorkflowDefinitionsPage.tsx
+++ b/ui/src/pages/WorkflowDefinitionsPage.tsx
@@ -1,3 +1,298 @@
+import { useState, useEffect, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+    Button,
+    EmptyState,
+    EmptyStateBody,
+    Flex,
+    FlexItem,
+    Form,
+    FormGroup,
+    Label,
+    Modal,
+    ModalBody,
+    ModalFooter,
+    ModalHeader,
+    PageSection,
+    Pagination,
+    TextArea,
+    TextInput,
+    Title,
+    Toolbar,
+    ToolbarContent,
+    ToolbarItem,
+} from "@patternfly/react-core";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+import PlusCircleIcon from "@patternfly/react-icons/dist/esm/icons/plus-circle-icon";
+import SyncAltIcon from "@patternfly/react-icons/dist/esm/icons/sync-alt-icon";
+import TrashIcon from "@patternfly/react-icons/dist/esm/icons/trash-icon";
+import {
+    type ChipFilterCriteria,
+    type ChipFilterType,
+    ChipFilterInput,
+    FilterChips,
+} from "@apitomy/common-ui-components";
+import {
+    type WorkflowDefinition,
+    type NewWorkflowDefinition,
+    fetchWorkflowDefinitions,
+    createWorkflowDefinition,
+    deleteWorkflowDefinition,
+} from "../config/api";
+import { ConfirmDeleteModal } from "../components/ConfirmDeleteModal";
+
+const FILTER_TYPES: ChipFilterType[] = [
+    { value: "name", label: "Name", testId: "workflow-definition-filter-name" },
+];
+
 export function WorkflowDefinitionsPage() {
-    return <div>Workflow Definitions - Coming Soon</div>;
+    const navigate = useNavigate();
+    const [workflowDefinitions, setWorkflowDefinitions] = useState<WorkflowDefinition[]>([]);
+    const [totalCount, setTotalCount] = useState(0);
+    const [loading, setLoading] = useState(true);
+    const [isCreateOpen, setIsCreateOpen] = useState(false);
+    const [deleteTarget, setDeleteTarget] = useState<number | null>(null);
+    const [newName, setNewName] = useState("");
+    const [newDescription, setNewDescription] = useState("");
+
+    const [filters, setFilters] = useState<ChipFilterCriteria[]>([]);
+    const [page, setPage] = useState(1);
+    const [perPage, setPerPage] = useState(20);
+
+    const filterName = filters.find((f) => f.filterBy.value === "name")?.filterValue;
+    const isFiltered = filters.length > 0;
+
+    const load = useCallback(() => {
+        setLoading(true);
+        fetchWorkflowDefinitions(page, perPage, filterName || undefined)
+            .then((results) => {
+                setWorkflowDefinitions(results.items);
+                setTotalCount(results.totalCount);
+            })
+            .catch(console.error)
+            .finally(() => setLoading(false));
+    }, [page, perPage, filterName]);
+
+    useEffect(() => { load(); }, [load]);
+
+    const onAddFilterCriteria = (criteria: ChipFilterCriteria) => {
+        if (!criteria.filterValue) return;
+        const updated = filters.filter((f) =>
+            !(f.filterBy.value === criteria.filterBy.value && f.filterValue === criteria.filterValue));
+        if (criteria.filterBy.value === "name") {
+            const withoutSame = updated.filter((f) => f.filterBy.value !== criteria.filterBy.value);
+            withoutSame.push(criteria);
+            setFilters(withoutSame);
+        } else {
+            updated.push(criteria);
+            setFilters(updated);
+        }
+        setPage(1);
+    };
+
+    const onRemoveFilterCriteria = (criteria: ChipFilterCriteria) => {
+        setFilters(filters.filter((f) =>
+            !(f.filterBy.value === criteria.filterBy.value && f.filterValue === criteria.filterValue)));
+        setPage(1);
+    };
+
+    const onClearAllFilters = () => {
+        setFilters([]);
+        setPage(1);
+    };
+
+    const handleCreate = () => {
+        const data: NewWorkflowDefinition = {
+            name: newName,
+            description: newDescription || undefined,
+        };
+        createWorkflowDefinition(data)
+            .then((created) => {
+                setIsCreateOpen(false);
+                setNewName("");
+                setNewDescription("");
+                navigate(`/components/workflows/${created.id}`);
+            })
+            .catch(console.error);
+    };
+
+    const handleDelete = (e: React.MouseEvent, id: number) => {
+        e.stopPropagation();
+        setDeleteTarget(id);
+    };
+
+    const confirmDelete = () => {
+        if (deleteTarget !== null) {
+            deleteWorkflowDefinition(deleteTarget).then(load).catch(console.error);
+            setDeleteTarget(null);
+        }
+    };
+
+    const formatDate = (dateString: string) => {
+        const date = new Date(dateString);
+        return date.toLocaleDateString(undefined, {
+            year: "numeric",
+            month: "short",
+            day: "numeric",
+            hour: "2-digit",
+            minute: "2-digit",
+        });
+    };
+
+    const truncateDescription = (description?: string, maxLength = 100) => {
+        if (!description) return "";
+        if (description.length <= maxLength) return description;
+        return description.substring(0, maxLength) + "...";
+    };
+
+    return (
+        <PageSection>
+            <Flex justifyContent={{ default: "justifyContentSpaceBetween" }} alignItems={{ default: "alignItemsCenter" }}>
+                <FlexItem><Title headingLevel="h1" size="lg">Workflow Definitions</Title></FlexItem>
+                <FlexItem>
+                    <Button variant="primary" icon={<PlusCircleIcon />} onClick={() => {
+                        setNewName("");
+                        setNewDescription("");
+                        setIsCreateOpen(true);
+                    }}>
+                        Create Workflow Definition
+                    </Button>
+                </FlexItem>
+            </Flex>
+
+            <Toolbar style={{ marginTop: "16px" }}>
+                <ToolbarContent>
+                    <ToolbarItem>
+                        <ChipFilterInput
+                            filterTypes={FILTER_TYPES}
+                            onAddCriteria={onAddFilterCriteria} />
+                    </ToolbarItem>
+                    <ToolbarItem>
+                        <Button variant="control" aria-label="Refresh" onClick={load}>
+                            <SyncAltIcon />
+                        </Button>
+                    </ToolbarItem>
+                    <ToolbarItem variant="pagination" align={{ default: "alignEnd" }}>
+                        <Pagination
+                            itemCount={totalCount}
+                            perPage={perPage}
+                            page={page}
+                            onSetPage={(_e, p) => setPage(p)}
+                            onPerPageSelect={(_e, pp) => { setPerPage(pp); setPage(1); }}
+                            isCompact
+                        />
+                    </ToolbarItem>
+                </ToolbarContent>
+            </Toolbar>
+            {isFiltered && (
+                <Toolbar>
+                    <ToolbarContent>
+                        <ToolbarItem>
+                            <FilterChips
+                                criteria={filters}
+                                onClearAllCriteria={onClearAllFilters}
+                                onRemoveCriteria={onRemoveFilterCriteria} />
+                        </ToolbarItem>
+                    </ToolbarContent>
+                </Toolbar>
+            )}
+
+            <div>
+                {loading ? (
+                    <EmptyState><EmptyStateBody>Loading...</EmptyStateBody></EmptyState>
+                ) : workflowDefinitions.length === 0 ? (
+                    <EmptyState><EmptyStateBody>
+                        {isFiltered
+                            ? "No workflow definitions match the current filters."
+                            : "No workflow definitions defined."}
+                    </EmptyStateBody></EmptyState>
+                ) : (
+                    <Table aria-label="Workflow Definitions" variant="compact">
+                        <Thead>
+                            <Tr>
+                                <Th>Name</Th>
+                                <Th>Description</Th>
+                                <Th>Version</Th>
+                                <Th>Updated</Th>
+                                <Th />
+                            </Tr>
+                        </Thead>
+                        <Tbody>
+                            {workflowDefinitions.map((wd) => (
+                                <Tr
+                                    key={wd.id}
+                                    isClickable
+                                    onRowClick={() => navigate(`/components/workflows/${wd.id}`)}
+                                >
+                                    <Td>{wd.name}</Td>
+                                    <Td>{truncateDescription(wd.description)}</Td>
+                                    <Td>
+                                        {wd.currentVersion != null ? (
+                                            <Label isCompact color="blue">
+                                                v{wd.currentVersion}
+                                            </Label>
+                                        ) : (
+                                            <Label isCompact color="grey">
+                                                Draft
+                                            </Label>
+                                        )}
+                                    </Td>
+                                    <Td>{formatDate(wd.updatedOn)}</Td>
+                                    <Td>
+                                        <Button variant="plain" size="sm" style={{ padding: 0 }}
+                                            onClick={(e) => handleDelete(e, wd.id)}>
+                                            <TrashIcon />
+                                        </Button>
+                                    </Td>
+                                </Tr>
+                            ))}
+                        </Tbody>
+                    </Table>
+                )}
+            </div>
+
+            <ConfirmDeleteModal isOpen={deleteTarget !== null} title="Delete Workflow Definition"
+                onConfirm={confirmDelete} onCancel={() => setDeleteTarget(null)}>
+                Delete this workflow definition?
+            </ConfirmDeleteModal>
+
+            <Modal isOpen={isCreateOpen} onClose={() => setIsCreateOpen(false)} variant="small">
+                <ModalHeader title="Create Workflow Definition" />
+                <ModalBody>
+                    <Form>
+                        <FormGroup label="Name" isRequired fieldId="name">
+                            <TextInput
+                                id="name"
+                                isRequired
+                                value={newName}
+                                onChange={(_e, v) => setNewName(v)}
+                                onKeyDown={(e) => {
+                                    if (e.key === "Enter" && newName.trim()) {
+                                        e.preventDefault();
+                                        handleCreate();
+                                    }
+                                }}
+                            />
+                        </FormGroup>
+                        <FormGroup label="Description" fieldId="description">
+                            <TextArea
+                                id="description"
+                                value={newDescription}
+                                onChange={(_e, v) => setNewDescription(v)}
+                                rows={3}
+                            />
+                        </FormGroup>
+                    </Form>
+                </ModalBody>
+                <ModalFooter>
+                    <Button variant="primary" onClick={handleCreate} isDisabled={!newName.trim()}>
+                        Create
+                    </Button>
+                    <Button variant="link" onClick={() => setIsCreateOpen(false)}>
+                        Cancel
+                    </Button>
+                </ModalFooter>
+            </Modal>
+        </PageSection>
+    );
 }

--- a/ui/src/pages/WorkflowDefinitionsPage.tsx
+++ b/ui/src/pages/WorkflowDefinitionsPage.tsx
@@ -1,0 +1,3 @@
+export function WorkflowDefinitionsPage() {
+    return <div>Workflow Definitions - Coming Soon</div>;
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,8 +1,17 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import path from "path";
 
 export default defineConfig({
     plugins: [react()],
+    resolve: {
+        alias: {
+            // Workaround for https://github.com/Apitomy/apitomy-flow/issues/21
+            "@apitomy/flow-ui/style.css": path.resolve(
+                __dirname, "node_modules/@apitomy/flow-ui/dist/index.css"
+            ),
+        },
+    },
     server: {
         port: 9191,
         proxy: {

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,17 +1,8 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
-import path from "path";
 
 export default defineConfig({
     plugins: [react()],
-    resolve: {
-        alias: {
-            // Workaround for https://github.com/Apitomy/apitomy-flow/issues/21
-            "@apitomy/flow-ui/style.css": path.resolve(
-                __dirname, "node_modules/@apitomy/flow-ui/dist/index.css"
-            ),
-        },
-    },
     server: {
         port: 9191,
         proxy: {


### PR DESCRIPTION
## Summary

Adds workflow definition management with a visual drag-and-drop editor to Axiom, powered by
[Apitomy Flow](https://github.com/Apitomy/apitomy-flow). This is Phase 1 of the custom
workflow feature.

- **CRUD API** for workflow definitions with draft + immutable versioned snapshots
- **Visual editor** using the `WorkflowEditor` component from `@apitomy/flow-ui`
- **Server-side validation** on publish using Apitomy Flow's `WorkflowValidator`
- **UI** under Components > Workflows with list page, create modal, and full-featured detail
  page with save/publish/delete

### Backend
- New DB tables: `workflow_definition` and `workflow_definition_version` (V43 migration)
- OpenAPI spec with 5 schemas, 6 paths, 9 operations
- `WorkflowDefinitionsResourceImpl` with full CRUD, content updates, publish with validation,
  and version management
- 12 REST integration tests

### Frontend
- "Workflows" nav item under Components section
- List page with filtering, pagination, create modal, delete confirmation
- Detail page with embedded `WorkflowEditor`, explicit save (dirty tracking), publish,
  version history, metadata editing, and beforeunload guard
- EditorSpi integration providing Axiom action types to the editor

### Dependencies
- `io.apitomy:apitomy-flow-engine:1.0.0` (Maven)
- `@apitomy/flow-ui:1.0.0` (npm)

Fixes #228

## Test plan
- [x] Backend: 12 integration tests covering all CRUD, publish, versioning, and validation
  endpoints (349 total tests pass)
- [x] Manual: Created workflow, saved draft, published v1, verified version history,
  tested save/publish button states, verified validation panel