### PR TITLE
Add timeoutSeconds to action types

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/ImportExportService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ImportExportService.java
@@ -333,6 +333,7 @@ public class ImportExportService {
             entity.engine = textOrNull(item, "engine");
             entity.maxSteps = item.has("maxSteps") ? item.path("maxSteps").asInt() : null;
             entity.maxBudgetUsd = item.has("maxBudgetUsd") ? item.path("maxBudgetUsd").asDouble() : null;
+            entity.timeoutSeconds = item.has("timeoutSeconds") ? item.path("timeoutSeconds").asInt() : null;
             entity.environment = jsonOrNull(item, "environment");
             JsonNode labelsNode = item.path("labels");
             if (labelsNode.isArray()) {
@@ -468,6 +469,7 @@ public class ImportExportService {
             entity.engine = textOrNull(item, "engine");
             entity.maxSteps = item.has("maxSteps") ? item.path("maxSteps").asInt() : null;
             entity.maxBudgetUsd = item.has("maxBudgetUsd") ? item.path("maxBudgetUsd").asDouble() : null;
+            entity.timeoutSeconds = item.has("timeoutSeconds") ? item.path("timeoutSeconds").asInt() : null;
             entity.environment = jsonOrNull(item, "environment");
             entity.labels.clear();
             JsonNode labelsNode = item.path("labels");
@@ -673,6 +675,7 @@ public class ImportExportService {
         putIfNotNull(n, "engine", e.engine);
         if (e.maxSteps != null) n.put("maxSteps", e.maxSteps);
         if (e.maxBudgetUsd != null) n.put("maxBudgetUsd", e.maxBudgetUsd);
+        if (e.timeoutSeconds != null) n.put("timeoutSeconds", e.timeoutSeconds);
         putIfNotNull(n, "environment", e.environment);
         if (e.labels != null && !e.labels.isEmpty()) {
             var labelsArr = n.putArray("labels");

--- a/app/src/main/java/io/apitomy/axiom/app/TaskExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/TaskExecutionService.java
@@ -181,6 +181,8 @@ public class TaskExecutionService {
                 .maxSteps(actionTypeEntity != null && actionTypeEntity.maxSteps != null
                         ? actionTypeEntity.maxSteps : 50)
                 .maxBudgetUsd(actionTypeEntity != null ? actionTypeEntity.maxBudgetUsd : null)
+                .timeoutSeconds(actionTypeEntity != null && actionTypeEntity.timeoutSeconds != null
+                        ? actionTypeEntity.timeoutSeconds : 120)
                 .build();
 
         // Execute asynchronously

--- a/app/src/main/java/io/apitomy/axiom/app/rest/ActionResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/ActionResourceImpl.java
@@ -212,6 +212,7 @@ public class ActionResourceImpl implements ActionResource {
         entity.engine = data.getEngine();
         entity.maxSteps = data.getMaxSteps();
         entity.maxBudgetUsd = data.getMaxBudgetUsd();
+        entity.timeoutSeconds = data.getTimeoutSeconds();
         entity.emitsEvent = data.getEmitsEvent() != null ? data.getEmitsEvent() : false;
         entity.environment = environmentToJson(data.getEnvironment());
         entity.labels.clear();
@@ -247,6 +248,7 @@ public class ActionResourceImpl implements ActionResource {
         actionType.setEngine(entity.engine);
         actionType.setMaxSteps(entity.maxSteps);
         actionType.setMaxBudgetUsd(entity.maxBudgetUsd);
+        actionType.setTimeoutSeconds(entity.timeoutSeconds);
         actionType.setEmitsEvent(entity.emitsEvent);
         actionType.setEnvironment(jsonToEnvironment(entity.environment));
         actionType.setLabels(entity.labels);

--- a/app/src/main/resources/db/migration/V49__add_timeout_seconds_to_action_type.sql
+++ b/app/src/main/resources/db/migration/V49__add_timeout_seconds_to_action_type.sql
@@ -1,0 +1,7 @@
+-- =============================================================================
+-- V49: Add timeoutSeconds column to action_type
+-- Allows per-action-type overrides for the agent execution timeout.
+-- When NULL, the global default (120s) applies.
+-- =============================================================================
+
+ALTER TABLE action_type ADD COLUMN IF NOT EXISTS timeout_seconds INTEGER;

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -5809,6 +5809,11 @@
             "description": "Maximum budget in USD for this action type. When empty, the global default is used.",
             "type": "number"
           },
+          "timeoutSeconds": {
+            "format": "int32",
+            "description": "Timeout in seconds for agent execution. When empty, the global default (120s) is used.",
+            "type": "integer"
+          },
           "labels": {
             "description": "Free-form labels for categorization",
             "type": "array",
@@ -5889,6 +5894,11 @@
             "format": "double",
             "description": "Maximum budget in USD for this action type. When empty, the global default is used.",
             "type": "number"
+          },
+          "timeoutSeconds": {
+            "format": "int32",
+            "description": "Timeout in seconds for agent execution. When empty, the global default (120s) is used.",
+            "type": "integer"
           },
           "labels": {
             "description": "Free-form labels for categorization",

--- a/core/src/main/java/io/apitomy/axiom/core/entities/ActionTypeEntity.java
+++ b/core/src/main/java/io/apitomy/axiom/core/entities/ActionTypeEntity.java
@@ -76,6 +76,13 @@ public class ActionTypeEntity extends PanacheEntity {
     @Column(name = "max_budget_usd")
     public Double maxBudgetUsd;
 
+    /**
+     * Optional timeout override in seconds for agent execution.
+     * When null, the global default (120s) is used.
+     */
+    @Column(name = "timeout_seconds")
+    public Integer timeoutSeconds;
+
     @Column(name = "manager_triggerable", nullable = false)
     public boolean managerTriggerable;
 

--- a/ui/src/components/assistant/ActionTypeDetailModal.tsx
+++ b/ui/src/components/assistant/ActionTypeDetailModal.tsx
@@ -42,6 +42,7 @@ export function ActionTypeDetailModal({ isOpen, onClose, name, content, errors }
     const engine = (content.engine as string) || "";
     const maxSteps = content.maxSteps as number | undefined;
     const maxBudgetUsd = content.maxBudgetUsd as number | undefined;
+    const timeoutSeconds = content.timeoutSeconds as number | undefined;
 
     const toolsList = Array.isArray(rawAllowedTools)
         ? rawAllowedTools as string[]
@@ -131,6 +132,12 @@ export function ActionTypeDetailModal({ isOpen, onClose, name, content, errors }
                                     <DescriptionListGroup>
                                         <DescriptionListTerm style={{ whiteSpace: "nowrap" }}>Max Budget (USD)</DescriptionListTerm>
                                         <DescriptionListDescription>${maxBudgetUsd.toFixed(2)}</DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                )}
+                                {timeoutSeconds != null && (
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm style={{ whiteSpace: "nowrap" }}>Timeout (s)</DescriptionListTerm>
+                                        <DescriptionListDescription>{timeoutSeconds}s</DescriptionListDescription>
                                     </DescriptionListGroup>
                                 )}
                             </DescriptionList>

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -351,6 +351,7 @@ export interface ActionType {
     engine?: string;
     maxSteps?: number;
     maxBudgetUsd?: number;
+    timeoutSeconds?: number;
     emitsEvent: boolean;
     environment?: Record<string, string>;
     labels?: string[];

--- a/ui/src/pages/ActionTypeDetailPage.tsx
+++ b/ui/src/pages/ActionTypeDetailPage.tsx
@@ -111,6 +111,7 @@ export function ActionTypeDetailPage() {
                     engine: at.engine,
                     maxSteps: at.maxSteps,
                     maxBudgetUsd: at.maxBudgetUsd,
+                    timeoutSeconds: at.timeoutSeconds,
                     labels: at.labels || [],
                 });
                 setTools(at.allowedTools || []);
@@ -439,6 +440,20 @@ function InfoTab({ form, updateForm, availableModels, availableEngines, onEditLa
                         value={form.maxBudgetUsd ?? ""}
                         onChange={(_e, v) => updateForm({ maxBudgetUsd: v === "" ? undefined : Number(v) })}
                         placeholder="Global default"
+                    />
+                </FormGroup>
+            )}
+            {form.executionMode === "agent" && (
+                <FormGroup label="Timeout (seconds)" fieldId="timeoutSeconds">
+                    <HelperText>
+                        <HelperTextItem>Timeout in seconds for agent execution. Leave empty to use the global default (120s).</HelperTextItem>
+                    </HelperText>
+                    <TextInput
+                        id="timeoutSeconds"
+                        type="number"
+                        value={form.timeoutSeconds ?? ""}
+                        onChange={(_e, v) => updateForm({ timeoutSeconds: v === "" ? undefined : Number(v) })}
+                        placeholder="120 (default)"
                     />
                 </FormGroup>
             )}


### PR DESCRIPTION
## Summary
- Add optional `timeoutSeconds` field to action types for per-action-type agent execution timeout overrides
- Default is 120 seconds when not set
- Full stack: OpenAPI spec, DB migration (V49), entity, REST resource, import/export, task execution, and UI (detail page + assistant modal)

## Test plan
- [ ] Create/edit an action type with a custom timeout value
- [ ] Verify the timeout field appears only for agent execution mode
- [ ] Verify leaving timeout empty defaults to 120s at execution time
- [ ] Verify import/export round-trips the timeoutSeconds field
- [ ] Verify the assistant modal displays the timeout when set