### PR TITLE
feat: show subagent tool approvals in subagent card and add per-subagent allow-all

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSession.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSession.java
@@ -19,6 +19,8 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -75,6 +77,7 @@ public class AssistantSession {
     private final Object eventLock = new Object();
     private final CopyOnWriteArrayList<AutoApprovalRule> autoApprovalRules = new CopyOnWriteArrayList<>();
     private volatile boolean allowAll;
+    private final Set<String> subagentAllowAll = ConcurrentHashMap.newKeySet();
     private volatile BufferedWriter rawEventsWriter;
     private final Long projectId;
     private final String projectName;
@@ -523,6 +526,18 @@ public class AssistantSession {
         this.allowAll = allowAll;
     }
 
+    public boolean isSubagentAllowAll(String subagentToolUseId) {
+        return subagentAllowAll.contains(subagentToolUseId);
+    }
+
+    public void setSubagentAllowAll(String subagentToolUseId, boolean enabled) {
+        if (enabled) {
+            subagentAllowAll.add(subagentToolUseId);
+        } else {
+            subagentAllowAll.remove(subagentToolUseId);
+        }
+    }
+
     /**
      * Checks whether a tool permission request matches any auto-approval rule.
      *
@@ -640,6 +655,22 @@ public class AssistantSession {
         // which requires the user to provide answers rather than just approval.
         if (allowAll && !"AskUserQuestion".equals(toolName)) {
             LOG.infof("Auto-approving %s (allow-all) in session %s", toolName, id);
+            try {
+                addEvent(event);
+                respondToPermission(requestId, true, toolInput);
+            } catch (IOException e) {
+                LOG.warnf(e, "Failed to auto-approve %s in session %s", toolName, id);
+                return false;
+            }
+            return true;
+        }
+
+        // Subagent-scoped allow-all
+        String subagentId = event.data().path("subagentToolUseId").asText("");
+        if (!subagentId.isEmpty() && subagentAllowAll.contains(subagentId)
+                && !"AskUserQuestion".equals(toolName)) {
+            LOG.infof("Auto-approving %s (subagent allow-all for %s) in session %s",
+                    toolName, subagentId, id);
             try {
                 addEvent(event);
                 respondToPermission(requestId, true, toolInput);

--- a/app/src/main/java/io/apitomy/axiom/app/rest/AssistantResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/AssistantResourceImpl.java
@@ -19,6 +19,7 @@ import io.apitomy.axiom.api.beans.RenameAssistantSessionRequest;
 import io.apitomy.axiom.api.beans.SendAssistantMessageRequest;
 import io.apitomy.axiom.api.beans.SessionTemplate;
 import io.apitomy.axiom.api.beans.SetAllowAllRequest;
+import io.apitomy.axiom.api.beans.SetSubagentAllowAllRequest;
 import io.apitomy.axiom.app.assistant.AssistantEventParser.SseEvent;
 import io.apitomy.axiom.app.assistant.AssistantSession;
 import io.apitomy.axiom.app.ImportExportService;
@@ -556,6 +557,22 @@ public class AssistantResourceImpl implements AssistantResource {
         ObjectNode eventData = objectMapper.createObjectNode();
         eventData.put("enabled", enabled);
         session.addEvent(new SseEvent("allow_all_changed", eventData));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setSubagentAllowAll(String sessionId, SetSubagentAllowAllRequest data) {
+        AssistantSession session = requireSession(sessionId);
+        String subagentToolUseId = data.getSubagentToolUseId();
+        if (subagentToolUseId == null || subagentToolUseId.isBlank()) {
+            throw new WebApplicationException("Missing 'subagentToolUseId' field", 400);
+        }
+        boolean enabled = data.getEnabled() != null && data.getEnabled();
+        session.setSubagentAllowAll(subagentToolUseId, enabled);
+        ObjectNode eventData = objectMapper.createObjectNode();
+        eventData.put("subagentToolUseId", subagentToolUseId);
+        eventData.put("enabled", enabled);
+        session.addEvent(new SseEvent("subagent_allow_all_changed", eventData));
     }
 
     // ── Helpers ──────────────────────────────────────────────────────

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -4463,6 +4463,44 @@
         }
       }
     },
+    "/assistant/sessions/{sessionId}/subagent-allow-all": {
+      "put": {
+        "tags": [
+          "assistant"
+        ],
+        "summary": "Enable or disable Allow All mode for a specific subagent",
+        "description": "Sets the Allow All mode for a specific subagent within the session. When enabled, all tool permission requests from this subagent are automatically approved.",
+        "operationId": "setSubagentAllowAll",
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "description": "The assistant session ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetSubagentAllowAllRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Subagent Allow All mode updated successfully"
+          },
+          "404": {
+            "description": "Session not found"
+          }
+        }
+      }
+    },
     "/dashboards": {
       "get": {
         "tags": [
@@ -8295,6 +8333,23 @@
         "properties": {
           "enabled": {
             "description": "Whether to enable or disable the Allow All mode",
+            "type": "boolean"
+          }
+        }
+      },
+      "SetSubagentAllowAllRequest": {
+        "required": [
+          "subagentToolUseId",
+          "enabled"
+        ],
+        "type": "object",
+        "properties": {
+          "subagentToolUseId": {
+            "description": "The tool use ID of the subagent to set allow-all for",
+            "type": "string"
+          },
+          "enabled": {
+            "description": "Whether to enable or disable Allow All mode for this subagent",
             "type": "boolean"
           }
         }

--- a/ui/src/components/assistant/AssistantChatPanel.tsx
+++ b/ui/src/components/assistant/AssistantChatPanel.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { AssistantMessageList, type ChatMessage } from "./AssistantMessageList";
 import { AssistantMessageInput } from "./AssistantMessageInput";
 import { AssistantSubagentPanel } from "./AssistantSubagentPanel";
-import type { SubagentCardData, SubagentActivityEntry } from "./AssistantSubagentCard";
+import type { SubagentCardData, SubagentActivityEntry, SubagentPermission } from "./AssistantSubagentCard";
 import type { BackgroundTaskCardData } from "./AssistantBackgroundTaskCard";
 import {
     sendAssistantMessage,
@@ -10,6 +10,7 @@ import {
     createAutoApproval,
     dismissAssistantCard,
     fetchAssistantSessionHistory,
+    setSubagentAllowAll,
 } from "../../config/api";
 import { sseClient } from "../../config/sse";
 import { randomThinkingMessage } from "./thinkingMessages";
@@ -38,6 +39,7 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
     const [panelWidth, setPanelWidth] = useState(320);
     const sessionEndedRef = useRef(false);
     const lastSeenIndexRef = useRef(-1);
+    const pendingSubagentPermissionsRef = useRef<Map<string, SubagentPermission[]>>(new Map());
 
     const onItemsChangedRef = useRef(onItemsChanged);
     const onModeChangeRef = useRef(onModeChange);
@@ -127,18 +129,24 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
 
             case "permission_request":
                 if (data.subagentToolUseId) {
+                    const newPerm: SubagentPermission = {
+                        permissionId: data.requestId as string,
+                        toolName: data.toolName as string,
+                        toolInput: data.toolInput as Record<string, unknown>,
+                        resolved: false,
+                    };
                     setSubagentCards((prev) => {
                         const card = prev.get(data.subagentToolUseId as string);
-                        if (!card) return prev;
+                        if (!card) {
+                            const buf = pendingSubagentPermissionsRef.current;
+                            const key = data.subagentToolUseId as string;
+                            buf.set(key, [...(buf.get(key) || []), newPerm]);
+                            return prev;
+                        }
                         const next = new Map(prev);
                         next.set(card.id, {
                             ...card,
-                            permissions: [...card.permissions, {
-                                permissionId: data.requestId as string,
-                                toolName: data.toolName as string,
-                                toolInput: data.toolInput as Record<string, unknown>,
-                                resolved: false,
-                            }],
+                            permissions: [...card.permissions, newPerm],
                         });
                         return next;
                     });
@@ -249,6 +257,7 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
                 }]);
                 setSubagentCards(new Map());
                 setBackgroundTaskCards(new Map());
+                pendingSubagentPermissionsRef.current.clear();
                 setIsProcessing(false);
                 break;
 
@@ -266,11 +275,24 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
                 onAllowAllChangedRef.current?.(data.enabled as boolean);
                 break;
 
+            case "subagent_allow_all_changed":
+                setSubagentCards((prev) => {
+                    const card = prev.get(data.subagentToolUseId as string);
+                    if (!card) return prev;
+                    const next = new Map(prev);
+                    next.set(card.id, { ...card, allowAll: data.enabled as boolean });
+                    return next;
+                });
+                break;
+
             case "subagent_started":
                 setSubagentCards((prev) => {
+                    const toolUseId = data.toolUseId as string;
+                    const buffered = pendingSubagentPermissionsRef.current.get(toolUseId) || [];
+                    pendingSubagentPermissionsRef.current.delete(toolUseId);
                     const next = new Map(prev);
-                    next.set(data.toolUseId as string, {
-                        id: data.toolUseId as string,
+                    next.set(toolUseId, {
+                        id: toolUseId,
                         taskId: data.taskId as string,
                         description: data.description as string,
                         subagentType: data.subagentType as string,
@@ -278,8 +300,9 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
                         toolCount: 0,
                         durationMs: 0,
                         activityLog: [],
-                        permissions: [],
+                        permissions: buffered,
                         dismissed: false,
+                        allowAll: false,
                     });
                     return next;
                 });
@@ -573,6 +596,39 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
         }
     }, [sessionId, addMessage]);
 
+    const handleSubagentAllowAll = useCallback(async (subagentToolUseId: string) => {
+        const card = subagentCards.get(subagentToolUseId);
+        const unresolvedPerms = card ? card.permissions.filter((p) => !p.resolved) : [];
+
+        setSubagentCards((prev) => {
+            const c = prev.get(subagentToolUseId);
+            if (!c) return prev;
+            const next = new Map(prev);
+            const updatedPerms = c.permissions.map((p) =>
+                p.resolved ? p : { ...p, resolved: true, allowed: true }
+            );
+            next.set(c.id, { ...c, allowAll: true, permissions: updatedPerms });
+            return next;
+        });
+
+        try {
+            await setSubagentAllowAll(sessionId, subagentToolUseId, true);
+        } catch (err) {
+            console.error("Failed to enable subagent Allow All:", err);
+        }
+
+        for (const perm of unresolvedPerms) {
+            try {
+                await respondToAssistantPermission(sessionId, perm.permissionId, true, perm.toolInput);
+            } catch (err) {
+                console.error("Failed to approve permission:", perm.permissionId, err);
+            }
+        }
+        if (unresolvedPerms.length > 0) {
+            setIsProcessing(true);
+        }
+    }, [sessionId, subagentCards]);
+
     const handleCreateAutoApproval = useCallback(async (
         toolName: string, fieldName: string | undefined,
         pattern: string | undefined, permissionId: string
@@ -706,6 +762,7 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
                     onDismissAllCompleted={handleDismissAllCompleted}
                     onNavigateToAgent={handleNavigateToAgent}
                     onPermissionRespond={handlePermissionRespond}
+                    onAllowAll={handleSubagentAllowAll}
                     highlightedCardId={highlightedCardId}
                     width={panelWidth}
                     onWidthChange={setPanelWidth}

--- a/ui/src/components/assistant/AssistantSubagentCard.css
+++ b/ui/src/components/assistant/AssistantSubagentCard.css
@@ -166,6 +166,16 @@
     color: var(--pf-t--global--text--color--subtle, #6a6e73);
 }
 
+/* Allow-all controls */
+.axiom-subagent-card__allow-all-bar {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.axiom-subagent-card__allow-all-badge {
+    margin-bottom: 2px;
+}
+
 /* Navigate button */
 .axiom-subagent-card__navigate {
     padding: 8px 12px;

--- a/ui/src/components/assistant/AssistantSubagentCard.tsx
+++ b/ui/src/components/assistant/AssistantSubagentCard.tsx
@@ -37,6 +37,7 @@ export interface SubagentCardData {
     activityLog: SubagentActivityEntry[];
     permissions: SubagentPermission[];
     dismissed: boolean;
+    allowAll: boolean;
 }
 
 interface AssistantSubagentCardProps {
@@ -44,11 +45,12 @@ interface AssistantSubagentCardProps {
     onDismiss: (id: string) => void;
     onNavigateToAgent?: (toolUseId: string) => void;
     onPermissionRespond?: (permissionId: string, allow: boolean, toolInput?: Record<string, unknown>) => void;
+    onAllowAll?: (subagentToolUseId: string) => void;
     highlighted?: boolean;
 }
 
 export const AssistantSubagentCard = memo(function AssistantSubagentCard({
-    card, onDismiss, onNavigateToAgent, onPermissionRespond, highlighted,
+    card, onDismiss, onNavigateToAgent, onPermissionRespond, onAllowAll, highlighted,
 }: AssistantSubagentCardProps) {
     const [isExpanded, setIsExpanded] = useState(false);
     const isComplete = card.status === "completed";
@@ -126,6 +128,22 @@ export const AssistantSubagentCard = memo(function AssistantSubagentCard({
 
             {card.permissions.length > 0 && (
                 <div className="axiom-subagent-card__permissions">
+                    {!card.allowAll && card.permissions.some((p) => !p.resolved) && onAllowAll && (
+                        <div className="axiom-subagent-card__allow-all-bar">
+                            <Button
+                                variant="secondary"
+                                size="sm"
+                                onClick={() => onAllowAll(card.id)}
+                            >
+                                Allow All
+                            </Button>
+                        </div>
+                    )}
+                    {card.allowAll && (
+                        <div className="axiom-subagent-card__allow-all-badge">
+                            <Label isCompact color="green">Auto-approving all</Label>
+                        </div>
+                    )}
                     {card.permissions.map((perm) => (
                         <div
                             key={perm.permissionId}
@@ -146,22 +164,24 @@ export const AssistantSubagentCard = memo(function AssistantSubagentCard({
                                             {JSON.stringify(perm.toolInput, null, 2).substring(0, 200)}
                                         </pre>
                                     )}
-                                    <div className="axiom-subagent-card__permission-actions">
-                                        <Button
-                                            variant="primary"
-                                            size="sm"
-                                            onClick={() => onPermissionRespond?.(perm.permissionId, true, perm.toolInput)}
-                                        >
-                                            Allow
-                                        </Button>
-                                        <Button
-                                            variant="secondary"
-                                            size="sm"
-                                            onClick={() => onPermissionRespond?.(perm.permissionId, false, perm.toolInput)}
-                                        >
-                                            Deny
-                                        </Button>
-                                    </div>
+                                    {!card.allowAll && (
+                                        <div className="axiom-subagent-card__permission-actions">
+                                            <Button
+                                                variant="primary"
+                                                size="sm"
+                                                onClick={() => onPermissionRespond?.(perm.permissionId, true, perm.toolInput)}
+                                            >
+                                                Allow
+                                            </Button>
+                                            <Button
+                                                variant="secondary"
+                                                size="sm"
+                                                onClick={() => onPermissionRespond?.(perm.permissionId, false, perm.toolInput)}
+                                            >
+                                                Deny
+                                            </Button>
+                                        </div>
+                                    )}
                                 </>
                             )}
                         </div>

--- a/ui/src/components/assistant/AssistantSubagentPanel.tsx
+++ b/ui/src/components/assistant/AssistantSubagentPanel.tsx
@@ -18,6 +18,7 @@ interface AssistantSubagentPanelProps {
     onDismissAllCompleted: () => void;
     onNavigateToAgent?: (toolUseId: string) => void;
     onPermissionRespond?: (permissionId: string, allow: boolean, toolInput?: Record<string, unknown>) => void;
+    onAllowAll?: (subagentToolUseId: string) => void;
     highlightedCardId?: string;
     width: number;
     onWidthChange: (width: number) => void;
@@ -29,7 +30,7 @@ const MAX_WIDTH = 500;
 export function AssistantSubagentPanel({
     subagentCards, backgroundTaskCards,
     onDismissSubagent, onDismissBackgroundTask, onDismissAllCompleted,
-    onNavigateToAgent, onPermissionRespond,
+    onNavigateToAgent, onPermissionRespond, onAllowAll,
     highlightedCardId, width, onWidthChange,
 }: AssistantSubagentPanelProps) {
     const [activeTab, setActiveTab] = useState<string | number>("subagents");
@@ -106,6 +107,7 @@ export function AssistantSubagentPanel({
                                     onDismiss={onDismissSubagent}
                                     onNavigateToAgent={onNavigateToAgent}
                                     onPermissionRespond={onPermissionRespond}
+                                    onAllowAll={onAllowAll}
                                     highlighted={highlightedCardId === card.id}
                                 />
                             ))}

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -1544,6 +1544,20 @@ export async function setAllowAll(sessionId: string, enabled: boolean): Promise<
     if (!response.ok) throw new Error("Failed to update Allow All mode");
 }
 
+export async function setSubagentAllowAll(
+    sessionId: string, subagentToolUseId: string, enabled: boolean
+): Promise<void> {
+    const response = await fetch(
+        `${API}/assistant/sessions/${sessionId}/subagent-allow-all`,
+        {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ subagentToolUseId, enabled }),
+        }
+    );
+    if (!response.ok) throw new Error("Failed to update subagent Allow All mode");
+}
+
 export function assistantEventsUrl(sessionId: string): string {
     return `${API}/assistant/sessions/${sessionId}/events`;
 }


### PR DESCRIPTION
## Summary

Closes #233

- **Buffer subagent permissions (race condition fix):** When a `permission_request` event arrives with `subagentToolUseId` before the subagent card exists, it is now buffered and attached when `subagent_started` creates the card — previously it was silently dropped.
- **Per-subagent "Allow All":** Adds a new `PUT /sessions/{sessionId}/subagent-allow-all` endpoint and an "Allow All" button on the subagent card. When clicked, all pending permissions for that subagent are approved immediately, and future permissions are auto-approved on the backend via a per-subagent allow-all set in `AssistantSession`.

## Test plan

- [ ] Start a chat session and trigger a subagent (e.g., ask it to spawn an Explore agent)
- [ ] Verify permission prompts appear in the subagent card in the side panel, not in the main conversation
- [ ] Verify the "Allow All" button appears on the subagent card when there are unresolved permissions
- [ ] Click "Allow All" and verify all pending permissions are approved and an "Auto-approving all" badge appears
- [ ] Verify subsequent permissions from the same subagent are auto-approved without prompting
- [ ] Verify global "Allow All" still works independently
- [ ] Run `mvn install` and `npm run build` — both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)