### PR TITLE
feat: track AI engine and model in usage records

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/ActionTypeAiService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ActionTypeAiService.java
@@ -197,6 +197,7 @@ public class ActionTypeAiService {
         AiUsageEntity usage = new AiUsageEntity();
         usage.invocationType = "action-type-edit";
         usage.actionType = "action-type-ai-edit";
+        usage.engine = helperEngine.orElse(agentRegistry.getDefaultAgentType());
         usage.costUsd = costUsd;
         usage.inputTokens = inputTokens;
         usage.outputTokens = outputTokens;

--- a/app/src/main/java/io/apitomy/axiom/app/ReportExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ReportExecutionService.java
@@ -299,6 +299,10 @@ public class ReportExecutionService {
         AiUsageEntity usage = new AiUsageEntity();
         usage.invocationType = "report";
         usage.actionType = "generate-report";
+        String reportEngine = def != null ? def.engine : null;
+        usage.engine = reportEngine != null && !reportEngine.isBlank()
+                ? reportEngine : agentRegistry.getDefaultAgentType();
+        usage.model = def != null ? def.model : null;
         usage.costUsd = result.costUsd();
         usage.inputTokens = result.inputTokens();
         usage.outputTokens = result.outputTokens();

--- a/app/src/main/java/io/apitomy/axiom/app/ScheduledJobExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ScheduledJobExecutionService.java
@@ -313,6 +313,10 @@ public class ScheduledJobExecutionService {
         AiUsageEntity usage = new AiUsageEntity();
         usage.invocationType = "scheduled-job";
         usage.actionType = job != null ? job.name : "unknown";
+        String jobEngine = job != null ? job.engine : null;
+        usage.engine = jobEngine != null && !jobEngine.isBlank()
+                ? jobEngine : agentRegistry.getDefaultAgentType();
+        usage.model = job != null ? job.model : null;
         usage.costUsd = result.costUsd();
         usage.inputTokens = result.inputTokens();
         usage.outputTokens = result.outputTokens();

--- a/app/src/main/java/io/apitomy/axiom/app/ScriptAiService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ScriptAiService.java
@@ -172,6 +172,8 @@ public class ScriptAiService {
         AiUsageEntity usage = new AiUsageEntity();
         usage.invocationType = "script-edit";
         usage.actionType = "script-ai-edit";
+        usage.engine = helperEngine.orElse(agentRegistry.getDefaultAgentType());
+        usage.model = model.orElse(null);
         usage.costUsd = costUsd;
         usage.inputTokens = inputTokens;
         usage.outputTokens = outputTokens;

--- a/app/src/main/java/io/apitomy/axiom/app/TaskExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/TaskExecutionService.java
@@ -379,9 +379,15 @@ public class TaskExecutionService {
                 result.inputTokens() != null ? result.inputTokens() : 0,
                 result.outputTokens() != null ? result.outputTokens() : 0);
 
-        // Record AI usage
+        // Record AI usage (resolve engine/model from the action type definition)
+        ActionTypeEntity actionTypeEntity = ActionTypeEntity.find("name", task.actionType).firstResult();
+        String engine = actionTypeEntity != null ? actionTypeEntity.engine : null;
+        String model = actionTypeEntity != null ? actionTypeEntity.model : null;
+        if (engine == null || engine.isBlank()) {
+            engine = agentRegistry.getDefaultAgentType();
+        }
         recordAiUsage("task", taskId, task.eventId, task.projectId,
-                task.assignedAgent, task.actionType,
+                task.assignedAgent, task.actionType, engine, model,
                 result.costUsd(), result.inputTokens(), result.outputTokens());
 
         // Log to activity
@@ -534,6 +540,7 @@ public class TaskExecutionService {
 
     private void recordAiUsage(String invocationType, Long taskId, Long eventId,
                                 Long projectId, Long agentId, String actionType,
+                                String engine, String model,
                                 Double costUsd, Long inputTokens, Long outputTokens) {
         AiUsageEntity usage = new AiUsageEntity();
         usage.invocationType = invocationType;
@@ -542,6 +549,8 @@ public class TaskExecutionService {
         usage.projectId = projectId;
         usage.agentId = agentId;
         usage.actionType = actionType;
+        usage.engine = engine;
+        usage.model = model;
         usage.costUsd = costUsd;
         usage.inputTokens = inputTokens;
         usage.outputTokens = outputTokens;

--- a/app/src/main/java/io/apitomy/axiom/app/ToolAiService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ToolAiService.java
@@ -202,6 +202,8 @@ public class ToolAiService {
         AiUsageEntity usage = new AiUsageEntity();
         usage.invocationType = "tool-edit";
         usage.actionType = "tool-ai-edit";
+        usage.engine = helperEngine.orElse(agentRegistry.getDefaultAgentType());
+        usage.model = model.orElse(null);
         usage.costUsd = costUsd;
         usage.inputTokens = inputTokens;
         usage.outputTokens = outputTokens;

--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSessionManager.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSessionManager.java
@@ -370,6 +370,7 @@ public class AssistantSessionManager {
         AiUsageEntity usage = new AiUsageEntity();
         usage.invocationType = "assistant-session";
         usage.actionType = "assistant-session";
+        usage.engine = agentRegistry.getDefaultAgentType();
         usage.costUsd = session.getTotalCostUsd();
         usage.inputTokens = session.getTotalInputTokens();
         usage.outputTokens = session.getTotalOutputTokens();

--- a/app/src/main/java/io/apitomy/axiom/app/rest/UsageResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/UsageResourceImpl.java
@@ -49,7 +49,9 @@ public class UsageResourceImpl implements UsageResource {
                                            String filterActionType,
                                            String filterDateFrom,
                                            String filterDateTo,
-                                           String filterLabels) {
+                                           String filterLabels,
+                                           String filterEngine,
+                                           String filterModel) {
         int pageNum = page != null ? page.intValue() : 1;
         int pageSize = limit != null ? limit.intValue() : 20;
 
@@ -93,6 +95,14 @@ public class UsageResourceImpl implements UsageResource {
                     + " GROUP BY p.id HAVING COUNT(DISTINCT pl) = :labelCount)");
             params.put("labels", labels);
             params.put("labelCount", (long) labels.size());
+        }
+        if (filterEngine != null && !filterEngine.isBlank()) {
+            hql.append(" and engine = :engine");
+            params.put("engine", filterEngine);
+        }
+        if (filterModel != null && !filterModel.isBlank()) {
+            hql.append(" and model = :model");
+            params.put("model", filterModel);
         }
 
         long totalCount = AiUsageEntity.count(hql.toString(), params);
@@ -212,6 +222,7 @@ public class UsageResourceImpl implements UsageResource {
         usage.setProjectId(entity.projectId);
         usage.setAgentId(entity.agentId);
         usage.setActionType(entity.actionType);
+        usage.setEngine(entity.engine);
         usage.setModel(entity.model);
         usage.setCostUsd(entity.costUsd);
         usage.setInputTokens(entity.inputTokens);

--- a/app/src/main/resources/db/migration/V52__add_engine_to_ai_usage.sql
+++ b/app/src/main/resources/db/migration/V52__add_engine_to_ai_usage.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ai_usage ADD COLUMN engine VARCHAR(255);

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -1695,6 +1695,22 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "filterEngine",
+            "in": "query",
+            "description": "Filter by AI engine (e.g. claude-code, opencode, copilot)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filterModel",
+            "in": "query",
+            "description": "Filter by AI model (e.g. claude-sonnet-4-6)",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -6609,6 +6625,10 @@
             "type": "integer"
           },
           "actionType": {
+            "type": "string"
+          },
+          "engine": {
+            "description": "The AI engine used (e.g. claude-code, opencode, copilot)",
             "type": "string"
           },
           "model": {

--- a/core/src/main/java/io/apitomy/axiom/core/entities/AiUsageEntity.java
+++ b/core/src/main/java/io/apitomy/axiom/core/entities/AiUsageEntity.java
@@ -57,6 +57,11 @@ public class AiUsageEntity extends PanacheEntity {
     public String actionType;
 
     /**
+     * The AI engine used (e.g. "claude-code", "opencode", "copilot").
+     */
+    public String engine;
+
+    /**
      * The AI model used (e.g. "claude-sonnet-4-6").
      */
     public String model;

--- a/manager/src/main/java/io/apitomy/axiom/manager/ManagerService.java
+++ b/manager/src/main/java/io/apitomy/axiom/manager/ManagerService.java
@@ -342,12 +342,16 @@ public class ManagerService {
 
     void recordAiUsage(Long eventId, Long projectId,
                         Double costUsd, Long inputTokens, Long outputTokens) {
+        String resolvedEngine = managerEngine.orElse(agentRegistry.getDefaultAgentType());
+        String resolvedModel = model.orElse(null);
         QuarkusTransaction.requiringNew().run(() -> {
             AiUsageEntity usage = new AiUsageEntity();
             usage.invocationType = "manager";
             usage.eventId = eventId;
             usage.projectId = projectId;
             usage.actionType = "manager-evaluate";
+            usage.engine = resolvedEngine;
+            usage.model = resolvedModel;
             usage.costUsd = costUsd;
             usage.inputTokens = inputTokens;
             usage.outputTokens = outputTokens;

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -1184,6 +1184,7 @@ export interface AiUsage {
     projectId?: number;
     agentId?: number;
     actionType?: string;
+    engine?: string;
     model?: string;
     costUsd?: number;
     inputTokens?: number;
@@ -1203,7 +1204,8 @@ export async function fetchUsage(
     filterInvocationType?: string, filterProjectId?: number,
     filterAgentId?: number, filterActionType?: string,
     filterDateFrom?: string, filterDateTo?: string,
-    filterLabels?: string
+    filterLabels?: string, filterEngine?: string,
+    filterModel?: string
 ): Promise<AiUsageSearchResults> {
     const params = new URLSearchParams();
     params.set("page", String(page));
@@ -1215,6 +1217,8 @@ export async function fetchUsage(
     if (filterDateFrom) params.set("filterDateFrom", filterDateFrom);
     if (filterDateTo) params.set("filterDateTo", filterDateTo);
     if (filterLabels) params.set("filterLabels", filterLabels);
+    if (filterEngine) params.set("filterEngine", filterEngine);
+    if (filterModel) params.set("filterModel", filterModel);
     const response = await fetch(`${API}/usage/ai?${params}`);
     if (!response.ok) throw new Error(`Failed to fetch usage: ${response.status}`);
     return response.json();

--- a/ui/src/pages/AiUsagePage.tsx
+++ b/ui/src/pages/AiUsagePage.tsx
@@ -34,6 +34,8 @@ const TYPE_COLORS: Record<string, "blue" | "green"> = {
 const FILTER_TYPES: ChipFilterType[] = [
     { value: "invocationType", label: "Type", testId: "usage-filter-type" },
     { value: "actionType", label: "Action Type", testId: "usage-filter-action" },
+    { value: "engine", label: "Engine", testId: "usage-filter-engine" },
+    { value: "model", label: "Model", testId: "usage-filter-model" },
 ];
 
 export function AiUsagePage() {
@@ -54,6 +56,8 @@ export function AiUsagePage() {
 
     const filterInvocationType = filters.find((f) => f.filterBy.value === "invocationType")?.filterValue;
     const filterActionType = filters.find((f) => f.filterBy.value === "actionType")?.filterValue;
+    const filterEngine = filters.find((f) => f.filterBy.value === "engine")?.filterValue;
+    const filterModel = filters.find((f) => f.filterBy.value === "model")?.filterValue;
     const isFiltered = filters.length > 0 || !!filterDateFrom || !!filterDateTo;
 
     const loadData = useCallback(() => {
@@ -64,7 +68,10 @@ export function AiUsagePage() {
             undefined, undefined,
             filterActionType || undefined,
             filterDateFrom || undefined,
-            filterDateTo || undefined
+            filterDateTo || undefined,
+            undefined,
+            filterEngine || undefined,
+            filterModel || undefined
         )
             .then((results) => {
                 setRecords(results.items);
@@ -75,7 +82,8 @@ export function AiUsagePage() {
             })
             .catch(console.error)
             .finally(() => setLoading(false));
-    }, [page, perPage, filterInvocationType, filterActionType, filterDateFrom, filterDateTo]);
+    }, [page, perPage, filterInvocationType, filterActionType, filterDateFrom, filterDateTo,
+        filterEngine, filterModel]);
 
     useEffect(() => { loadData(); }, [loadData]);
 
@@ -226,6 +234,8 @@ export function AiUsagePage() {
                                 <Th>Time</Th>
                                 <Th>Type</Th>
                                 <Th>Action</Th>
+                                <Th>Engine</Th>
+                                <Th>Model</Th>
                                 <Th>Project</Th>
                                 <Th>Cost</Th>
                                 <Th>Input Tokens</Th>
@@ -250,6 +260,23 @@ export function AiUsagePage() {
                                         </Label>
                                     </Td>
                                     <Td>{r.actionType || "—"}</Td>
+                                    <Td>
+                                        {r.engine ? (
+                                            <Label isCompact color="purple"
+                                                style={{ cursor: "pointer" }}
+                                                onClick={() => {
+                                                    const engineFilter = FILTER_TYPES.find(
+                                                        (t) => t.value === "engine")!;
+                                                    onAddFilterCriteria({
+                                                        filterBy: engineFilter,
+                                                        filterValue: r.engine!,
+                                                    });
+                                                }}>
+                                                {r.engine}
+                                            </Label>
+                                        ) : "—"}
+                                    </Td>
+                                    <Td>{r.model || "—"}</Td>
                                     <Td>
                                         {r.projectId ? `Project #${r.projectId}` : "—"}
                                     </Td>


### PR DESCRIPTION
## Summary

- Adds `engine` column to the `ai_usage` table (V52 migration) and populates the
  existing (but previously unused) `model` column across all 8 AI usage recording sites
- Adds `filterEngine` and `filterModel` query parameters to the `GET /usage/ai` endpoint
- Adds Engine and Model columns to the AI Usage page with chip-based filter dropdowns,
  matching the existing Type and Action Type filter pattern

## Details

**Recording sites updated:**
- TaskExecutionService — resolves engine/model from ActionTypeEntity
- ManagerService — uses `axiom.manager.engine` / `axiom.manager.model` config
- ReportExecutionService — uses per-definition engine/model
- ScriptAiService, ToolAiService, ActionTypeAiService — use `axiom.helper-services.engine`
- AssistantSessionManager — uses default agent type
- ScheduledJobExecutionService — uses per-job engine/model

All sites fall back to the default agent type when no explicit engine is configured.

## Test plan

- [ ] Verify the V52 migration runs cleanly on startup
- [ ] Trigger AI invocations (task, manager evaluation, report, assistant session)
  and confirm engine/model are populated in the `ai_usage` table
- [ ] Visit `/metrics/ai-usage` and verify Engine and Model columns appear with data
- [ ] Click an engine label to filter — confirm the chip filter is applied and results
  are filtered correctly
- [ ] Use the Engine and Model filter dropdowns from the toolbar
- [ ] Confirm existing records with null engine/model display as "—"
- [ ] Confirm summary cards still show correct aggregates when filters are applied