### PR TITLE
fix: Add shutdown guard to scheduled tasks to prevent clean shutdown failure

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/ClosedProjectCleanup.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ClosedProjectCleanup.java
@@ -3,6 +3,7 @@ package io.apitomy.axiom.app;
 import io.apitomy.axiom.core.entities.ProjectEntity;
 import io.apitomy.axiom.core.entities.RetentionConfigEntity;
 import io.quarkus.scheduler.Scheduled;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -24,12 +25,22 @@ public class ClosedProjectCleanup {
     @Inject
     ProjectDeletionService projectDeletionService;
 
+    private volatile boolean shuttingDown = false;
+
+    @PreDestroy
+    void onShutdown() {
+        shuttingDown = true;
+    }
+
     /**
      * Finds and deletes closed projects older than the retention period.
      */
     @Scheduled(every = "1h", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
     @Transactional
     void cleanup() {
+        if (shuttingDown) {
+            return;
+        }
         RetentionConfigEntity config = RetentionConfigEntity.<RetentionConfigEntity>findAll()
                 .firstResult();
         if (config == null) {

--- a/app/src/main/java/io/apitomy/axiom/app/EventCleanup.java
+++ b/app/src/main/java/io/apitomy/axiom/app/EventCleanup.java
@@ -7,6 +7,7 @@ import io.apitomy.axiom.core.entities.EventQueueEntity;
 import io.apitomy.axiom.core.entities.RetentionConfigEntity;
 import io.apitomy.axiom.core.entities.TraceEntity;
 import io.quarkus.scheduler.Scheduled;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
 import org.jboss.logging.Logger;
@@ -25,12 +26,22 @@ public class EventCleanup {
 
     private static final Logger LOG = Logger.getLogger(EventCleanup.class);
 
+    private volatile boolean shuttingDown = false;
+
+    @PreDestroy
+    void onShutdown() {
+        shuttingDown = true;
+    }
+
     /**
      * Finds and deletes events older than the retention period.
      */
     @Scheduled(every = "1h", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
     @Transactional
     void cleanup() {
+        if (shuttingDown) {
+            return;
+        }
         RetentionConfigEntity config = RetentionConfigEntity.<RetentionConfigEntity>findAll()
                 .firstResult();
         if (config == null) {

--- a/app/src/main/java/io/apitomy/axiom/app/EventQueueCleanup.java
+++ b/app/src/main/java/io/apitomy/axiom/app/EventQueueCleanup.java
@@ -2,6 +2,7 @@ package io.apitomy.axiom.app;
 
 import io.apitomy.axiom.core.entities.EventQueueEntity;
 import io.quarkus.scheduler.Scheduled;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
 import org.jboss.logging.Logger;
@@ -19,12 +20,22 @@ public class EventQueueCleanup {
 
     private static final Logger LOG = Logger.getLogger(EventQueueCleanup.class);
 
+    private volatile boolean shuttingDown = false;
+
+    @PreDestroy
+    void onShutdown() {
+        shuttingDown = true;
+    }
+
     /**
      * Deletes processed event queue entries older than one day.
      */
     @Scheduled(every = "1h", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
     @Transactional
     void cleanup() {
+        if (shuttingDown) {
+            return;
+        }
         Instant cutoff = Instant.now().minus(1, ChronoUnit.DAYS);
         long deleted = EventQueueEntity.delete(
                 "processedAt is not null and processedAt < ?1", cutoff);

--- a/app/src/main/java/io/apitomy/axiom/app/EventSourceLogCleanup.java
+++ b/app/src/main/java/io/apitomy/axiom/app/EventSourceLogCleanup.java
@@ -3,6 +3,7 @@ package io.apitomy.axiom.app;
 import io.apitomy.axiom.core.entities.EventSourceLogEntity;
 import io.apitomy.axiom.core.entities.RetentionConfigEntity;
 import io.quarkus.scheduler.Scheduled;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
 import org.jboss.logging.Logger;
@@ -20,12 +21,22 @@ public class EventSourceLogCleanup {
 
     private static final Logger LOG = Logger.getLogger(EventSourceLogCleanup.class);
 
+    private volatile boolean shuttingDown = false;
+
+    @PreDestroy
+    void onShutdown() {
+        shuttingDown = true;
+    }
+
     /**
      * Deletes event source log entries older than the retention period.
      */
     @Scheduled(every = "1h", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
     @Transactional
     void cleanup() {
+        if (shuttingDown) {
+            return;
+        }
         RetentionConfigEntity config = RetentionConfigEntity.<RetentionConfigEntity>findAll()
                 .firstResult();
         if (config == null) {

--- a/app/src/main/java/io/apitomy/axiom/app/PipelineOrchestrator.java
+++ b/app/src/main/java/io/apitomy/axiom/app/PipelineOrchestrator.java
@@ -20,6 +20,7 @@ import io.apitomy.axiom.core.services.WorkspaceService;
 import io.apitomy.axiom.manager.ManagerDecision;
 import io.apitomy.axiom.manager.ManagerService;
 import io.quarkus.scheduler.Scheduled;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Event;
 import jakarta.inject.Inject;
@@ -66,6 +67,13 @@ public class PipelineOrchestrator {
     @Inject
     TraceService traceService;
 
+    private volatile boolean shuttingDown = false;
+
+    @PreDestroy
+    void onShutdown() {
+        shuttingDown = true;
+    }
+
     /**
      * Polls the event queue every 5 seconds and processes one pending event at a time.
      * Events are processed sequentially to avoid race conditions in the Manager.
@@ -81,6 +89,9 @@ public class PipelineOrchestrator {
     @Scheduled(every = "${axiom.pipeline.poll-interval:5s}",
                concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
     void processNextEvent() {
+        if (shuttingDown) {
+            return;
+        }
         EventQueueEntity queueEntry = findNextPendingEvent();
         if (queueEntry == null) {
             return;

--- a/app/src/main/java/io/apitomy/axiom/app/ReportScheduler.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ReportScheduler.java
@@ -4,6 +4,7 @@ import io.apitomy.axiom.core.entities.ReportDefinitionEntity;
 import io.apitomy.axiom.core.entities.ReportEntity;
 import io.apitomy.axiom.core.events.SseEvent;
 import io.quarkus.scheduler.Scheduled;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Event;
 import jakarta.inject.Inject;
@@ -35,6 +36,13 @@ public class ReportScheduler {
     @Inject
     Event<SseEvent> sseEvents;
 
+    private volatile boolean shuttingDown = false;
+
+    @PreDestroy
+    void onShutdown() {
+        shuttingDown = true;
+    }
+
     /**
      * Checks for report definitions that are due and triggers generation.
      * The transactional work (creating reports, advancing nextRunAt) is
@@ -43,6 +51,9 @@ public class ReportScheduler {
     @Scheduled(every = "${axiom.reports.poll-interval:60s}",
             concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
     void checkDueReports() {
+        if (shuttingDown) {
+            return;
+        }
         // Step 1: create reports and advance schedules (transactional)
         List<Long> reportIds = createPendingReports();
 

--- a/app/src/main/java/io/apitomy/axiom/app/ScheduledJobScheduler.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ScheduledJobScheduler.java
@@ -4,6 +4,7 @@ import io.apitomy.axiom.core.entities.ScheduledJobEntity;
 import io.apitomy.axiom.core.entities.ScheduledJobRunEntity;
 import io.apitomy.axiom.core.events.SseEvent;
 import io.quarkus.scheduler.Scheduled;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Event;
 import jakarta.inject.Inject;
@@ -34,6 +35,13 @@ public class ScheduledJobScheduler {
     @Inject
     Event<SseEvent> sseEvents;
 
+    private volatile boolean shuttingDown = false;
+
+    @PreDestroy
+    void onShutdown() {
+        shuttingDown = true;
+    }
+
     /**
      * Checks for scheduled jobs that are due and triggers execution.
      * The transactional work (creating runs, advancing nextRunAt) is
@@ -42,6 +50,9 @@ public class ScheduledJobScheduler {
     @Scheduled(every = "${axiom.scheduled-jobs.poll-interval:60s}",
             concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
     void checkDueJobs() {
+        if (shuttingDown) {
+            return;
+        }
         List<Long> runIds = createPendingRuns();
 
         for (Long runId : runIds) {

--- a/app/src/main/java/io/apitomy/axiom/app/TaskQueuePoller.java
+++ b/app/src/main/java/io/apitomy/axiom/app/TaskQueuePoller.java
@@ -2,6 +2,7 @@ package io.apitomy.axiom.app;
 
 import io.apitomy.axiom.core.entities.TaskEntity;
 import io.quarkus.scheduler.Scheduled;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
@@ -20,12 +21,22 @@ public class TaskQueuePoller {
     @Inject
     TaskExecutionService taskExecutionService;
 
+    private volatile boolean shuttingDown = false;
+
+    @PreDestroy
+    void onShutdown() {
+        shuttingDown = true;
+    }
+
     /**
      * Checks for pending tasks every 5 seconds and dispatches them.
      */
     @Scheduled(every = "${axiom.task-queue.poll-interval:5s}",
                concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
     void pollTaskQueue() {
+        if (shuttingDown) {
+            return;
+        }
         // Find distinct project IDs that have pending tasks
         List<Long> projectIds = TaskEntity.find(
                 "select distinct t.projectId from TaskEntity t where t.status = 'Pending'")

--- a/app/src/main/java/io/apitomy/axiom/app/TraceCleanup.java
+++ b/app/src/main/java/io/apitomy/axiom/app/TraceCleanup.java
@@ -9,6 +9,7 @@ import io.apitomy.axiom.core.entities.ToolExecutionEntity;
 import io.apitomy.axiom.core.entities.TraceEntity;
 import io.apitomy.axiom.core.entities.TraceNodeEntity;
 import io.quarkus.scheduler.Scheduled;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
 import org.jboss.logging.Logger;
@@ -28,12 +29,22 @@ public class TraceCleanup {
 
     private static final Logger LOG = Logger.getLogger(TraceCleanup.class);
 
+    private volatile boolean shuttingDown = false;
+
+    @PreDestroy
+    void onShutdown() {
+        shuttingDown = true;
+    }
+
     /**
      * Finds and deletes traces older than the retention period.
      */
     @Scheduled(every = "1h", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
     @Transactional
     void cleanup() {
+        if (shuttingDown) {
+            return;
+        }
         RetentionConfigEntity config = RetentionConfigEntity.<RetentionConfigEntity>findAll()
                 .firstResult();
         if (config == null) {


### PR DESCRIPTION
## Summary

Adds a `@PreDestroy` shutdown guard to all `@Scheduled` methods in the `app` module that access the database. This prevents the Quarkus scheduler from invoking these methods after the H2 datasource has been closed during shutdown, which previously caused an infinite error loop requiring `kill -9` to stop the process.

## Problem

During application shutdown, the H2 database is closed before the Quarkus scheduler stops. Scheduled tasks (particularly `PipelineOrchestrator.processNextEvent()` at 5-second intervals) continue firing and attempt to acquire JDBC connections, resulting in repeated `SQLException: Database is already closed` errors that prevent the JVM from exiting cleanly.

## Fix

Each scheduled task class now:
1. Declares a `private volatile boolean shuttingDown` flag
2. Sets the flag to `true` via a `@PreDestroy` callback
3. Checks the flag at the top of its `@Scheduled` method and returns immediately if shutting down

This follows the exact same pattern already used by `GitHubPoller` and `JiraPoller` in the events modules.

## Files Modified

- `PipelineOrchestrator.java` — primary culprit (5s poll interval)
- `TaskQueuePoller.java` — 5s poll interval
- `EventCleanup.java` — 1h interval
- `ClosedProjectCleanup.java` — 1h interval
- `EventQueueCleanup.java` — 1h interval
- `EventSourceLogCleanup.java` — 1h interval
- `TraceCleanup.java` — 1h interval
- `ReportScheduler.java` — 60s interval
- `ScheduledJobScheduler.java` — 60s interval

Fixes #246