### PR TITLE
Remove capabilities from Create Agent modal

### DIFF
--- a/ui/src/pages/AgentsPage.tsx
+++ b/ui/src/pages/AgentsPage.tsx
@@ -42,7 +42,6 @@ export function AgentsPage() {
     const [form, setForm] = useState<NewAgent>({
         name: "", agentType: "claude-code", capabilities: [],
     });
-    const [capabilitiesText, setCapabilitiesText] = useState("");
 
     const load = useCallback(() => {
         setLoading(true);
@@ -53,15 +52,12 @@ export function AgentsPage() {
 
     const openCreate = () => {
         setEditing(null);
-        setForm({ name: "", agentType: "claude-code", capabilities: [] });
-        setCapabilitiesText("");
+        setForm({ name: "", agentType: "claude-code", capabilities: ["*"] });
         setIsModalOpen(true);
     };
 
     const handleSave = () => {
-        const caps = capabilitiesText.split(",").map((s) => s.trim()).filter(Boolean);
-        const data = { ...form, capabilities: caps };
-        const action = editing ? updateAgent(editing.id, data) : createAgent(data);
+        const action = editing ? updateAgent(editing.id, form) : createAgent(form);
         action.then(() => { setIsModalOpen(false); load(); }).catch(console.error);
     };
 
@@ -131,9 +127,6 @@ export function AgentsPage() {
                                 <FormSelectOption value="opencode" label="OpenCode" />
                                 <FormSelectOption value="copilot" label="Copilot" />
                             </FormSelect>
-                        </FormGroup>
-                        <FormGroup label="Capabilities" fieldId="capabilities">
-                            <TextInput id="capabilities" value={capabilitiesText} onChange={(_e, v) => setCapabilitiesText(v)} placeholder="analyze, implement, review (comma-separated)" />
                         </FormGroup>
                     </Form>
                 </ModalBody>


### PR DESCRIPTION
## Summary
- Removed the "Capabilities" text input from the Create Agent modal
- New agents now default to `*` (all capabilities)
- Users can refine capabilities on the Agent Detail Page after creation

## Test plan
- [ ] Open the Create Agent modal — verify no "Capabilities" field is shown
- [ ] Create a new agent — verify it is saved with `*` capability
- [ ] Navigate to the Agent Detail Page — verify capabilities can still be edited there