### PR TITLE
fix: split ClosedProjectCleanup transaction to delete one project per transaction

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/ProjectDeletionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ProjectDeletionService.java
@@ -9,6 +9,8 @@ import io.apitomy.axiom.core.entities.ThreadEntryEntity;
 import io.apitomy.axiom.core.services.WorkspaceService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.transaction.Transactional.TxType;
 
 /**
  * Handles the full cascade deletion of a project and all its associated data.
@@ -26,6 +28,7 @@ public class ProjectDeletionService {
      *
      * @param project the project to delete (must already be in Completed status)
      */
+    @Transactional(TxType.REQUIRES_NEW)
     public void deleteProject(ProjectEntity project) {
         long projectId = project.id;
         ThreadEntryEntity.delete("projectId", projectId);


### PR DESCRIPTION
## Summary

Adds `@Transactional(TxType.REQUIRES_NEW)` to `ProjectDeletionService.deleteProject()` so that each project deletion runs in its own independent transaction.

## Problem

`ClosedProjectCleanup.cleanup()` is annotated with `@Transactional` and loops over all stale closed projects, calling `ProjectDeletionService.deleteProject()` for each one. Since `deleteProject()` had no `@Transactional` annotation, all deletions accumulated in a single long-lived transaction. This caused deadlocks on the `activity_log` table when the cleanup ran concurrently with other scheduled tasks (e.g. `EventCleanup`).

## Fix

By giving `deleteProject()` its own `@Transactional(TxType.REQUIRES_NEW)`, each project deletion now:
- Suspends the outer transaction from `cleanup()`
- Runs in a short-lived independent transaction
- Commits (or rolls back) independently

This reduces lock hold time and limits the blast radius of any deadlock to a single project rather than failing the entire batch.

## Changes

- **`ProjectDeletionService.java`**: Added `@Transactional(TxType.REQUIRES_NEW)` annotation to `deleteProject()` method, along with the necessary imports.

Fixes #237