### PR TITLE
fix: route subagent permissions using agent_id and improve approval UX

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantEventParser.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantEventParser.java
@@ -256,6 +256,10 @@ public class AssistantEventParser {
         if (!parentToolUseId.isEmpty()) {
             data.put("subagentToolUseId", parentToolUseId);
         }
+        String agentId = request.path("agent_id").asText("");
+        if (!agentId.isEmpty()) {
+            data.put("agentId", agentId);
+        }
         return List.of(new SseEvent("permission_request", data));
     }
 

--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSession.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSession.java
@@ -78,6 +78,7 @@ public class AssistantSession {
     private final CopyOnWriteArrayList<AutoApprovalRule> autoApprovalRules = new CopyOnWriteArrayList<>();
     private volatile boolean allowAll;
     private final Set<String> subagentAllowAll = ConcurrentHashMap.newKeySet();
+    private final Map<String, String> subagentTaskToToolUseId = new ConcurrentHashMap<>();
     private volatile BufferedWriter rawEventsWriter;
     private final Long projectId;
     private final String projectName;
@@ -610,6 +611,13 @@ public class AssistantSession {
                     writeRawEvent(line);
                     List<SseEvent> events = parser.parse(line);
                     for (SseEvent event : events) {
+                        if ("subagent_started".equals(event.type())) {
+                            String taskId = event.data().path("taskId").asText("");
+                            String toolUseId = event.data().path("toolUseId").asText("");
+                            if (!taskId.isEmpty() && !toolUseId.isEmpty()) {
+                                subagentTaskToToolUseId.put(taskId, toolUseId);
+                            }
+                        }
                         if (handleAutoApproval(event)) {
                             continue;
                         }
@@ -665,8 +673,15 @@ public class AssistantSession {
             return true;
         }
 
-        // Subagent-scoped allow-all
+        // Subagent-scoped allow-all: check subagentToolUseId directly,
+        // or resolve agentId (taskId) to toolUseId via the mapping
         String subagentId = event.data().path("subagentToolUseId").asText("");
+        if (subagentId.isEmpty()) {
+            String agentId = event.data().path("agentId").asText("");
+            if (!agentId.isEmpty()) {
+                subagentId = subagentTaskToToolUseId.getOrDefault(agentId, "");
+            }
+        }
         if (!subagentId.isEmpty() && subagentAllowAll.contains(subagentId)
                 && !"AskUserQuestion".equals(toolName)) {
             LOG.infof("Auto-approving %s (subagent allow-all for %s) in session %s",

--- a/ui/src/components/assistant/AssistantChatPanel.tsx
+++ b/ui/src/components/assistant/AssistantChatPanel.tsx
@@ -127,19 +127,32 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
                 onItemsChangedRef.current?.();
                 break;
 
-            case "permission_request":
-                if (data.subagentToolUseId) {
-                    const newPerm: SubagentPermission = {
-                        permissionId: data.requestId as string,
-                        toolName: data.toolName as string,
-                        toolInput: data.toolInput as Record<string, unknown>,
-                        resolved: false,
-                    };
+            case "permission_request": {
+                const newPerm: SubagentPermission = {
+                    permissionId: data.requestId as string,
+                    toolName: data.toolName as string,
+                    toolInput: data.toolInput as Record<string, unknown>,
+                    resolved: false,
+                };
+                const subagentKey = data.subagentToolUseId as string | undefined;
+                const agentId = data.agentId as string | undefined;
+                if (subagentKey || agentId) {
                     setSubagentCards((prev) => {
-                        const card = prev.get(data.subagentToolUseId as string);
+                        let card: SubagentCardData | undefined;
+                        if (subagentKey) {
+                            card = prev.get(subagentKey);
+                        }
+                        if (!card && agentId) {
+                            for (const c of prev.values()) {
+                                if (c.taskId === agentId) {
+                                    card = c;
+                                    break;
+                                }
+                            }
+                        }
                         if (!card) {
                             const buf = pendingSubagentPermissionsRef.current;
-                            const key = data.subagentToolUseId as string;
+                            const key = subagentKey || agentId!;
                             buf.set(key, [...(buf.get(key) || []), newPerm]);
                             return prev;
                         }
@@ -199,6 +212,7 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
                     };
                 }
                 break;
+            }
 
             case "permission_resolved":
                 setMessages((prev) => {
@@ -288,8 +302,11 @@ export function AssistantChatPanel({ sessionId, onItemsChanged, onModeChange, on
             case "subagent_started":
                 setSubagentCards((prev) => {
                     const toolUseId = data.toolUseId as string;
-                    const buffered = pendingSubagentPermissionsRef.current.get(toolUseId) || [];
-                    pendingSubagentPermissionsRef.current.delete(toolUseId);
+                    const taskId = data.taskId as string;
+                    const buf = pendingSubagentPermissionsRef.current;
+                    const buffered = [...(buf.get(toolUseId) || []), ...(buf.get(taskId) || [])];
+                    buf.delete(toolUseId);
+                    buf.delete(taskId);
                     const next = new Map(prev);
                     next.set(toolUseId, {
                         id: toolUseId,

--- a/ui/src/components/assistant/AssistantSubagentCard.css
+++ b/ui/src/components/assistant/AssistantSubagentCard.css
@@ -166,14 +166,35 @@
     color: var(--pf-t--global--text--color--subtle, #6a6e73);
 }
 
-/* Allow-all controls */
-.axiom-subagent-card__allow-all-bar {
-    display: flex;
-    justify-content: flex-end;
+/* Approval takeover */
+.axiom-subagent-card__approval-takeover {
+    padding: 10px 12px;
+    border-top: 2px solid var(--pf-t--global--color--status--warning--default, #f0ab00);
+    background-color: var(--pf-t--global--background--color--primary--default, #fff);
 }
 
+.axiom-subagent-card__approval-tool {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 6px;
+}
+
+.axiom-subagent-card__approval-label {
+    font-size: 12px;
+    color: var(--pf-t--global--text--color--subtle, #6a6e73);
+}
+
+.axiom-subagent-card__approval-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+/* Allow-all badge (when active) */
 .axiom-subagent-card__allow-all-badge {
-    margin-bottom: 2px;
+    padding: 6px 12px;
 }
 
 /* Navigate button */

--- a/ui/src/components/assistant/AssistantSubagentCard.tsx
+++ b/ui/src/components/assistant/AssistantSubagentCard.tsx
@@ -54,6 +54,9 @@ export const AssistantSubagentCard = memo(function AssistantSubagentCard({
 }: AssistantSubagentCardProps) {
     const [isExpanded, setIsExpanded] = useState(false);
     const isComplete = card.status === "completed";
+    const pendingPerm = !card.allowAll
+        ? card.permissions.find((p) => !p.resolved)
+        : undefined;
 
     return (
         <div
@@ -100,7 +103,7 @@ export const AssistantSubagentCard = memo(function AssistantSubagentCard({
                 )}
             </div>
 
-            {card.activityLog.length > 0 && (
+            {!pendingPerm && card.activityLog.length > 0 && (
                 <ExpandableSection
                     toggleText={isExpanded
                         ? "Hide activity"
@@ -126,70 +129,53 @@ export const AssistantSubagentCard = memo(function AssistantSubagentCard({
                 </ExpandableSection>
             )}
 
-            {card.permissions.length > 0 && (
-                <div className="axiom-subagent-card__permissions">
-                    {!card.allowAll && card.permissions.some((p) => !p.resolved) && onAllowAll && (
-                        <div className="axiom-subagent-card__allow-all-bar">
+            {pendingPerm && (
+                <div className="axiom-subagent-card__approval-takeover">
+                    <div className="axiom-subagent-card__approval-tool">
+                        <Label isCompact color="yellow">{pendingPerm.toolName}</Label>
+                        <span className="axiom-subagent-card__approval-label">
+                            needs approval
+                        </span>
+                    </div>
+                    {pendingPerm.toolInput && (
+                        <pre className="axiom-subagent-card__permission-input">
+                            {JSON.stringify(pendingPerm.toolInput, null, 2).substring(0, 200)}
+                        </pre>
+                    )}
+                    <div className="axiom-subagent-card__approval-actions">
+                        <Button
+                            variant="primary"
+                            size="sm"
+                            onClick={() => onPermissionRespond?.(pendingPerm.permissionId, true, pendingPerm.toolInput)}
+                        >
+                            Allow
+                        </Button>
+                        <Button
+                            variant="secondary"
+                            size="sm"
+                            onClick={() => onPermissionRespond?.(pendingPerm.permissionId, false, pendingPerm.toolInput)}
+                        >
+                            Deny
+                        </Button>
+                        {onAllowAll && (
                             <Button
-                                variant="secondary"
+                                variant="link"
                                 size="sm"
                                 onClick={() => onAllowAll(card.id)}
                             >
                                 Allow All
                             </Button>
-                        </div>
-                    )}
-                    {card.allowAll && (
-                        <div className="axiom-subagent-card__allow-all-badge">
-                            <Label isCompact color="green">Auto-approving all</Label>
-                        </div>
-                    )}
-                    {card.permissions.map((perm) => (
-                        <div
-                            key={perm.permissionId}
-                            className="axiom-subagent-card__permission"
-                            data-resolved={perm.resolved}
-                        >
-                            {perm.resolved ? (
-                                <span className="axiom-subagent-card__permission-resolved">
-                                    {perm.allowed ? "Allowed" : "Denied"}: {perm.toolName}
-                                </span>
-                            ) : (
-                                <>
-                                    <div className="axiom-subagent-card__permission-header">
-                                        <Label isCompact color="yellow">{perm.toolName}</Label>
-                                    </div>
-                                    {perm.toolInput && (
-                                        <pre className="axiom-subagent-card__permission-input">
-                                            {JSON.stringify(perm.toolInput, null, 2).substring(0, 200)}
-                                        </pre>
-                                    )}
-                                    {!card.allowAll && (
-                                        <div className="axiom-subagent-card__permission-actions">
-                                            <Button
-                                                variant="primary"
-                                                size="sm"
-                                                onClick={() => onPermissionRespond?.(perm.permissionId, true, perm.toolInput)}
-                                            >
-                                                Allow
-                                            </Button>
-                                            <Button
-                                                variant="secondary"
-                                                size="sm"
-                                                onClick={() => onPermissionRespond?.(perm.permissionId, false, perm.toolInput)}
-                                            >
-                                                Deny
-                                            </Button>
-                                        </div>
-                                    )}
-                                </>
-                            )}
-                        </div>
-                    ))}
+                        )}
+                    </div>
+                </div>
+            )}
+            {card.allowAll && (
+                <div className="axiom-subagent-card__allow-all-badge">
+                    <Label isCompact color="green">Auto-approving all</Label>
                 </div>
             )}
 
-            {onNavigateToAgent && (
+            {!pendingPerm && onNavigateToAgent && (
                 <Button
                     variant="link"
                     size="sm"


### PR DESCRIPTION
## Summary

Follow-up to #234. Fixes subagent permission routing and improves the approval card UX.

- **Fix permission routing:** Claude Code's `control_request` events don't include `parent_tool_use_id` for subagent permissions, but they do include `request.agent_id` (matching the subagent's task ID). The parser now extracts `agent_id`, and the frontend uses it to correlate permissions with the correct subagent card via `taskId`. The backend also maintains a `taskId → toolUseId` mapping so per-subagent allow-all works correctly.
- **Approval takeover UI:** When a permission is pending, the approval card now takes over the subagent card body — the activity log and "Show in conversation" link are hidden, and Allow, Deny, and Allow All buttons appear together in one row.

Closes #233

## Test plan

- [ ] Start an assistant session and trigger a subagent (e.g. "Use a subagent to search for all SSE-related files")
- [ ] Verify the permission prompt appears in the subagent card, not the main conversation
- [ ] Verify the approval card takes over the subagent card body (no activity log or navigate link visible)
- [ ] Verify Allow, Deny, and Allow All buttons are all in one row
- [ ] Click Allow All and verify auto-approving badge appears and future permissions are auto-approved
- [ ] After approval resolves, verify the activity log and navigate link reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)