### PR TITLE
feat: support multiple AI engines simultaneously

### DIFF
--- a/agents/claude-code/src/main/java/io/apitomy/axiom/agents/claudecode/ClaudeCodeAgent.java
+++ b/agents/claude-code/src/main/java/io/apitomy/axiom/agents/claudecode/ClaudeCodeAgent.java
@@ -12,6 +12,7 @@ import org.jboss.logging.Logger;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -44,6 +45,9 @@ public class ClaudeCodeAgent implements Agent {
     @ConfigProperty(name = "axiom.agent.claude-code.timeout-seconds", defaultValue = "600")
     int defaultTimeoutSeconds;
 
+    @ConfigProperty(name = "axiom.agent.claude-code.available-models", defaultValue = "")
+    String availableModels;
+
     @Inject
     ClaudeCodeMcpManager mcpManager;
 
@@ -53,6 +57,30 @@ public class ClaudeCodeAgent implements Agent {
     @Override
     public String getType() {
         return "claude-code";
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getLabel() {
+        return "Claude Code";
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<String> getAvailableModels() {
+        if (availableModels == null || availableModels.isBlank()) {
+            return List.of();
+        }
+        return Arrays.stream(availableModels.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean supportsInteractiveSessions() {
+        return true;
     }
 
     /** {@inheritDoc} */

--- a/agents/copilot/src/main/java/io/apitomy/axiom/agents/copilot/CopilotAgent.java
+++ b/agents/copilot/src/main/java/io/apitomy/axiom/agents/copilot/CopilotAgent.java
@@ -11,6 +11,7 @@ import org.jboss.logging.Logger;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -42,6 +43,9 @@ public class CopilotAgent implements Agent {
     @ConfigProperty(name = "axiom.agent.copilot.timeout-seconds", defaultValue = "600")
     int defaultTimeoutSeconds;
 
+    @ConfigProperty(name = "axiom.agent.copilot.available-models", defaultValue = "")
+    String availableModels;
+
     @Inject
     CopilotMcpManager mcpManager;
 
@@ -55,6 +59,24 @@ public class CopilotAgent implements Agent {
     @Override
     public String getType() {
         return "copilot";
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getLabel() {
+        return "GitHub Copilot CLI";
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<String> getAvailableModels() {
+        if (availableModels == null || availableModels.isBlank()) {
+            return List.of();
+        }
+        return Arrays.stream(availableModels.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
     }
 
     /**

--- a/agents/opencode/src/main/java/io/apitomy/axiom/agents/opencode/OpenCodeAgent.java
+++ b/agents/opencode/src/main/java/io/apitomy/axiom/agents/opencode/OpenCodeAgent.java
@@ -14,6 +14,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -50,6 +51,9 @@ public class OpenCodeAgent implements Agent {
     @ConfigProperty(name = "axiom.agent.opencode.timeout-seconds", defaultValue = "600")
     int defaultTimeoutSeconds;
 
+    @ConfigProperty(name = "axiom.agent.opencode.available-models", defaultValue = "")
+    String availableModels;
+
     @Inject
     OpenCodeMcpManager mcpManager;
 
@@ -62,6 +66,24 @@ public class OpenCodeAgent implements Agent {
     @Override
     public String getType() {
         return "opencode";
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getLabel() {
+        return "OpenCode";
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<String> getAvailableModels() {
+        if (availableModels == null || availableModels.isBlank()) {
+            return List.of();
+        }
+        return Arrays.stream(availableModels.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
     }
 
     /** {@inheritDoc} */

--- a/agents/spi/src/main/java/io/apitomy/axiom/agents/spi/Agent.java
+++ b/agents/spi/src/main/java/io/apitomy/axiom/agents/spi/Agent.java
@@ -21,6 +21,31 @@ public interface Agent {
     String getType();
 
     /**
+     * Returns a human-readable display label for this agent type
+     * (e.g. "Claude Code", "OpenCode", "GitHub Copilot CLI").
+     *
+     * @return the display label
+     */
+    String getLabel();
+
+    /**
+     * Returns the list of available model identifiers for this agent.
+     *
+     * @return model names (may be empty, never null)
+     */
+    List<String> getAvailableModels();
+
+    /**
+     * Returns whether this agent supports interactive (streaming) sessions.
+     * Agents that return {@code true} can be used with the AI Assistant feature.
+     *
+     * @return true if interactive sessions are supported
+     */
+    default boolean supportsInteractiveSessions() {
+        return false;
+    }
+
+    /**
      * Executes a prompt and returns the result asynchronously.
      *
      * @param request the agent request containing prompt, config, and environment

--- a/agents/spi/src/main/java/io/apitomy/axiom/agents/spi/AgentRegistry.java
+++ b/agents/spi/src/main/java/io/apitomy/axiom/agents/spi/AgentRegistry.java
@@ -119,4 +119,13 @@ public class AgentRegistry {
     public List<String> getAvailableTypes() {
         return List.copyOf(agentMap.keySet());
     }
+
+    /**
+     * Returns all registered agent implementations.
+     *
+     * @return an unmodifiable list of all registered agents
+     */
+    public List<Agent> getAllAgents() {
+        return List.copyOf(agentMap.values());
+    }
 }

--- a/app/src/main/java/io/apitomy/axiom/app/ActionTypeAiService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ActionTypeAiService.java
@@ -17,6 +17,7 @@ import org.jboss.logging.Logger;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Service that invokes the AI engine to generate or update prompt templates
@@ -32,6 +33,9 @@ public class ActionTypeAiService {
 
     @Inject
     AgentRegistry agentRegistry;
+
+    @ConfigProperty(name = "axiom.helper-services.engine")
+    Optional<String> helperEngine;
 
     @ConfigProperty(name = "axiom.ai-assistant.timeout-seconds", defaultValue = "300")
     int assistantTimeoutSeconds;
@@ -131,8 +135,8 @@ public class ActionTypeAiService {
                 .build();
 
         try {
-            AgentResult result = agentRegistry.getDefaultAgent().executeWithSchema(agentRequest,
-                    RESPONSE_SCHEMA).join();
+            AgentResult result = agentRegistry.getAgent(helperEngine.orElse(null))
+                    .executeWithSchema(agentRequest, RESPONSE_SCHEMA).join();
 
             recordAiUsage(result.costUsd(), result.inputTokens(), result.outputTokens());
 

--- a/app/src/main/java/io/apitomy/axiom/app/ImportExportService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ImportExportService.java
@@ -361,6 +361,10 @@ public class ImportExportService {
             entity.promptTemplate = item.path("promptTemplate").asText("");
             entity.allowedTools = csvOrNull(item, "allowedTools");
             entity.environment = jsonOrNull(item, "environment");
+            entity.engine = textOrNull(item, "engine");
+            entity.model = textOrNull(item, "model");
+            if (item.has("maxSteps")) entity.maxSteps = item.path("maxSteps").asInt();
+            if (item.has("maxBudgetUsd")) entity.maxBudgetUsd = item.path("maxBudgetUsd").asDouble();
             entity.timeoutSeconds = item.has("timeoutSeconds")
                     ? item.path("timeoutSeconds").asInt() : null;
             entity.enabled = false;
@@ -506,6 +510,10 @@ public class ImportExportService {
             entity.promptTemplate = item.path("promptTemplate").asText("");
             entity.allowedTools = csvOrNull(item, "allowedTools");
             entity.environment = jsonOrNull(item, "environment");
+            entity.engine = textOrNull(item, "engine");
+            entity.model = textOrNull(item, "model");
+            if (item.has("maxSteps")) entity.maxSteps = item.path("maxSteps").asInt();
+            if (item.has("maxBudgetUsd")) entity.maxBudgetUsd = item.path("maxBudgetUsd").asDouble();
             entity.timeoutSeconds = item.has("timeoutSeconds")
                     ? item.path("timeoutSeconds").asInt() : null;
             entity.updatedOn = Instant.now();
@@ -695,6 +703,10 @@ public class ImportExportService {
         putIfNotNull(n, "promptTemplate", e.promptTemplate);
         putIfNotNull(n, "allowedTools", e.allowedTools);
         putIfNotNull(n, "environment", e.environment);
+        putIfNotNull(n, "engine", e.engine);
+        putIfNotNull(n, "model", e.model);
+        if (e.maxSteps != null) n.put("maxSteps", e.maxSteps);
+        if (e.maxBudgetUsd != null) n.put("maxBudgetUsd", e.maxBudgetUsd);
         if (e.timeoutSeconds != null) n.put("timeoutSeconds", e.timeoutSeconds);
         return n;
     }
@@ -741,6 +753,7 @@ public class ImportExportService {
             entity.allowedTools = csvOrNull(item, "allowedTools");
             if (item.has("maxSteps")) entity.maxSteps = item.path("maxSteps").asInt();
             if (item.has("maxBudgetUsd")) entity.maxBudgetUsd = item.path("maxBudgetUsd").asDouble();
+            if (item.has("timeoutSeconds")) entity.timeoutSeconds = item.path("timeoutSeconds").asInt();
             entity.environment = jsonOrNull(item, "environment");
             entity.enabled = false;
             entity.createdOn = Instant.now();
@@ -780,6 +793,7 @@ public class ImportExportService {
             entity.allowedTools = csvOrNull(item, "allowedTools");
             if (item.has("maxSteps")) entity.maxSteps = item.path("maxSteps").asInt();
             if (item.has("maxBudgetUsd")) entity.maxBudgetUsd = item.path("maxBudgetUsd").asDouble();
+            if (item.has("timeoutSeconds")) entity.timeoutSeconds = item.path("timeoutSeconds").asInt();
             entity.environment = jsonOrNull(item, "environment");
             entity.labels.clear();
             JsonNode labelsNode = item.path("labels");
@@ -809,6 +823,7 @@ public class ImportExportService {
         putIfNotNull(n, "allowedTools", e.allowedTools);
         if (e.maxSteps != null) n.put("maxSteps", e.maxSteps);
         if (e.maxBudgetUsd != null) n.put("maxBudgetUsd", e.maxBudgetUsd);
+        if (e.timeoutSeconds != null) n.put("timeoutSeconds", e.timeoutSeconds);
         putIfNotNull(n, "environment", e.environment);
         if (e.labels != null && !e.labels.isEmpty()) {
             ArrayNode arr = n.putArray("labels");

--- a/app/src/main/java/io/apitomy/axiom/app/ReportExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ReportExecutionService.java
@@ -37,7 +37,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * Executes report generation by invoking the AI engine with a prompt template,
@@ -76,11 +75,8 @@ public class ReportExecutionService {
     @Inject
     TraceService traceService;
 
-    @ConfigProperty(name = "axiom.agent.claude-code.model")
-    Optional<String> model;
-
     @ConfigProperty(name = "axiom.agent.claude-code.timeout-seconds", defaultValue = "600")
-    int timeoutSeconds;
+    int defaultTimeoutSeconds;
 
     private static final String SYSTEM_PROMPT = """
             You are a report generator for Apicurio Axiom. Your job is to gather \
@@ -177,22 +173,26 @@ public class ReportExecutionService {
         // it registers MCP servers dynamically via HTTP rather than a config
         // file, and generateMcpConfig() above only produces a file that
         // OpenCode ignores.
+        String agentType = definition.engine;
         try {
-            agentRegistry.getMcpManager(null).configureMcpServers(reportId, env, allowedTools);
+            agentRegistry.getMcpManager(agentType).configureMcpServers(reportId, env, allowedTools);
         } catch (Exception e) {
             LOG.warnf(e, "Failed to configure agent MCP servers for report %d", reportId);
         }
 
-        // Build agent request
+        // Build agent request using per-definition overrides
         int effectiveTimeout = definition.timeoutSeconds != null
-                ? definition.timeoutSeconds : timeoutSeconds;
+                ? definition.timeoutSeconds : defaultTimeoutSeconds;
+        int effectiveMaxSteps = definition.maxSteps != null
+                ? definition.maxSteps : 30;
         AgentRequest agentRequest = AgentRequest.builder()
                 .prompt(prompt)
                 .systemPrompt(SYSTEM_PROMPT)
                 .allowedTools(allowedTools)
                 .timeoutSeconds(effectiveTimeout)
-                .maxSteps(30)
-                .model(model.orElse(null))
+                .maxSteps(effectiveMaxSteps)
+                .maxBudgetUsd(definition.maxBudgetUsd)
+                .model(definition.model)
                 .environment(env)
                 .mcpConfigFile(mcpConfig)
                 .build();

--- a/app/src/main/java/io/apitomy/axiom/app/ScheduledJobExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ScheduledJobExecutionService.java
@@ -140,12 +140,14 @@ public class ScheduledJobExecutionService {
         String effectiveModel = job.model != null ? job.model : defaultModel.orElse(null);
         int effectiveMaxSteps = job.maxSteps != null ? job.maxSteps : 30;
         Double effectiveMaxBudget = job.maxBudgetUsd;
+        int effectiveTimeout = job.timeoutSeconds != null
+                ? job.timeoutSeconds : defaultTimeoutSeconds;
 
         AgentRequest agentRequest = AgentRequest.builder()
                 .prompt(prompt)
                 .systemPrompt(SYSTEM_PROMPT)
                 .allowedTools(allowedTools)
-                .timeoutSeconds(defaultTimeoutSeconds)
+                .timeoutSeconds(effectiveTimeout)
                 .maxSteps(effectiveMaxSteps)
                 .maxBudgetUsd(effectiveMaxBudget)
                 .model(effectiveModel)

--- a/app/src/main/java/io/apitomy/axiom/app/ScriptAiService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ScriptAiService.java
@@ -33,6 +33,9 @@ public class ScriptAiService {
     @Inject
     AgentRegistry agentRegistry;
 
+    @ConfigProperty(name = "axiom.helper-services.engine")
+    Optional<String> helperEngine;
+
     @ConfigProperty(name = "axiom.manager.model")
     Optional<String> model;
 
@@ -123,8 +126,8 @@ public class ScriptAiService {
                 .build();
 
         try {
-            AgentResult result = agentRegistry.getDefaultAgent().executeWithSchema(agentRequest,
-                    RESPONSE_SCHEMA).join();
+            AgentResult result = agentRegistry.getAgent(helperEngine.orElse(null))
+                    .executeWithSchema(agentRequest, RESPONSE_SCHEMA).join();
 
             recordAiUsage(result.costUsd(), result.inputTokens(), result.outputTokens());
 

--- a/app/src/main/java/io/apitomy/axiom/app/StartupCheckService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/StartupCheckService.java
@@ -1,5 +1,6 @@
 package io.apitomy.axiom.app;
 
+import io.apitomy.axiom.agents.spi.Agent;
 import io.apitomy.axiom.agents.spi.AgentCheckResult;
 import io.apitomy.axiom.agents.spi.AgentRegistry;
 import io.quarkus.runtime.StartupEvent;
@@ -9,7 +10,9 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -26,6 +29,7 @@ public class StartupCheckService {
     AgentRegistry agentRegistry;
 
     private final List<CheckResult> results = new ArrayList<>();
+    private final Map<String, List<CheckResult>> engineResults = new LinkedHashMap<>();
 
     /**
      * Runs all startup checks when the application starts.
@@ -35,7 +39,7 @@ public class StartupCheckService {
     void onStart(@Observes StartupEvent event) {
         LOG.info("Running startup configuration checks...");
         checkNodeJs();
-        checkAiEngine();
+        checkAllEngines();
 
         long errors = results.stream().filter(r -> "error".equals(r.status())).count();
         long warnings = results.stream().filter(r -> "warning".equals(r.status())).count();
@@ -53,6 +57,16 @@ public class StartupCheckService {
      */
     public List<CheckResult> getResults() {
         return List.copyOf(results);
+    }
+
+    /**
+     * Returns the health check results for a specific engine type.
+     *
+     * @param engineType the engine type identifier
+     * @return the list of check results for that engine (may be empty)
+     */
+    public List<CheckResult> getResultsForEngine(String engineType) {
+        return engineResults.getOrDefault(engineType, List.of());
     }
 
     /**
@@ -116,19 +130,56 @@ public class StartupCheckService {
         }
     }
 
-    private void checkAiEngine() {
-        LOG.infof("Checking AI engine: %s", agentRegistry.getDefaultAgent().getType());
-        List<AgentCheckResult> engineResults = agentRegistry.getDefaultAgent().healthCheck();
-        for (AgentCheckResult engineResult : engineResults) {
-            results.add(new CheckResult(engineResult.name(), engineResult.status(),
-                    engineResult.message()));
-            if ("ok".equals(engineResult.status())) {
-                LOG.infof("Startup check OK: %s", engineResult.name());
-            } else {
-                LOG.warnf("Startup check %s: %s — %s",
-                        engineResult.status().toUpperCase(), engineResult.name(),
-                        engineResult.message());
+    private void checkAllEngines() {
+        // First pass: collect per-engine results with their true status
+        Map<String, List<AgentCheckResult>> rawResults = new LinkedHashMap<>();
+        for (Agent agent : agentRegistry.getAllAgents()) {
+            LOG.infof("Checking AI engine: %s", agent.getType());
+            rawResults.put(agent.getType(), agent.healthCheck());
+        }
+
+        // Determine if at least one engine is fully healthy (no errors)
+        boolean anyEngineHealthy = rawResults.values().stream()
+                .anyMatch(checks -> checks.stream()
+                        .noneMatch(c -> "error".equals(c.status())));
+
+        // Second pass: store per-engine results as-is, but downgrade errors
+        // to warnings in the system-level list when another engine is healthy
+        for (var entry : rawResults.entrySet()) {
+            String engineType = entry.getKey();
+            List<AgentCheckResult> agentChecks = entry.getValue();
+            boolean thisEngineHealthy = agentChecks.stream()
+                    .noneMatch(c -> "error".equals(c.status()));
+
+            List<CheckResult> perEngine = new ArrayList<>();
+            for (AgentCheckResult engineResult : agentChecks) {
+                // Per-engine results always reflect the true status
+                CheckResult perEngineResult = new CheckResult(engineResult.name(),
+                        engineResult.status(), engineResult.message());
+                perEngine.add(perEngineResult);
+
+                // System-level: downgrade to warning if this engine failed
+                // but at least one other engine is healthy
+                String systemStatus = engineResult.status();
+                if ("error".equals(systemStatus) && anyEngineHealthy && !thisEngineHealthy) {
+                    systemStatus = "warning";
+                }
+                results.add(new CheckResult(engineResult.name(),
+                        systemStatus, engineResult.message()));
+
+                if ("ok".equals(engineResult.status())) {
+                    LOG.infof("Startup check OK: %s", engineResult.name());
+                } else {
+                    LOG.warnf("Startup check %s: %s — %s",
+                            engineResult.status().toUpperCase(), engineResult.name(),
+                            engineResult.message());
+                }
             }
+            engineResults.put(engineType, List.copyOf(perEngine));
+        }
+
+        if (!anyEngineHealthy) {
+            LOG.error("No AI engines are available — at least one engine must be configured");
         }
     }
 

--- a/app/src/main/java/io/apitomy/axiom/app/ToolAiService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ToolAiService.java
@@ -36,6 +36,9 @@ public class ToolAiService {
     @Inject
     AgentRegistry agentRegistry;
 
+    @ConfigProperty(name = "axiom.helper-services.engine")
+    Optional<String> helperEngine;
+
     @ConfigProperty(name = "axiom.manager.model")
     Optional<String> model;
 
@@ -127,8 +130,8 @@ public class ToolAiService {
                 .build();
 
         try {
-            AgentResult result = agentRegistry.getDefaultAgent().executeWithSchema(agentRequest,
-                    RESPONSE_SCHEMA).join();
+            AgentResult result = agentRegistry.getAgent(helperEngine.orElse(null))
+                    .executeWithSchema(agentRequest, RESPONSE_SCHEMA).join();
 
             // Record AI usage
             recordAiUsage(result.costUsd(), result.inputTokens(), result.outputTokens());

--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSessionManager.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSessionManager.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.apitomy.axiom.agents.spi.Agent;
+import io.apitomy.axiom.agents.spi.AgentRegistry;
 import io.apitomy.axiom.app.ImportExportService;
 import io.apitomy.axiom.app.McpConfigGenerator;
 import io.apitomy.axiom.app.assistant.AssistantEventParser.SseEvent;
@@ -55,13 +57,16 @@ public class AssistantSessionManager {
     int maxSessions;
 
     @ConfigProperty(name = "axiom.agent.default-type", defaultValue = "claude-code")
-    String aiEngine;
+    String defaultEngineType;
 
     @ConfigProperty(name = "axiom.agent.claude-code.executable", defaultValue = "claude")
     String claudeExecutable;
 
     @ConfigProperty(name = "quarkus.http.port", defaultValue = "9090")
     int httpPort;
+
+    @Inject
+    AgentRegistry agentRegistry;
 
     @Inject
     SessionTemplateService templateService;
@@ -108,10 +113,12 @@ public class AssistantSessionManager {
      */
     public AssistantSession createSession(String name, String templateId,
                                           Long projectId) throws IOException {
-        if (!"claude-code".equals(aiEngine)) {
+        Agent agent = agentRegistry.getDefaultAgent();
+        if (!agent.supportsInteractiveSessions()) {
             throw new IllegalStateException(
-                    "The AI Assistant requires Claude Code as the active AI engine. "
-                            + "Current engine: " + aiEngine);
+                    "The AI Assistant requires an engine that supports interactive sessions. "
+                            + "Current engine (" + agent.getLabel()
+                            + ") does not support this feature.");
         }
 
         // Atomically reserve a session slot before doing any setup work.
@@ -463,12 +470,13 @@ public class AssistantSessionManager {
     }
 
     /**
-     * Returns whether the AI engine supports the assistant feature.
+     * Returns whether any registered engine supports interactive sessions.
      *
-     * @return true if Claude Code is the active engine
+     * @return true if at least one engine supports interactive sessions
      */
     public boolean isAvailable() {
-        return "claude-code".equals(aiEngine);
+        return agentRegistry.getAllAgents().stream()
+                .anyMatch(Agent::supportsInteractiveSessions);
     }
 
     /**

--- a/app/src/main/java/io/apitomy/axiom/app/rest/ReportsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/ReportsResourceImpl.java
@@ -352,6 +352,10 @@ public class ReportsResourceImpl implements ReportsResource {
                 ? String.join(",", data.getAllowedTools()) : null;
         entity.enabled = "none".equals(data.getSchedule()) ? false
                 : (data.getEnabled() != null ? data.getEnabled() : false);
+        entity.engine = data.getEngine();
+        entity.model = data.getModel();
+        entity.maxSteps = data.getMaxSteps();
+        entity.maxBudgetUsd = data.getMaxBudgetUsd();
         entity.timeoutSeconds = data.getTimeoutSeconds();
         entity.environment = environmentToJson(data.getEnvironment());
         entity.initialLabels.clear();
@@ -384,6 +388,10 @@ public class ReportsResourceImpl implements ReportsResource {
                     .map(String::trim).filter(s -> !s.isEmpty()).toList());
         }
         def.setEnabled(entity.enabled);
+        def.setEngine(entity.engine);
+        def.setModel(entity.model);
+        def.setMaxSteps(entity.maxSteps);
+        def.setMaxBudgetUsd(entity.maxBudgetUsd);
         def.setTimeoutSeconds(entity.timeoutSeconds);
         def.setEnvironment(jsonToEnvironment(entity.environment));
         if (entity.nextRunAt != null) def.setNextRunAt(Date.from(entity.nextRunAt));

--- a/app/src/main/java/io/apitomy/axiom/app/rest/ScheduledJobsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/ScheduledJobsResourceImpl.java
@@ -329,6 +329,7 @@ public class ScheduledJobsResourceImpl implements ScheduledResource {
                 ? String.join(",", data.getAllowedTools()) : null;
         entity.maxSteps = data.getMaxSteps();
         entity.maxBudgetUsd = data.getMaxBudgetUsd();
+        entity.timeoutSeconds = data.getTimeoutSeconds();
         entity.enabled = "none".equals(data.getSchedule()) ? false
                 : (data.getEnabled() != null ? data.getEnabled() : false);
         entity.environment = environmentToJson(data.getEnvironment());
@@ -368,6 +369,7 @@ public class ScheduledJobsResourceImpl implements ScheduledResource {
         }
         bean.setMaxSteps(entity.maxSteps);
         bean.setMaxBudgetUsd(entity.maxBudgetUsd);
+        bean.setTimeoutSeconds(entity.timeoutSeconds);
         bean.setEnvironment(jsonToEnvironment(entity.environment));
         bean.setCreatedOn(Date.from(entity.createdOn));
         bean.setUpdatedOn(Date.from(entity.updatedOn));

--- a/app/src/main/java/io/apitomy/axiom/app/rest/SystemResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/SystemResourceImpl.java
@@ -2,6 +2,7 @@ package io.apitomy.axiom.app.rest;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.apitomy.axiom.api.beans.EngineInfo;
 import io.apitomy.axiom.api.beans.Features;
 import io.apitomy.axiom.api.beans.ImportResult;
 import io.apitomy.axiom.api.beans.PackExportRequest;
@@ -10,6 +11,7 @@ import io.apitomy.axiom.api.beans.StartupCheck;
 import io.apitomy.axiom.api.beans.SystemConfig;
 import io.apitomy.axiom.api.beans.SystemHealth;
 import io.apitomy.axiom.api.SystemResource;
+import io.apitomy.axiom.agents.spi.Agent;
 import io.apitomy.axiom.app.ImportExportService;
 import io.apitomy.axiom.app.StartupCheckService;
 import io.apitomy.axiom.core.entities.RetentionConfigEntity;
@@ -23,10 +25,9 @@ import jakarta.transaction.Transactional;
 import java.io.InputStream;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Implementation of the System API endpoints.
@@ -37,18 +38,6 @@ public class SystemResourceImpl implements SystemResource {
 
     @ConfigProperty(name = "quarkus.application.version", defaultValue = "1.0.0-SNAPSHOT")
     String applicationVersion;
-
-    @ConfigProperty(name = "axiom.agent.claude-code.available-models",
-            defaultValue = "claude-opus-4-7,claude-sonnet-4-6,claude-opus-4-6,claude-haiku-4-5-20251001,opus,sonnet,haiku")
-    String claudeAvailableModels;
-
-    @ConfigProperty(name = "axiom.agent.opencode.available-models",
-            defaultValue = "anthropic/claude-sonnet-4-6,anthropic/claude-opus-4-6,anthropic/claude-haiku-4-5-20251001,openai/gpt-4o,openai/o3-mini")
-    String openCodeAvailableModels;
-
-    @ConfigProperty(name = "axiom.agent.copilot.available-models",
-            defaultValue = "claude-sonnet-5,claude-opus-5,claude-haiku-4.5,gpt-5.4,gpt-5-mini,auto")
-    String copilotAvailableModels;
 
     @Inject
     AgentRegistry agentRegistry;
@@ -81,8 +70,41 @@ public class SystemResourceImpl implements SystemResource {
     public SystemConfig getSystemConfig() {
         SystemConfig config = new SystemConfig();
         config.setVersion(applicationVersion);
-        config.setEngine(agentRegistry.getDefaultAgent().getType());
+
+        String defaultType = agentRegistry.getDefaultAgent().getType();
+        config.setEngine(defaultType);
+        config.setDefaultEngine(defaultType);
         config.setFeatures(new Features());
+
+        // Build per-engine info
+        List<EngineInfo> engineInfos = new ArrayList<>();
+        for (Agent agent : agentRegistry.getAllAgents()) {
+            EngineInfo info = new EngineInfo();
+            info.setType(agent.getType());
+            info.setLabel(agent.getLabel());
+            info.setSupportsInteractiveSessions(agent.supportsInteractiveSessions());
+            info.setModels(agent.getAvailableModels());
+
+            List<StartupCheckService.CheckResult> engineChecks =
+                    startupCheckService.getResultsForEngine(agent.getType());
+            List<StartupCheck> checks = engineChecks.stream()
+                    .map(r -> {
+                        StartupCheck check = new StartupCheck();
+                        check.setName(r.name());
+                        check.setStatus(StartupCheck.Status.fromValue(r.status()));
+                        check.setMessage(r.message());
+                        return check;
+                    })
+                    .toList();
+            info.setChecks(checks);
+            info.setAvailable(checks.stream().noneMatch(
+                    c -> c.getStatus() == StartupCheck.Status.ERROR));
+
+            engineInfos.add(info);
+        }
+        config.setEngines(engineInfos);
+
+        // Flat checks list (backwards compat)
         config.setChecks(startupCheckService.getResults().stream()
                 .map(r -> {
                     StartupCheck check = new StartupCheck();
@@ -107,22 +129,15 @@ public class SystemResourceImpl implements SystemResource {
      * {@inheritDoc}
      *
      * Returns the available models for the specified engine, or the default
-     * engine if not specified. Claude Code returns short model names;
-     * OpenCode returns provider/model format.
+     * engine if not specified. Delegates to the Agent SPI's
+     * {@code getAvailableModels()} method.
      */
     @Override
     public List<String> listModels(String engine) {
-        String engineType = (engine != null && !engine.isBlank()) ? engine : agentRegistry.getDefaultAgent().getType();
-        String models = switch (engineType) {
-            case "opencode" -> openCodeAvailableModels;
-            case "copilot" -> copilotAvailableModels;
-            default -> claudeAvailableModels;
-        };
-
-        return Arrays.stream(models.split(","))
-                .map(String::trim)
-                .filter(s -> !s.isEmpty())
-                .toList();
+        Agent agent = (engine != null && !engine.isBlank())
+                ? agentRegistry.getAgent(engine)
+                : agentRegistry.getDefaultAgent();
+        return agent.getAvailableModels();
     }
 
     /**

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -45,8 +45,15 @@ axiom.manager.confidence-threshold=0.7
 axiom.manager.timeout-seconds=120
 # Maximum agentic turns for the Manager
 axiom.manager.max-turns=5
+# Engine override for the Manager (optional, defaults to global default)
+# axiom.manager.engine=claude-code
 # Model override for the Manager (optional)
 # axiom.manager.model=claude-sonnet-4-6
+
+# --- Helper Services ---
+# Engine override for AI helper services (prompt editor, script editor, tool editor)
+# Defaults to the global default agent if not set.
+# axiom.helper-services.engine=claude-code
 
 # --- Claude Code Agent ---
 # Path to the claude CLI executable (defaults to "claude" on PATH)

--- a/app/src/main/resources/db/migration/V51__add_ai_config_to_report_def_and_scheduled_job.sql
+++ b/app/src/main/resources/db/migration/V51__add_ai_config_to_report_def_and_scheduled_job.sql
@@ -1,0 +1,8 @@
+-- Add missing AI configuration fields to report_definition
+ALTER TABLE report_definition ADD COLUMN engine VARCHAR(255);
+ALTER TABLE report_definition ADD COLUMN model VARCHAR(255);
+ALTER TABLE report_definition ADD COLUMN max_steps INTEGER;
+ALTER TABLE report_definition ADD COLUMN max_budget_usd DOUBLE PRECISION;
+
+-- Add missing timeout_seconds to scheduled_job
+ALTER TABLE scheduled_job ADD COLUMN timeout_seconds INTEGER;

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -5404,8 +5404,19 @@
             "type": "string"
           },
           "engine": {
-            "description": "The active AI engine type (e.g. claude-code, opencode, copilot)",
+            "description": "The default AI engine type (deprecated — use defaultEngine instead)",
             "type": "string"
+          },
+          "defaultEngine": {
+            "description": "The default AI engine type identifier",
+            "type": "string"
+          },
+          "engines": {
+            "description": "All registered AI engines with per-engine health checks, models, and capabilities",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineInfo"
+            }
           },
           "features": {
             "$ref": "#/components/schemas/Features"
@@ -5415,6 +5426,46 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/StartupCheck"
+            }
+          }
+        }
+      },
+      "EngineInfo": {
+        "required": [
+          "type",
+          "label",
+          "available"
+        ],
+        "type": "object",
+        "properties": {
+          "type": {
+            "description": "Engine type identifier (e.g. claude-code, opencode, copilot)",
+            "type": "string"
+          },
+          "label": {
+            "description": "Human-readable display name for this engine",
+            "type": "string"
+          },
+          "available": {
+            "description": "Whether this engine passed all health checks without errors",
+            "type": "boolean"
+          },
+          "supportsInteractiveSessions": {
+            "description": "Whether this engine supports interactive assistant sessions",
+            "type": "boolean"
+          },
+          "checks": {
+            "description": "Health check results for this engine",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StartupCheck"
+            }
+          },
+          "models": {
+            "description": "Available model identifiers for this engine",
+            "type": "array",
+            "items": {
+              "type": "string"
             }
           }
         }
@@ -6258,6 +6309,23 @@
             "description": "Day of week for weekly schedules (e.g. monday, tuesday)",
             "type": "string"
           },
+          "engine": {
+            "description": "Optional AI engine override",
+            "type": "string"
+          },
+          "model": {
+            "description": "Optional AI model override",
+            "type": "string"
+          },
+          "maxSteps": {
+            "description": "Max agent steps",
+            "type": "integer"
+          },
+          "maxBudgetUsd": {
+            "format": "double",
+            "description": "Max budget in USD",
+            "type": "number"
+          },
           "timeoutSeconds": {
             "description": "Optional timeout in seconds for report generation. Overrides the global default when set.",
             "type": "integer"
@@ -6324,6 +6392,23 @@
           "scheduleDayOfWeek": {
             "description": "Day of week for weekly schedules (e.g. monday, tuesday)",
             "type": "string"
+          },
+          "engine": {
+            "description": "Optional AI engine override",
+            "type": "string"
+          },
+          "model": {
+            "description": "Optional AI model override",
+            "type": "string"
+          },
+          "maxSteps": {
+            "description": "Max agent steps",
+            "type": "integer"
+          },
+          "maxBudgetUsd": {
+            "format": "double",
+            "description": "Max budget in USD",
+            "type": "number"
           },
           "timeoutSeconds": {
             "description": "Optional timeout in seconds for report generation. Overrides the global default when set.",
@@ -8750,6 +8835,10 @@
             "description": "Max budget in USD",
             "type": "number"
           },
+          "timeoutSeconds": {
+            "description": "Optional timeout in seconds. Overrides the global default when set.",
+            "type": "integer"
+          },
           "environment": {
             "description": "Custom environment variables. Values can reference secrets using ${secret:NAME} syntax.",
             "type": "object",
@@ -8840,6 +8929,10 @@
             "format": "double",
             "description": "Max budget in USD",
             "type": "number"
+          },
+          "timeoutSeconds": {
+            "description": "Optional timeout in seconds. Overrides the global default when set.",
+            "type": "integer"
           },
           "environment": {
             "description": "Custom environment variables. Values can reference secrets using ${secret:NAME} syntax.",

--- a/core/src/main/java/io/apitomy/axiom/core/entities/ReportDefinitionEntity.java
+++ b/core/src/main/java/io/apitomy/axiom/core/entities/ReportDefinitionEntity.java
@@ -83,6 +83,28 @@ public class ReportDefinitionEntity extends PanacheEntity {
     public String environment;
 
     /**
+     * Optional AI engine override (e.g. "claude-code", "opencode").
+     */
+    public String engine;
+
+    /**
+     * Optional AI model override (e.g. "claude-sonnet-4-6").
+     */
+    public String model;
+
+    /**
+     * Optional maximum number of agent steps/turns.
+     */
+    @Column(name = "max_steps")
+    public Integer maxSteps;
+
+    /**
+     * Optional maximum budget in USD for AI execution.
+     */
+    @Column(name = "max_budget_usd")
+    public Double maxBudgetUsd;
+
+    /**
      * Optional per-report timeout in seconds. Overrides the global default when set.
      */
     @Column(name = "timeout_seconds")

--- a/core/src/main/java/io/apitomy/axiom/core/entities/ScheduledJobEntity.java
+++ b/core/src/main/java/io/apitomy/axiom/core/entities/ScheduledJobEntity.java
@@ -106,6 +106,12 @@ public class ScheduledJobEntity extends PanacheEntity {
     public Double maxBudgetUsd;
 
     /**
+     * Optional timeout in seconds for agent execution.
+     */
+    @Column(name = "timeout_seconds")
+    public Integer timeoutSeconds;
+
+    /**
      * Optional JSON object of environment variables for the subprocess.
      * Values can reference secrets using ${secret:NAME} syntax.
      */

--- a/manager/src/main/java/io/apitomy/axiom/manager/ManagerService.java
+++ b/manager/src/main/java/io/apitomy/axiom/manager/ManagerService.java
@@ -58,6 +58,9 @@ public class ManagerService {
     @ConfigProperty(name = "axiom.manager.max-turns", defaultValue = "5")
     int maxTurns;
 
+    @ConfigProperty(name = "axiom.manager.engine")
+    Optional<String> managerEngine;
+
     @ConfigProperty(name = "axiom.manager.model")
     Optional<String> model;
 
@@ -147,7 +150,8 @@ public class ManagerService {
                 .build();
 
         try {
-            AgentResult result = agentRegistry.getDefaultAgent().executeWithSchema(agentRequest, jsonSchema).join();
+            AgentResult result = agentRegistry.getAgent(managerEngine.orElse(null))
+                    .executeWithSchema(agentRequest, jsonSchema).join();
             String executionLog = result.executionLog();
 
             // Record AI usage for this Manager evaluation

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -56,7 +56,8 @@ export function App() {
     const location = useLocation();
     const { mode: themeMode, effectiveTheme, setMode: setThemeMode } = useTheme();
     const [startupChecks, setStartupChecks] = useState<StartupCheck[] | null>(null);
-    const [engineName, setEngineName] = useState<string | undefined>(undefined);
+    const [engineLabel, setEngineLabel] = useState<string | undefined>(undefined);
+    const [assistantAvailable, setAssistantAvailable] = useState(false);
     const [appVersion, setAppVersion] = useState<string>("");
     const themeProps = useMemo(() => ({ themeMode, setThemeMode }), [themeMode, setThemeMode]);
 
@@ -70,12 +71,21 @@ export function App() {
                 if (config.checks) {
                     setStartupChecks(config.checks);
                 }
-                if (config.engine) {
-                    setEngineName(config.engine);
-                }
                 if (config.version) {
                     setAppVersion(config.version);
                 }
+                // Resolve default engine label from engines array
+                const defaultType = config.defaultEngine || config.engine;
+                const defaultInfo = (config.engines || []).find(
+                    (e) => e.type === defaultType
+                );
+                setEngineLabel(defaultInfo?.label || defaultType);
+                // Assistant is available if any engine supports interactive sessions
+                setAssistantAvailable(
+                    (config.engines || []).some(
+                        (e) => e.supportsInteractiveSessions && e.available
+                    )
+                );
             })
             .catch(console.error);
 
@@ -93,7 +103,7 @@ export function App() {
     return (
         <EffectiveThemeContext.Provider value={effectiveTheme}>
             <Page
-                masthead={isBreakout ? undefined : <AppMasthead engineName={engineName} appVersion={appVersion} {...themeProps} />}
+                masthead={isBreakout ? undefined : <AppMasthead engineLabel={engineLabel} assistantAvailable={assistantAvailable} appVersion={appVersion} {...themeProps} />}
                 sidebar={hasCheckErrors || isAssistantPage || isBreakout ? undefined : <AppSidebar />}
                 isContentFilled
                 style={isBreakout ? {

--- a/ui/src/components/AiConfigTab.tsx
+++ b/ui/src/components/AiConfigTab.tsx
@@ -1,0 +1,167 @@
+import {
+    FormGroup,
+    FormSelect,
+    FormSelectOption,
+    FormSelectOptionGroup,
+    HelperText,
+    HelperTextItem,
+    TextInput,
+} from "@patternfly/react-core";
+
+export interface AiConfigValues {
+    engine?: string;
+    model?: string;
+    maxSteps?: number;
+    maxBudgetUsd?: number;
+    timeoutSeconds?: number;
+}
+
+const ENGINE_LABELS: Record<string, string> = {
+    "claude-code": "Claude Code",
+    "opencode": "OpenCode",
+    "copilot": "GitHub Copilot CLI",
+};
+
+/**
+ * Shared AI configuration form fields used by Action Types,
+ * Scheduled Jobs, and Report Definitions.
+ */
+export function AiConfigTab({ values, onChange, availableEngines, availableModels }: {
+    values: AiConfigValues;
+    onChange: (updates: Partial<AiConfigValues>) => void;
+    availableEngines: string[];
+    availableModels: string[];
+}) {
+    return (
+        <>
+            {availableEngines.length > 1 && (
+                <FormGroup label="Engine" fieldId="engine">
+                    <HelperText>
+                        <HelperTextItem>
+                            AI engine to use. Select &lsquo;Global default&rsquo; to use
+                            the system-wide setting.
+                        </HelperTextItem>
+                    </HelperText>
+                    <FormSelect
+                        id="engine"
+                        value={values.engine || ""}
+                        onChange={(_e, v) => onChange({ engine: v || undefined })}
+                    >
+                        <FormSelectOption value="" label="Global default" />
+                        {availableEngines.map((e) => (
+                            <FormSelectOption
+                                key={e}
+                                value={e}
+                                label={ENGINE_LABELS[e] || e}
+                            />
+                        ))}
+                    </FormSelect>
+                </FormGroup>
+            )}
+
+            <FormGroup label="Model" fieldId="model">
+                <HelperText>
+                    <HelperTextItem>
+                        AI model to use. Select &lsquo;Global default&rsquo; to use
+                        the system-wide setting.
+                    </HelperTextItem>
+                </HelperText>
+                <FormSelect
+                    id="model"
+                    value={values.model || ""}
+                    onChange={(_e, v) => onChange({ model: v || undefined })}
+                >
+                    <FormSelectOption value="" label="Global default" />
+                    {renderModelOptions(availableModels)}
+                </FormSelect>
+            </FormGroup>
+
+            <FormGroup label="Max Steps" fieldId="maxSteps">
+                <HelperText>
+                    <HelperTextItem>
+                        Maximum number of agent steps/turns. Leave empty to use the
+                        global default.
+                    </HelperTextItem>
+                </HelperText>
+                <TextInput
+                    id="maxSteps"
+                    type="number"
+                    value={values.maxSteps ?? ""}
+                    onChange={(_e, v) =>
+                        onChange({ maxSteps: v === "" ? undefined : Number(v) })
+                    }
+                    placeholder="Global default"
+                />
+            </FormGroup>
+
+            <FormGroup label="Max Budget (USD)" fieldId="maxBudgetUsd">
+                <HelperText>
+                    <HelperTextItem>
+                        Maximum budget in USD per execution. Leave empty to use the
+                        global default.
+                    </HelperTextItem>
+                </HelperText>
+                <TextInput
+                    id="maxBudgetUsd"
+                    type="number"
+                    value={values.maxBudgetUsd ?? ""}
+                    onChange={(_e, v) =>
+                        onChange({ maxBudgetUsd: v === "" ? undefined : Number(v) })
+                    }
+                    placeholder="Global default"
+                />
+            </FormGroup>
+
+            <FormGroup label="Timeout (seconds)" fieldId="timeoutSeconds">
+                <HelperText>
+                    <HelperTextItem>
+                        Timeout in seconds for agent execution. Leave empty to use the
+                        global default.
+                    </HelperTextItem>
+                </HelperText>
+                <TextInput
+                    id="timeoutSeconds"
+                    type="number"
+                    value={values.timeoutSeconds ?? ""}
+                    onChange={(_e, v) =>
+                        onChange({
+                            timeoutSeconds: v === "" ? undefined : Number(v),
+                        })
+                    }
+                    placeholder="Global default"
+                />
+            </FormGroup>
+        </>
+    );
+}
+
+function renderModelOptions(models: string[]) {
+    const hasProviders = models.some((m) => m.includes("/"));
+    if (hasProviders) {
+        const groups: Record<string, string[]> = {};
+        for (const m of models) {
+            if (m.includes("/")) {
+                const [provider] = m.split("/", 2);
+                const key =
+                    provider.charAt(0).toUpperCase() + provider.slice(1);
+                if (!groups[key]) groups[key] = [];
+                groups[key].push(m);
+            } else {
+                if (!groups["Other"]) groups["Other"] = [];
+                groups["Other"].push(m);
+            }
+        }
+        return Object.entries(groups).map(([provider, providerModels]) => (
+            <FormSelectOptionGroup key={provider} label={provider}>
+                {providerModels.map((m) => (
+                    <FormSelectOption
+                        key={m}
+                        value={m}
+                        label={m.split("/").pop() || m}
+                    />
+                ))}
+            </FormSelectOptionGroup>
+        ));
+    }
+    return models.map((m) => <FormSelectOption key={m} value={m} label={m} />);
+}

--- a/ui/src/components/AppMasthead.tsx
+++ b/ui/src/components/AppMasthead.tsx
@@ -22,7 +22,8 @@ import DesktopIcon from "@patternfly/react-icons/dist/esm/icons/desktop-icon";
 import { type ThemeMode } from "../hooks/useTheme";
 
 interface AppMastheadProps {
-    engineName?: string;
+    engineLabel?: string;
+    assistantAvailable: boolean;
     appVersion: string;
     themeMode: ThemeMode;
     setThemeMode: (mode: ThemeMode) => void;
@@ -44,7 +45,7 @@ function themeDisplay(mode: ThemeMode) {
     }
 }
 
-export function AppMasthead({ engineName, appVersion, themeMode, setThemeMode }: AppMastheadProps) {
+export function AppMasthead({ engineLabel, assistantAvailable, appVersion, themeMode, setThemeMode }: AppMastheadProps) {
     const navigate = useNavigate();
     const [isAboutOpen, setIsAboutOpen] = useState(false);
     const { icon: themeIcon, label: themeLabel } = themeDisplay(themeMode);
@@ -69,7 +70,7 @@ export function AppMasthead({ engineName, appVersion, themeMode, setThemeMode }:
                     <Toolbar>
                         <ToolbarContent>
                             <ToolbarItem align={{ default: "alignEnd" }}>
-                                {engineName === "claude-code" && (
+                                {assistantAvailable && (
                                     <Tooltip content="AI Assistant">
                                         <Button variant="plain" aria-label="AI Assistant"
                                             onClick={() => {
@@ -120,10 +121,7 @@ export function AppMasthead({ engineName, appVersion, themeMode, setThemeMode }:
                     <dd>{appVersion || "—"}</dd>
                     <dt>AI Engine</dt>
                     <dd>
-                        {engineName === "opencode" ? "OpenCode"
-                            : engineName === "claude-code" ? "Claude Code"
-                            : engineName === "copilot" ? "GitHub Copilot CLI"
-                            : engineName || "—"}
+                        {engineLabel || "—"}
                     </dd>
                     <dt>License</dt>
                     <dd>Apache License 2.0</dd>

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -29,9 +29,20 @@ export interface StartupCheck {
     message: string;
 }
 
+export interface EngineInfo {
+    type: string;
+    label: string;
+    available: boolean;
+    supportsInteractiveSessions?: boolean;
+    checks?: StartupCheck[];
+    models?: string[];
+}
+
 export interface SystemConfig {
     version: string;
     engine?: string;
+    defaultEngine?: string;
+    engines?: EngineInfo[];
     features: Record<string, boolean>;
     checks?: StartupCheck[];
 }
@@ -984,6 +995,10 @@ export interface ReportDefinition {
     titleTemplate?: string;
     allowedTools?: string[];
     enabled: boolean;
+    engine?: string;
+    model?: string;
+    maxSteps?: number;
+    maxBudgetUsd?: number;
     timeoutSeconds?: number;
     environment?: Record<string, string>;
     initialLabels?: string[];
@@ -1920,6 +1935,7 @@ export interface ScheduledJob {
     allowedTools?: string[];
     maxSteps?: number;
     maxBudgetUsd?: number;
+    timeoutSeconds?: number;
     environment?: Record<string, string>;
     createdOn: string;
     updatedOn: string;

--- a/ui/src/pages/ActionTypeDetailPage.tsx
+++ b/ui/src/pages/ActionTypeDetailPage.tsx
@@ -14,7 +14,6 @@ import {
     FormGroup,
     FormSelect,
     FormSelectOption,
-    FormSelectOptionGroup,
     PageSection,
     Tab,
     TabContent,
@@ -22,11 +21,12 @@ import {
     Tabs,
     TextArea,
     TextInput,
-    Title, HelperText, HelperTextItem,
+    Title,
 } from "@patternfly/react-core";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import { registerPlaceholderCompletions, ACTION_TYPE_PLACEHOLDERS } from "../components/PlaceholderCompletionProvider";
 import { EditLabelsModal } from "../components/EditLabelsModal";
+import { AiConfigTab } from "../components/AiConfigTab";
 import { EnvironmentTab } from "../components/EnvironmentTab";
 import { LabelDisplay } from "../components/LabelDisplay";
 import { ToolListEditor } from "../components/ToolListEditor";
@@ -238,7 +238,7 @@ export function ActionTypeDetailPage() {
             <Tabs activeKey={activeTab} onSelect={(_e, k) => setActiveTab(k as number)}>
                 <Tab eventKey={0} title={<TabTitleText>Info</TabTitleText>}>
                     <TabContent id="info-tab" eventKey={0} activeKey={activeTab} style={{ marginTop: "24px" }}>
-                        <InfoTab form={form} updateForm={updateForm} availableModels={availableModels} availableEngines={availableEngines} onEditLabels={() => setIsLabelsOpen(true)} />
+                        <InfoTab form={form} updateForm={updateForm} onEditLabels={() => setIsLabelsOpen(true)} />
                     </TabContent>
                 </Tab>
                 {form.executionMode === "agent" && (
@@ -288,6 +288,20 @@ export function ActionTypeDetailPage() {
                                 value={form.promptTemplate || ""}
                                 onChange={(v) => updateForm({ promptTemplate: v })}
                             />
+                        </TabContent>
+                    </Tab>
+                )}
+                {form.executionMode === "agent" && (
+                    <Tab eventKey={10} title={<TabTitleText>AI Config</TabTitleText>}>
+                        <TabContent id="ai-config-tab" eventKey={10} activeKey={activeTab} style={{ marginTop: "24px" }}>
+                            <Form style={{ maxWidth: "600px" }}>
+                                <AiConfigTab
+                                    values={form}
+                                    onChange={updateForm}
+                                    availableEngines={availableEngines}
+                                    availableModels={availableModels}
+                                />
+                            </Form>
                         </TabContent>
                     </Tab>
                 )}
@@ -360,11 +374,9 @@ export function ActionTypeDetailPage() {
     );
 }
 
-function InfoTab({ form, updateForm, availableModels, availableEngines, onEditLabels }: {
+function InfoTab({ form, updateForm, onEditLabels }: {
     form: NewActionType;
     updateForm: (updates: Partial<NewActionType>) => void;
-    availableModels: string[];
-    availableEngines: string[];
     onEditLabels: () => void;
 }) {
     return (
@@ -398,107 +410,6 @@ function InfoTab({ form, updateForm, availableModels, availableEngines, onEditLa
                     <FormSelectOption value="script" label="Script — executes a bash script" />
                 </FormSelect>
             </FormGroup>
-            {form.executionMode === "agent" && availableEngines.length > 1 && (
-                <FormGroup label="AI Engine" fieldId="engine">
-                    <HelperText>
-                        <HelperTextItem>AI engine to use for this action type. Select 'Global default' to use the system-wide setting.</HelperTextItem>
-                    </HelperText>
-                    <FormSelect
-                        id="engine"
-                        value={form.engine || ""}
-                        onChange={(_e, v) => updateForm({ engine: v || undefined })}
-                    >
-                        <FormSelectOption value="" label="Global default" />
-                        {availableEngines.map((e) => (
-                            <FormSelectOption key={e} value={e} label={e === "opencode" ? "OpenCode" : e === "claude-code" ? "Claude Code" : e === "copilot" ? "GitHub Copilot CLI" : e} />
-                        ))}
-                    </FormSelect>
-                </FormGroup>
-            )}
-            {form.executionMode === "agent" && (
-                <FormGroup label="Max Steps" fieldId="maxSteps">
-                    <HelperText>
-                        <HelperTextItem>Maximum number of agent steps/turns. Leave empty to use the global default.</HelperTextItem>
-                    </HelperText>
-                    <TextInput
-                        id="maxSteps"
-                        type="number"
-                        value={form.maxSteps ?? ""}
-                        onChange={(_e, v) => updateForm({ maxSteps: v === "" ? undefined : Number(v) })}
-                        placeholder="Global default"
-                    />
-                </FormGroup>
-            )}
-            {form.executionMode === "agent" && (
-                <FormGroup label="Max Budget (USD)" fieldId="maxBudgetUsd">
-                    <HelperText>
-                        <HelperTextItem>Maximum budget in USD for this action type. Leave empty to use the global default.</HelperTextItem>
-                    </HelperText>
-                    <TextInput
-                        id="maxBudgetUsd"
-                        type="number"
-                        value={form.maxBudgetUsd ?? ""}
-                        onChange={(_e, v) => updateForm({ maxBudgetUsd: v === "" ? undefined : Number(v) })}
-                        placeholder="Global default"
-                    />
-                </FormGroup>
-            )}
-            {form.executionMode === "agent" && (
-                <FormGroup label="Timeout (seconds)" fieldId="timeoutSeconds">
-                    <HelperText>
-                        <HelperTextItem>Timeout in seconds for agent execution. Leave empty to use the global default (120s).</HelperTextItem>
-                    </HelperText>
-                    <TextInput
-                        id="timeoutSeconds"
-                        type="number"
-                        value={form.timeoutSeconds ?? ""}
-                        onChange={(_e, v) => updateForm({ timeoutSeconds: v === "" ? undefined : Number(v) })}
-                        placeholder="120 (default)"
-                    />
-                </FormGroup>
-            )}
-            {form.executionMode === "agent" && (
-                <FormGroup label="Model" fieldId="model">
-                    <HelperText>
-                        <HelperTextItem>AI model to use for this action type. Select 'Global default' to use the system-wide setting.</HelperTextItem>
-                    </HelperText>
-                    <FormSelect
-                        id="model"
-                        value={form.model || ""}
-                        onChange={(_e, v) => updateForm({ model: v || undefined })}
-                    >
-                        <FormSelectOption value="" label="Global default" />
-                        {(() => {
-                            // Group models by provider if they use provider/model format
-                            const hasProviders = availableModels.some((m) => m.includes("/"));
-                            if (hasProviders) {
-                                const groups: Record<string, string[]> = {};
-                                for (const m of availableModels) {
-                                    if (m.includes("/")) {
-                                        const [provider] = m.split("/", 2);
-                                        const key = provider.charAt(0).toUpperCase() + provider.slice(1);
-                                        if (!groups[key]) groups[key] = [];
-                                        groups[key].push(m);
-                                    } else {
-                                        if (!groups["Other"]) groups["Other"] = [];
-                                        groups["Other"].push(m);
-                                    }
-                                }
-                                return Object.entries(groups).map(([provider, models]) => (
-                                    <FormSelectOptionGroup key={provider} label={provider}>
-                                        {models.map((m) => (
-                                            <FormSelectOption key={m} value={m} label={m.split("/").pop() || m} />
-                                        ))}
-                                    </FormSelectOptionGroup>
-                                ));
-                            }
-                            return availableModels.map((m) => (
-                                <FormSelectOption key={m} value={m} label={m} />
-                            ));
-                        })()}
-                    </FormSelect>
-                </FormGroup>
-            )}
             <FormGroup fieldId="flags">
                 <Checkbox
                     id="userTriggerable"

--- a/ui/src/pages/EngineSettingsPage.tsx
+++ b/ui/src/pages/EngineSettingsPage.tsx
@@ -22,22 +22,15 @@ import ExclamationCircleIcon from "@patternfly/react-icons/dist/esm/icons/exclam
 import ExclamationTriangleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon";
 import CogIcon from "@patternfly/react-icons/dist/esm/icons/cog-icon";
 
-import { type SystemConfig, fetchSystemConfig, fetchModels } from "../config/api";
+import { type EngineInfo, type SystemConfig, fetchSystemConfig } from "../config/api";
 
 export function EngineSettingsPage() {
     const [config, setConfig] = useState<SystemConfig | null>(null);
-    const [models, setModels] = useState<string[]>([]);
     const [loading, setLoading] = useState(true);
 
     useEffect(() => {
-        Promise.all([
-            fetchSystemConfig(),
-            fetchModels(),
-        ])
-            .then(([cfg, mdls]) => {
-                setConfig(cfg);
-                setModels(mdls);
-            })
+        fetchSystemConfig()
+            .then(setConfig)
             .catch(console.error)
             .finally(() => setLoading(false));
     }, []);
@@ -53,24 +46,78 @@ export function EngineSettingsPage() {
     if (!config) {
         return (
             <PageSection>
-                <Title headingLevel="h1">AI Engine</Title>
+                <Title headingLevel="h1">AI Engines</Title>
                 <p>Failed to load engine configuration.</p>
             </PageSection>
         );
     }
 
-    const engineName = config.engine || "unknown";
-    const engineLabel = engineName === "opencode" ? "OpenCode" : engineName === "claude-code" ? "Claude Code" : engineName === "copilot" ? "GitHub Copilot CLI" : engineName;
-    const engineChecks = (config.checks || []).filter(
-        (c) => !["GitHub API Token", "Node.js"].includes(c.name)
-    );
-    const allHealthy = engineChecks.every((c) => c.status === "ok");
+    const engines = config.engines || [];
+    const defaultEngine = config.defaultEngine || config.engine;
+    const nodeJsCheck = (config.checks || []).find((c) => c.name === "Node.js");
 
-    // Group models by provider for OpenCode
-    const isOpenCode = engineName === "opencode";
+    return (
+        <PageSection>
+            <Title headingLevel="h1" style={{ marginBottom: 24 }}>
+                <CogIcon style={{ marginRight: 8 }} />
+                AI Engines
+            </Title>
+
+            <Flex direction={{ default: "column" }} gap={{ default: "gapMd" }}>
+                {/* Node.js check (shared prerequisite) */}
+                {nodeJsCheck && (
+                    <FlexItem>
+                        <Card>
+                            <CardTitle>Prerequisites</CardTitle>
+                            <CardBody>
+                                <DescriptionList isHorizontal>
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm>
+                                            <StatusIcon status={nodeJsCheck.status} />{" "}
+                                            {nodeJsCheck.name}
+                                        </DescriptionListTerm>
+                                        <DescriptionListDescription>
+                                            {nodeJsCheck.message}
+                                        </DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                </DescriptionList>
+                            </CardBody>
+                        </Card>
+                    </FlexItem>
+                )}
+
+                {/* One card per engine */}
+                {engines.map((engine) => (
+                    <FlexItem key={engine.type}>
+                        <EngineCard
+                            engine={engine}
+                            isDefault={engine.type === defaultEngine}
+                        />
+                    </FlexItem>
+                ))}
+
+                {engines.length === 0 && (
+                    <FlexItem>
+                        <Card>
+                            <CardBody>
+                                <p>No AI engines registered.</p>
+                            </CardBody>
+                        </Card>
+                    </FlexItem>
+                )}
+            </Flex>
+        </PageSection>
+    );
+}
+
+function EngineCard({ engine, isDefault }: { engine: EngineInfo; isDefault: boolean }) {
+    const checks = engine.checks || [];
+    const models = engine.models || [];
+
+    // Group models by provider (for engines that use provider/model format)
     const groupedModels: Record<string, string[]> = {};
     for (const m of models) {
-        if (isOpenCode && m.includes("/")) {
+        if (m.includes("/")) {
             const [provider, ...rest] = m.split("/");
             const key = provider.charAt(0).toUpperCase() + provider.slice(1);
             if (!groupedModels[key]) groupedModels[key] = [];
@@ -82,62 +129,57 @@ export function EngineSettingsPage() {
     }
 
     return (
-        <PageSection>
-            <Title headingLevel="h1" style={{ marginBottom: 24 }}>
-                <CogIcon style={{ marginRight: 8 }} />
-                AI Engine
-            </Title>
-
-            <Flex direction={{ default: "column" }} gap={{ default: "gapMd" }}>
-                {/* Engine Info Card */}
-                <FlexItem>
-                    <Card>
-                        <CardTitle>
-                            <Split hasGutter>
-                                <SplitItem>Active Engine</SplitItem>
-                                <SplitItem isFilled />
-                                <SplitItem>
-                                    <Label
-                                        color={allHealthy ? "green" : "red"}
-                                        icon={allHealthy ? <CheckCircleIcon /> : <ExclamationCircleIcon />}
-                                    >
-                                        {allHealthy ? "Healthy" : "Issues detected"}
-                                    </Label>
-                                </SplitItem>
-                            </Split>
-                        </CardTitle>
-                        <CardBody>
+        <Card>
+            <CardTitle>
+                <Split hasGutter>
+                    <SplitItem>
+                        {engine.label}
+                        {isDefault && (
+                            <Label
+                                color="blue"
+                                style={{ marginLeft: 8 }}
+                                isCompact
+                            >
+                                Default
+                            </Label>
+                        )}
+                    </SplitItem>
+                    <SplitItem isFilled />
+                    <SplitItem>
+                        <Label
+                            color={engine.available ? "green" : "red"}
+                            icon={
+                                engine.available ? (
+                                    <CheckCircleIcon />
+                                ) : (
+                                    <ExclamationCircleIcon />
+                                )
+                            }
+                        >
+                            {engine.available ? "Available" : "Unavailable"}
+                        </Label>
+                        {engine.supportsInteractiveSessions && (
+                            <Label
+                                color="purple"
+                                style={{ marginLeft: 8 }}
+                                isCompact
+                            >
+                                Interactive
+                            </Label>
+                        )}
+                    </SplitItem>
+                </Split>
+            </CardTitle>
+            <CardBody>
+                <Flex direction={{ default: "column" }} gap={{ default: "gapMd" }}>
+                    {/* Health Checks */}
+                    {checks.length > 0 && (
+                        <FlexItem>
+                            <Title headingLevel="h4" size="md" style={{ marginBottom: 8 }}>
+                                Health Checks
+                            </Title>
                             <DescriptionList isHorizontal>
-                                <DescriptionListGroup>
-                                    <DescriptionListTerm>Engine</DescriptionListTerm>
-                                    <DescriptionListDescription>
-                                        <Label variant="outline" color="blue">{engineLabel}</Label>
-                                    </DescriptionListDescription>
-                                </DescriptionListGroup>
-                                <DescriptionListGroup>
-                                    <DescriptionListTerm>Configuration</DescriptionListTerm>
-                                    <DescriptionListDescription>
-                                        <code>axiom.ai-engine={engineName}</code>
-                                    </DescriptionListDescription>
-                                </DescriptionListGroup>
-                                <DescriptionListGroup>
-                                    <DescriptionListTerm>Version</DescriptionListTerm>
-                                    <DescriptionListDescription>
-                                        {config.version}
-                                    </DescriptionListDescription>
-                                </DescriptionListGroup>
-                            </DescriptionList>
-                        </CardBody>
-                    </Card>
-                </FlexItem>
-
-                {/* Health Checks Card */}
-                <FlexItem>
-                    <Card>
-                        <CardTitle>Health Checks</CardTitle>
-                        <CardBody>
-                            <DescriptionList isHorizontal>
-                                {(config.checks || []).map((check) => (
+                                {checks.map((check) => (
                                     <DescriptionListGroup key={check.name}>
                                         <DescriptionListTerm>
                                             <StatusIcon status={check.status} />{" "}
@@ -149,59 +191,71 @@ export function EngineSettingsPage() {
                                     </DescriptionListGroup>
                                 ))}
                             </DescriptionList>
-                        </CardBody>
-                    </Card>
-                </FlexItem>
+                        </FlexItem>
+                    )}
 
-                {/* Available Models Card */}
-                <FlexItem>
-                    <Card>
-                        <CardTitle>Available Models</CardTitle>
-                        <CardBody>
-                            {Object.entries(groupedModels).map(([provider, providerModels]) => (
-                                <div key={provider} style={{ marginBottom: 16 }}>
-                                    {Object.keys(groupedModels).length > 1 && (
-                                        <Title headingLevel="h4" size="md" style={{ marginBottom: 8 }}>
-                                            {provider}
-                                        </Title>
-                                    )}
-                                    <Flex gap={{ default: "gapSm" }} flexWrap={{ default: "wrap" }}>
-                                        {providerModels.map((m) => (
-                                            <FlexItem key={m}>
-                                                <Label variant="outline">{m}</Label>
-                                            </FlexItem>
-                                        ))}
-                                    </Flex>
-                                </div>
-                            ))}
-                            {models.length === 0 && (
-                                <p className="axiom-text-subtle">No models configured.</p>
+                    {/* Available Models */}
+                    {models.length > 0 && (
+                        <FlexItem>
+                            <Title headingLevel="h4" size="md" style={{ marginBottom: 8 }}>
+                                Available Models
+                            </Title>
+                            {Object.entries(groupedModels).map(
+                                ([provider, providerModels]) => (
+                                    <div key={provider} style={{ marginBottom: 8 }}>
+                                        {Object.keys(groupedModels).length > 1 && (
+                                            <Title
+                                                headingLevel="h5"
+                                                size="md"
+                                                style={{ marginBottom: 4 }}
+                                            >
+                                                {provider}
+                                            </Title>
+                                        )}
+                                        <Flex
+                                            gap={{ default: "gapSm" }}
+                                            flexWrap={{ default: "wrap" }}
+                                        >
+                                            {providerModels.map((m) => (
+                                                <FlexItem key={m}>
+                                                    <Label variant="outline">{m}</Label>
+                                                </FlexItem>
+                                            ))}
+                                        </Flex>
+                                    </div>
+                                )
                             )}
-                        </CardBody>
-                    </Card>
-                </FlexItem>
-            </Flex>
-        </PageSection>
+                        </FlexItem>
+                    )}
+
+                    {models.length === 0 && (
+                        <FlexItem>
+                            <p className="axiom-text-subtle">No models configured.</p>
+                        </FlexItem>
+                    )}
+                </Flex>
+            </CardBody>
+        </Card>
     );
 }
 
 function StatusIcon({ status }: { status: string }) {
     if (status === "ok") {
         return (
-            <Icon status="success" size="sm">
+            <Icon status="success">
                 <CheckCircleIcon />
             </Icon>
         );
     }
     if (status === "warning") {
         return (
-            <Icon status="warning" size="sm">
+            <Icon status="warning">
                 <ExclamationTriangleIcon />
             </Icon>
         );
     }
     return (
-        <Icon status="danger" size="sm">
+        <Icon status="danger">
             <ExclamationCircleIcon />
         </Icon>
     );

--- a/ui/src/pages/ReportDefinitionDetailPage.tsx
+++ b/ui/src/pages/ReportDefinitionDetailPage.tsx
@@ -26,6 +26,7 @@ import {
 } from "@patternfly/react-core";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import { registerPlaceholderCompletions, REPORT_PLACEHOLDERS } from "../components/PlaceholderCompletionProvider";
+import { AiConfigTab } from "../components/AiConfigTab";
 import { EnvironmentTab } from "../components/EnvironmentTab";
 import { ToolListEditor } from "../components/ToolListEditor";
 import { LabelInput } from "../components/LabelInput";
@@ -45,6 +46,8 @@ import {
     runReportDefinition,
     deleteReportDefinition,
     validateReportDefinition,
+    fetchEngines,
+    fetchModels,
 } from "../config/api";
 import ExclamationTriangleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon";
 import ExclamationCircleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon";
@@ -74,6 +77,8 @@ export function ReportDefinitionDetailPage() {
     const [initialLabels, setInitialLabels] = useState<string[]>([]);
     const [envVars, setEnvVars] = useState<Record<string, string>>({});
     const [validationMessages, setValidationMessages] = useState<ToolValidationMessage[]>([]);
+    const [availableEngines, setAvailableEngines] = useState<string[]>([]);
+    const [availableModels, setAvailableModels] = useState<string[]>([]);
 
     const validationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -101,6 +106,10 @@ export function ReportDefinitionDetailPage() {
                     scheduleDayOfWeek: def.scheduleDayOfWeek,
                     timeWindow: def.timeWindow,
                     promptTemplate: def.promptTemplate, enabled: def.enabled,
+                    engine: def.engine,
+                    model: def.model,
+                    maxSteps: def.maxSteps,
+                    maxBudgetUsd: def.maxBudgetUsd,
                     timeoutSeconds: def.timeoutSeconds,
                     titleTemplate: def.titleTemplate,
                 });
@@ -119,6 +128,14 @@ export function ReportDefinitionDetailPage() {
 
     useEffect(() => { loadData(); }, [loadData]);
 
+    useEffect(() => {
+        fetchEngines().then(setAvailableEngines).catch(console.error);
+    }, []);
+
+    useEffect(() => {
+        fetchModels(form.engine || undefined).then(setAvailableModels).catch(console.error);
+    }, [form.engine]);
+
     const buildValidationData = (
         formData: NewReportDefinition,
         toolsList: string[],
@@ -132,6 +149,9 @@ export function ReportDefinitionDetailPage() {
     });
 
     const updateForm = (updates: Partial<NewReportDefinition>) => {
+        if (updates.engine !== undefined && updates.engine !== form.engine) {
+            updates = { ...updates, model: undefined };
+        }
         setForm((prev) => {
             const updated = { ...prev, ...updates };
             runValidation(buildValidationData(updated, tools, initialLabels, envVars));
@@ -310,6 +330,19 @@ export function ReportDefinitionDetailPage() {
                         />
                     </TabContent>
                 </Tab>
+                <Tab eventKey={10} title={<TabTitleText>AI Config</TabTitleText>}>
+                    <TabContent id="ai-config-tab" eventKey={10} activeKey={activeTab}
+                        style={{ marginTop: "24px" }}>
+                        <Form style={{ maxWidth: "600px" }}>
+                            <AiConfigTab
+                                values={form}
+                                onChange={updateForm}
+                                availableEngines={availableEngines}
+                                availableModels={availableModels}
+                            />
+                        </Form>
+                    </TabContent>
+                </Tab>
                 {validationMessages.length > 0 && (
                     <Tab eventKey={4} title={
                         <TabTitleText>
@@ -417,12 +450,6 @@ function InfoTab({ form, updateForm, initialLabels, onLabelsChange }: {
                     <FormSelectOption value="last-7d" label="Last 7 Days" />
                     <FormSelectOption value="last-30d" label="Last 30 Days" />
                 </FormSelect>
-            </FormGroup>
-            <FormGroup label="Timeout (seconds)" fieldId="timeoutSeconds">
-                <TextInput id="timeoutSeconds" type="number"
-                    value={form.timeoutSeconds?.toString() || ""}
-                    onChange={(_e, v) => updateForm({ timeoutSeconds: v ? parseInt(v) : undefined })}
-                    placeholder="Global default (600)" />
             </FormGroup>
             <FormGroup label="Labels" fieldId="initialLabels">
                 <LabelInput labels={initialLabels}

--- a/ui/src/pages/ScheduledJobDetailPage.tsx
+++ b/ui/src/pages/ScheduledJobDetailPage.tsx
@@ -14,7 +14,6 @@ import {
     FormGroup,
     FormSelect,
     FormSelectOption,
-    FormSelectOptionGroup,
     HelperText,
     HelperTextItem,
     Label,
@@ -31,6 +30,7 @@ import {
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import { ConfirmDeleteModal } from "../components/ConfirmDeleteModal";
+import { AiConfigTab } from "../components/AiConfigTab";
 import { EnvironmentTab } from "../components/EnvironmentTab";
 import { ToolListEditor } from "../components/ToolListEditor";
 import { LabelInput } from "../components/LabelInput";
@@ -268,9 +268,7 @@ export function ScheduledJobDetailPage() {
                         style={{ marginTop: "24px" }}>
                         <InfoTab form={form} updateForm={updateForm}
                             labels={labels}
-                            onLabelsChange={(l) => { setLabels(l); setDirty(true); }}
-                            availableModels={availableModels}
-                            availableEngines={availableEngines} />
+                            onLabelsChange={(l) => { setLabels(l); setDirty(true); }} />
                     </TabContent>
                 </Tab>
                 <Tab eventKey={1} title={<TabTitleText>Allowed Tools ({tools.length})</TabTitleText>}>
@@ -338,6 +336,21 @@ export function ScheduledJobDetailPage() {
                         )}
                     </TabContent>
                 </Tab>
+                {form.executionMode === "agent" && (
+                    <Tab eventKey={10} title={<TabTitleText>AI Config</TabTitleText>}>
+                        <TabContent id="ai-config-tab" eventKey={10} activeKey={activeTab}
+                            style={{ marginTop: "24px" }}>
+                            <Form style={{ maxWidth: "600px" }}>
+                                <AiConfigTab
+                                    values={form}
+                                    onChange={updateForm}
+                                    availableEngines={availableEngines}
+                                    availableModels={availableModels}
+                                />
+                            </Form>
+                        </TabContent>
+                    </Tab>
+                )}
                 <Tab eventKey={4} title={<TabTitleText>
                     Run History{runs.length > 0 ? ` (${runs.length})` : ""}
                 </TabTitleText>}>
@@ -359,13 +372,11 @@ export function ScheduledJobDetailPage() {
     );
 }
 
-function InfoTab({ form, updateForm, labels, onLabelsChange, availableModels, availableEngines }: {
+function InfoTab({ form, updateForm, labels, onLabelsChange }: {
     form: NewScheduledJob;
     updateForm: (updates: Partial<NewScheduledJob>) => void;
     labels: string[];
     onLabelsChange: (labels: string[]) => void;
-    availableModels: string[];
-    availableEngines: string[];
 }) {
     return (
         <Form style={{ maxWidth: "600px" }}>
@@ -428,101 +439,6 @@ function InfoTab({ form, updateForm, labels, onLabelsChange, availableModels, av
                     <FormSelectOption value="script" label="Script — executes a bash script" />
                 </FormSelect>
             </FormGroup>
-            {form.executionMode === "agent" && availableEngines.length > 1 && (
-                <FormGroup label="AI Engine" fieldId="engine">
-                    <HelperText>
-                        <HelperTextItem>
-                            AI engine to use for this job. Select &lsquo;Global default&rsquo; to
-                            use the system-wide setting.
-                        </HelperTextItem>
-                    </HelperText>
-                    <FormSelect id="engine" value={form.engine || ""}
-                        onChange={(_e, v) => updateForm({ engine: v || undefined })}>
-                        <FormSelectOption value="" label="Global default" />
-                        {availableEngines.map((e) => (
-                            <FormSelectOption key={e} value={e}
-                                label={e === "opencode" ? "OpenCode"
-                                    : e === "claude-code" ? "Claude Code"
-                                    : e === "copilot" ? "GitHub Copilot CLI" : e} />
-                        ))}
-                    </FormSelect>
-                </FormGroup>
-            )}
-            {form.executionMode === "agent" && (
-                <FormGroup label="Model" fieldId="model">
-                    <HelperText>
-                        <HelperTextItem>
-                            AI model to use for this job. Select &lsquo;Global default&rsquo; to
-                            use the system-wide setting.
-                        </HelperTextItem>
-                    </HelperText>
-                    <FormSelect id="model" value={form.model || ""}
-                        onChange={(_e, v) => updateForm({ model: v || undefined })}>
-                        <FormSelectOption value="" label="Global default" />
-                        {(() => {
-                            const hasProviders = availableModels.some((m) => m.includes("/"));
-                            if (hasProviders) {
-                                const groups: Record<string, string[]> = {};
-                                for (const m of availableModels) {
-                                    if (m.includes("/")) {
-                                        const [provider] = m.split("/", 2);
-                                        const key = provider.charAt(0).toUpperCase()
-                                            + provider.slice(1);
-                                        if (!groups[key]) groups[key] = [];
-                                        groups[key].push(m);
-                                    } else {
-                                        if (!groups["Other"]) groups["Other"] = [];
-                                        groups["Other"].push(m);
-                                    }
-                                }
-                                return Object.entries(groups).map(([provider, models]) => (
-                                    <FormSelectOptionGroup key={provider} label={provider}>
-                                        {models.map((m) => (
-                                            <FormSelectOption key={m} value={m}
-                                                label={m.split("/").pop() || m} />
-                                        ))}
-                                    </FormSelectOptionGroup>
-                                ));
-                            }
-                            return availableModels.map((m) => (
-                                <FormSelectOption key={m} value={m} label={m} />
-                            ));
-                        })()}
-                    </FormSelect>
-                </FormGroup>
-            )}
-            {form.executionMode === "agent" && (
-                <FormGroup label="Max Steps" fieldId="maxSteps">
-                    <HelperText>
-                        <HelperTextItem>
-                            Maximum number of agent steps/turns. Leave empty to use the global
-                            default.
-                        </HelperTextItem>
-                    </HelperText>
-                    <TextInput id="maxSteps" type="number"
-                        value={form.maxSteps ?? ""}
-                        onChange={(_e, v) => updateForm({
-                            maxSteps: v === "" ? undefined : Number(v),
-                        })}
-                        placeholder="Global default" />
-                </FormGroup>
-            )}
-            {form.executionMode === "agent" && (
-                <FormGroup label="Max Budget (USD)" fieldId="maxBudgetUsd">
-                    <HelperText>
-                        <HelperTextItem>
-                            Maximum budget in USD for this job. Leave empty to use the global
-                            default.
-                        </HelperTextItem>
-                    </HelperText>
-                    <TextInput id="maxBudgetUsd" type="number"
-                        value={form.maxBudgetUsd ?? ""}
-                        onChange={(_e, v) => updateForm({
-                            maxBudgetUsd: v === "" ? undefined : Number(v),
-                        })}
-                        placeholder="Global default" />
-                </FormGroup>
-            )}
             <FormGroup label="Labels" fieldId="labels">
                 <LabelInput labels={labels} onChange={onLabelsChange} />
             </FormGroup>


### PR DESCRIPTION
## Summary

- **Agent SPI**: Added `getLabel()`, `getAvailableModels()`, and `supportsInteractiveSessions()` to the `Agent` interface. All three implementations (Claude Code, OpenCode, Copilot) updated.
- **Multi-engine health checks**: `StartupCheckService` now checks all registered engines. Failures are downgraded to warnings when at least one engine is healthy — only a total absence of healthy engines is a system-level error.
- **OpenAPI / REST**: New `EngineInfo` schema with per-engine type, label, availability, capabilities, health checks, and models. `SystemConfig` gains `defaultEngine` and `engines[]` fields. `listModels()` delegates to the Agent SPI instead of a hardcoded switch.
- **Configurable engine for services**: `ManagerService` supports `axiom.manager.engine`. Helper services (`ActionTypeAiService`, `ScriptAiService`, `ToolAiService`) support `axiom.helper-services.engine`. Both fall back to the global default.
- **Assistant multi-engine**: Replaced hard-coded `claude-code` gate with `supportsInteractiveSessions()` capability check.
- **AI config parity**: Report definitions now have `engine`, `model`, `maxSteps`, `maxBudgetUsd`. Scheduled jobs now have `timeoutSeconds`. V51 migration adds the columns.
- **Shared AI Config tab**: New `AiConfigTab` component used by Action Type, Scheduled Job, and Report Definition detail pages. Fields: Engine, Model, Max Steps, Max Budget, Timeout. Shown only in agent execution mode (for action types and scheduled jobs).
- **Engine Settings UI**: Rewritten to show one card per registered engine with health checks, models, availability badge, default badge, and interactive capability badge.

## Test plan

- [ ] Start Axiom with only Claude Code installed — verify system is healthy, other engines show as warnings
- [ ] Start Axiom with no engines installed — verify system shows errors
- [ ] Check `/api/v1/system/config` returns `engines[]` with per-engine health/models
- [ ] Verify Engine Settings page shows all engines with correct status
- [ ] Verify AI Config tab appears on Action Type, Scheduled Job, and Report Definition pages
- [ ] Verify AI Config tab is hidden when execution mode is Script
- [ ] Verify engine/model selection works and model list refreshes on engine change
- [ ] Verify assistant button appears when any engine supports interactive sessions