### PR TITLE
feat: track actual AI model used in usage records

### DIFF
--- a/agents/claude-code/src/main/java/io/apitomy/axiom/agents/claudecode/ClaudeCodeAgent.java
+++ b/agents/claude-code/src/main/java/io/apitomy/axiom/agents/claudecode/ClaudeCodeAgent.java
@@ -189,9 +189,12 @@ public class ClaudeCodeAgent implements Agent {
                 .maxTurns(maxSteps)
                 .maxBudgetUsd(maxBudget);
 
+        String resolvedModel;
         if (request.getModel() != null && !request.getModel().isBlank()) {
-            cmdBuilder.model(request.getModel());
+            resolvedModel = request.getModel();
+            cmdBuilder.model(resolvedModel);
         } else {
+            resolvedModel = defaultModel.orElse(null);
             defaultModel.ifPresent(cmdBuilder::model);
         }
 
@@ -225,7 +228,7 @@ public class ClaudeCodeAgent implements Agent {
                     if (request.getExecutionId() != null) {
                         runningProcesses.remove(request.getExecutionId());
                     }
-                    return toAgentResult(result);
+                    return toAgentResult(result, resolvedModel);
                 })
                 .exceptionally(throwable -> {
                     if (request.getExecutionId() != null) {
@@ -236,7 +239,8 @@ public class ClaudeCodeAgent implements Agent {
                 });
     }
 
-    private static AgentResult toAgentResult(ClaudeCodeResult result) {
+    private AgentResult toAgentResult(ClaudeCodeResult result, String resolvedModel) {
+        String actualModel = result.model() != null ? result.model() : resolvedModel;
         return new AgentResult(
                 result.isSuccess(),
                 result.result(),
@@ -245,7 +249,9 @@ public class ClaudeCodeAgent implements Agent {
                 result.sessionId(),
                 result.totalCostUsd(),
                 result.inputTokens(),
-                result.outputTokens()
+                result.outputTokens(),
+                getType(),
+                actualModel
         );
     }
 }

--- a/agents/claude-code/src/main/java/io/apitomy/axiom/agents/claudecode/ClaudeCodeResult.java
+++ b/agents/claude-code/src/main/java/io/apitomy/axiom/agents/claudecode/ClaudeCodeResult.java
@@ -20,7 +20,8 @@ public record ClaudeCodeResult(
         Long inputTokens,
         Long outputTokens,
         int exitCode,
-        String executionLog
+        String executionLog,
+        String model
 ) {
 
     /**
@@ -31,7 +32,7 @@ public record ClaudeCodeResult(
      * @return a failed result
      */
     public static ClaudeCodeResult failed(String errorMessage, int exitCode) {
-        return new ClaudeCodeResult(errorMessage, null, null, null, null, exitCode, null);
+        return new ClaudeCodeResult(errorMessage, null, null, null, null, exitCode, null, null);
     }
 
     /**

--- a/agents/claude-code/src/main/java/io/apitomy/axiom/agents/claudecode/ClaudeCodeSubprocess.java
+++ b/agents/claude-code/src/main/java/io/apitomy/axiom/agents/claudecode/ClaudeCodeSubprocess.java
@@ -41,6 +41,7 @@ public class ClaudeCodeSubprocess {
     private volatile Long streamInputTokens;
     private volatile Long streamOutputTokens;
     private volatile String streamSessionId;
+    private volatile String streamModel;
 
     /**
      * Creates a new subprocess wrapper.
@@ -162,7 +163,7 @@ public class ClaudeCodeSubprocess {
             logBuilder.footer("Timed Out", null, null, null,
                     Duration.between(startTime, Instant.now()));
             return new ClaudeCodeResult("Process timed out after " + timeout,
-                    null, null, null, null, 124, logBuilder.build());
+                    null, null, null, null, 124, logBuilder.build(), streamModel);
         }
 
         destroyProcessTree();
@@ -181,7 +182,7 @@ public class ClaudeCodeSubprocess {
             logBuilder.footer("Failed (exit " + exitCode + ")", null, null, null,
                     Duration.between(startTime, Instant.now()));
             return new ClaudeCodeResult(error, null, null, null, null,
-                    exitCode, logBuilder.build());
+                    exitCode, logBuilder.build(), streamModel);
         }
 
         ClaudeCodeResult result = parseResult(lastResultLine.toString(), exitCode);
@@ -197,7 +198,7 @@ public class ClaudeCodeSubprocess {
                 Duration.between(startTime, Instant.now()));
         return new ClaudeCodeResult(finalResult, finalSessionId,
                 finalCostUsd, finalInputTokens, finalOutputTokens,
-                result.exitCode(), logBuilder.build());
+                result.exitCode(), logBuilder.build(), streamModel);
     }
 
     private ClaudeCodeResult parseResult(String jsonLine, int exitCode) {
@@ -235,11 +236,11 @@ public class ClaudeCodeSubprocess {
             }
 
             return new ClaudeCodeResult(result, sessionId, costUsd, inputTokens,
-                    outputTokens, exitCode, null);
+                    outputTokens, exitCode, null, null);
         } catch (Exception e) {
             LOG.warnf(e, "Failed to parse Claude Code output as JSON: %s",
                     jsonLine.substring(0, Math.min(jsonLine.length(), 200)));
-            return new ClaudeCodeResult(jsonLine, null, null, null, null, exitCode, null);
+            return new ClaudeCodeResult(jsonLine, null, null, null, null, exitCode, null, null);
         }
     }
 
@@ -347,6 +348,16 @@ public class ClaudeCodeSubprocess {
                     } else {
                         LOG.tracef("  [claude] Tool completed: %s", toolName);
                         logBuilder.toolResult(toolName, false, null);
+                    }
+                }
+                case "system" -> {
+                    String subtype = node.path("subtype").asText("");
+                    if ("init".equals(subtype)) {
+                        String model = node.path("model").asText(null);
+                        if (model != null && !model.isBlank()) {
+                            streamModel = model;
+                            LOG.tracef("  [claude] Model: %s", model);
+                        }
                     }
                 }
                 default -> LOG.tracef("  [claude] Stream event type: %s", type);

--- a/agents/copilot/src/main/java/io/apitomy/axiom/agents/copilot/CopilotAgent.java
+++ b/agents/copilot/src/main/java/io/apitomy/axiom/agents/copilot/CopilotAgent.java
@@ -218,9 +218,12 @@ public class CopilotAgent implements Agent {
                 .executable(executable);
 
         // Per-request model takes priority over the global default
+        String resolvedModel;
         if (request.getModel() != null && !request.getModel().isBlank()) {
-            cmdBuilder.model(request.getModel());
+            resolvedModel = request.getModel();
+            cmdBuilder.model(resolvedModel);
         } else {
+            resolvedModel = model.orElse(null);
             model.ifPresent(cmdBuilder::model);
         }
 
@@ -254,7 +257,7 @@ public class CopilotAgent implements Agent {
                     if (executionId != null) {
                         runningProcesses.remove(executionId);
                     }
-                    return toAgentResult(result);
+                    return toAgentResult(result, resolvedModel);
                 })
                 .exceptionally(throwable -> {
                     if (executionId != null) {
@@ -269,7 +272,8 @@ public class CopilotAgent implements Agent {
     /**
      * Converts a Copilot-specific result into the unified {@link AgentResult}.
      */
-    private static AgentResult toAgentResult(CopilotResult result) {
+    private AgentResult toAgentResult(CopilotResult result, String resolvedModel) {
+        String actualModel = result.model() != null ? result.model() : resolvedModel;
         return new AgentResult(
                 result.isSuccess(),
                 result.result(),
@@ -278,7 +282,9 @@ public class CopilotAgent implements Agent {
                 result.sessionId(),
                 result.costUsd(),
                 result.inputTokens(),
-                result.outputTokens()
+                result.outputTokens(),
+                getType(),
+                actualModel
         );
     }
 }

--- a/agents/copilot/src/main/java/io/apitomy/axiom/agents/copilot/CopilotResult.java
+++ b/agents/copilot/src/main/java/io/apitomy/axiom/agents/copilot/CopilotResult.java
@@ -19,7 +19,8 @@ public record CopilotResult(
         Long inputTokens,
         Long outputTokens,
         int exitCode,
-        String executionLog
+        String executionLog,
+        String model
 ) {
 
     /**
@@ -30,7 +31,7 @@ public record CopilotResult(
      * @return a failed result
      */
     public static CopilotResult failed(String errorMessage, int exitCode) {
-        return new CopilotResult(errorMessage, null, null, null, null, exitCode, null);
+        return new CopilotResult(errorMessage, null, null, null, null, exitCode, null, null);
     }
 
     /**

--- a/agents/copilot/src/main/java/io/apitomy/axiom/agents/copilot/CopilotSubprocess.java
+++ b/agents/copilot/src/main/java/io/apitomy/axiom/agents/copilot/CopilotSubprocess.java
@@ -44,6 +44,7 @@ public class CopilotSubprocess {
     private volatile String resultSessionId;
     private volatile int resultExitCode = -1;
     private volatile boolean sawResultEvent;
+    private volatile String streamModel;
 
     private final StringBuilder log = new StringBuilder();
 
@@ -145,7 +146,7 @@ public class CopilotSubprocess {
             destroyProcessTree();
             log.append("\n=== Timed Out ===\n");
             return new CopilotResult("Process timed out after " + timeout,
-                    null, null, null, null, 124, log.toString());
+                    null, null, null, null, 124, log.toString(), streamModel);
         }
 
         destroyProcessTree();
@@ -166,7 +167,7 @@ public class CopilotSubprocess {
             }
             log.append("\n=== Failed (exit ").append(exitCode).append(") ===\n");
             return new CopilotResult(error, resultSessionId, null, null, lastOutputTokens,
-                    exitCode, log.toString());
+                    exitCode, log.toString(), streamModel);
         }
 
         String result = lastAssistantMessage != null ? lastAssistantMessage : "";
@@ -179,7 +180,7 @@ public class CopilotSubprocess {
                 .append("\nDuration: ").append(duration.toSeconds()).append("s\n");
 
         return new CopilotResult(result, resultSessionId, null, null, lastOutputTokens,
-                finalExitCode, log.toString());
+                finalExitCode, log.toString(), streamModel);
     }
 
     /**
@@ -230,6 +231,14 @@ public class CopilotSubprocess {
                     String message = node.path("data").path("message").asText(null);
                     if (message != null) {
                         LOG.tracef("  [copilot] Info: %s", message);
+                    }
+                }
+                case "assistant.usage" -> {
+                    JsonNode data = node.path("data");
+                    String model = data.path("model").asText(null);
+                    if (model != null && !model.isBlank()) {
+                        streamModel = model;
+                        LOG.tracef("  [copilot] Model: %s", model);
                     }
                 }
                 default -> LOG.tracef("  [copilot] Stream event type: %s", type);

--- a/agents/opencode/src/main/java/io/apitomy/axiom/agents/opencode/OpenCodeAgent.java
+++ b/agents/opencode/src/main/java/io/apitomy/axiom/agents/opencode/OpenCodeAgent.java
@@ -237,7 +237,7 @@ public class OpenCodeAgent implements Agent {
                 }
 
                 // Parse response
-                return parseResponse(response, sessionId);
+                return parseResponse(response, sessionId, model);
 
             } catch (Exception e) {
                 if (request.getExecutionId() != null) {
@@ -273,7 +273,8 @@ public class OpenCodeAgent implements Agent {
      * }
      * </pre>
      */
-    private AgentResult parseResponse(JsonNode response, String sessionId) {
+    private AgentResult parseResponse(JsonNode response, String sessionId,
+                                      String resolvedModel) {
         try {
             // Extract text from parts
             StringBuilder resultText = new StringBuilder();
@@ -321,13 +322,18 @@ public class OpenCodeAgent implements Agent {
                 }
             }
 
+            String actualModel = info.path("modelID").asText(null);
+            if (actualModel == null || actualModel.isBlank()) {
+                actualModel = resolvedModel;
+            }
+
             return new AgentResult(true, result, null, null, sessionId,
-                    costUsd, inputTokens, outputTokens);
+                    costUsd, inputTokens, outputTokens, getType(), actualModel);
 
         } catch (Exception e) {
             LOG.warnf(e, "Failed to parse OpenCode response");
             return new AgentResult(true, response.toString(), null, null, sessionId,
-                    null, null, null);
+                    null, null, null, getType(), resolvedModel);
         }
     }
 

--- a/agents/spi/src/main/java/io/apitomy/axiom/agents/spi/AgentResult.java
+++ b/agents/spi/src/main/java/io/apitomy/axiom/agents/spi/AgentResult.java
@@ -13,6 +13,8 @@ package io.apitomy.axiom.agents.spi;
  * @param costUsd      cost in USD, or null if not tracked
  * @param inputTokens  number of input tokens consumed, or null if not tracked
  * @param outputTokens number of output tokens produced, or null if not tracked
+ * @param engine       the agent engine type that handled the invocation (e.g. "claude-code"), or null
+ * @param model        the AI model that was actually used (e.g. "claude-sonnet-4-6"), or null
  */
 public record AgentResult(
         boolean success,
@@ -22,7 +24,9 @@ public record AgentResult(
         String sessionId,
         Double costUsd,
         Long inputTokens,
-        Long outputTokens
+        Long outputTokens,
+        String engine,
+        String model
 ) {
 
     /**
@@ -32,7 +36,7 @@ public record AgentResult(
      * @return a successful AgentResult
      */
     public static AgentResult success(String output) {
-        return new AgentResult(true, output, null, null, null, null, null, null);
+        return new AgentResult(true, output, null, null, null, null, null, null, null, null);
     }
 
     /**
@@ -42,6 +46,6 @@ public record AgentResult(
      * @return a failed AgentResult
      */
     public static AgentResult failure(String errorMessage) {
-        return new AgentResult(false, null, errorMessage, null, null, null, null, null);
+        return new AgentResult(false, null, errorMessage, null, null, null, null, null, null, null);
     }
 }

--- a/app/src/main/java/io/apitomy/axiom/app/ActionTypeAiService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ActionTypeAiService.java
@@ -138,7 +138,8 @@ public class ActionTypeAiService {
             AgentResult result = agentRegistry.getAgent(helperEngine.orElse(null))
                     .executeWithSchema(agentRequest, RESPONSE_SCHEMA).join();
 
-            recordAiUsage(result.costUsd(), result.inputTokens(), result.outputTokens());
+            recordAiUsage(result.costUsd(), result.inputTokens(), result.outputTokens(),
+                    result.engine(), result.model());
 
             if (!result.success()) {
                 LOG.errorf("Action type AI edit failed: %s", result.output());
@@ -193,11 +194,15 @@ public class ActionTypeAiService {
     }
 
     @Transactional
-    void recordAiUsage(Double costUsd, Long inputTokens, Long outputTokens) {
+    void recordAiUsage(Double costUsd, Long inputTokens, Long outputTokens,
+                        String resultEngine, String resultModel) {
         AiUsageEntity usage = new AiUsageEntity();
         usage.invocationType = "action-type-edit";
         usage.actionType = "action-type-ai-edit";
-        usage.engine = helperEngine.orElse(agentRegistry.getDefaultAgentType());
+        usage.engine = resultEngine != null && !resultEngine.isBlank()
+                ? resultEngine : helperEngine.orElse(agentRegistry.getDefaultAgentType());
+        usage.model = resultModel != null && !resultModel.isBlank()
+                ? resultModel : null;
         usage.costUsd = costUsd;
         usage.inputTokens = inputTokens;
         usage.outputTokens = outputTokens;

--- a/app/src/main/java/io/apitomy/axiom/app/ReportAiService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ReportAiService.java
@@ -151,7 +151,8 @@ public class ReportAiService {
         try {
             ClaudeCodeResult result = subprocess.execute().join();
 
-            recordAiUsage(result.totalCostUsd(), result.inputTokens(), result.outputTokens());
+            recordAiUsage(result.totalCostUsd(), result.inputTokens(), result.outputTokens(),
+                    result.model());
 
             if (!result.isSuccess()) {
                 LOG.errorf("Report AI edit failed (exit %d): %s",
@@ -207,10 +208,13 @@ public class ReportAiService {
     }
 
     @Transactional
-    void recordAiUsage(Double costUsd, Long inputTokens, Long outputTokens) {
+    void recordAiUsage(Double costUsd, Long inputTokens, Long outputTokens,
+                        String streamModel) {
         AiUsageEntity usage = new AiUsageEntity();
         usage.invocationType = "report-edit";
         usage.actionType = "report-ai-edit";
+        usage.engine = "claude-code";
+        usage.model = streamModel != null ? streamModel : model.orElse(null);
         usage.costUsd = costUsd;
         usage.inputTokens = inputTokens;
         usage.outputTokens = outputTokens;

--- a/app/src/main/java/io/apitomy/axiom/app/ReportExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ReportExecutionService.java
@@ -295,14 +295,18 @@ public class ReportExecutionService {
                 reportId, report.status,
                 result.costUsd() != null ? String.format("%.4f", result.costUsd()) : "n/a");
 
-        // Record AI usage
+        // Record AI usage (prefer engine/model from the agent result, fall back to definition config)
         AiUsageEntity usage = new AiUsageEntity();
         usage.invocationType = "report";
         usage.actionType = "generate-report";
-        String reportEngine = def != null ? def.engine : null;
+        String reportEngine = result.engine();
+        if (reportEngine == null || reportEngine.isBlank()) {
+            reportEngine = def != null ? def.engine : null;
+        }
         usage.engine = reportEngine != null && !reportEngine.isBlank()
                 ? reportEngine : agentRegistry.getDefaultAgentType();
-        usage.model = def != null ? def.model : null;
+        usage.model = result.model() != null && !result.model().isBlank()
+                ? result.model() : (def != null ? def.model : null);
         usage.costUsd = result.costUsd();
         usage.inputTokens = result.inputTokens();
         usage.outputTokens = result.outputTokens();

--- a/app/src/main/java/io/apitomy/axiom/app/ScheduledJobExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ScheduledJobExecutionService.java
@@ -310,13 +310,18 @@ public class ScheduledJobExecutionService {
                 runId, run.status,
                 result.costUsd() != null ? String.format("%.4f", result.costUsd()) : "n/a");
 
+        // Record AI usage (prefer engine/model from the agent result, fall back to job config)
         AiUsageEntity usage = new AiUsageEntity();
         usage.invocationType = "scheduled-job";
         usage.actionType = job != null ? job.name : "unknown";
-        String jobEngine = job != null ? job.engine : null;
+        String jobEngine = result.engine();
+        if (jobEngine == null || jobEngine.isBlank()) {
+            jobEngine = job != null ? job.engine : null;
+        }
         usage.engine = jobEngine != null && !jobEngine.isBlank()
                 ? jobEngine : agentRegistry.getDefaultAgentType();
-        usage.model = job != null ? job.model : null;
+        usage.model = result.model() != null && !result.model().isBlank()
+                ? result.model() : (job != null ? job.model : null);
         usage.costUsd = result.costUsd();
         usage.inputTokens = result.inputTokens();
         usage.outputTokens = result.outputTokens();

--- a/app/src/main/java/io/apitomy/axiom/app/ScriptAiService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ScriptAiService.java
@@ -129,7 +129,8 @@ public class ScriptAiService {
             AgentResult result = agentRegistry.getAgent(helperEngine.orElse(null))
                     .executeWithSchema(agentRequest, RESPONSE_SCHEMA).join();
 
-            recordAiUsage(result.costUsd(), result.inputTokens(), result.outputTokens());
+            recordAiUsage(result.costUsd(), result.inputTokens(), result.outputTokens(),
+                    result.engine(), result.model());
 
             if (!result.success()) {
                 LOG.errorf("Script AI edit failed: %s", result.output());
@@ -168,12 +169,15 @@ public class ScriptAiService {
     }
 
     @Transactional
-    void recordAiUsage(Double costUsd, Long inputTokens, Long outputTokens) {
+    void recordAiUsage(Double costUsd, Long inputTokens, Long outputTokens,
+                        String resultEngine, String resultModel) {
         AiUsageEntity usage = new AiUsageEntity();
         usage.invocationType = "script-edit";
         usage.actionType = "script-ai-edit";
-        usage.engine = helperEngine.orElse(agentRegistry.getDefaultAgentType());
-        usage.model = model.orElse(null);
+        usage.engine = resultEngine != null && !resultEngine.isBlank()
+                ? resultEngine : helperEngine.orElse(agentRegistry.getDefaultAgentType());
+        usage.model = resultModel != null && !resultModel.isBlank()
+                ? resultModel : model.orElse(null);
         usage.costUsd = costUsd;
         usage.inputTokens = inputTokens;
         usage.outputTokens = outputTokens;

--- a/app/src/main/java/io/apitomy/axiom/app/TaskExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/TaskExecutionService.java
@@ -379,12 +379,18 @@ public class TaskExecutionService {
                 result.inputTokens() != null ? result.inputTokens() : 0,
                 result.outputTokens() != null ? result.outputTokens() : 0);
 
-        // Record AI usage (resolve engine/model from the action type definition)
+        // Record AI usage (prefer engine/model from the agent result, fall back to action type config)
         ActionTypeEntity actionTypeEntity = ActionTypeEntity.find("name", task.actionType).firstResult();
-        String engine = actionTypeEntity != null ? actionTypeEntity.engine : null;
-        String model = actionTypeEntity != null ? actionTypeEntity.model : null;
+        String engine = result.engine();
+        if (engine == null || engine.isBlank()) {
+            engine = actionTypeEntity != null ? actionTypeEntity.engine : null;
+        }
         if (engine == null || engine.isBlank()) {
             engine = agentRegistry.getDefaultAgentType();
+        }
+        String model = result.model();
+        if (model == null || model.isBlank()) {
+            model = actionTypeEntity != null ? actionTypeEntity.model : null;
         }
         recordAiUsage("task", taskId, task.eventId, task.projectId,
                 task.assignedAgent, task.actionType, engine, model,

--- a/app/src/main/java/io/apitomy/axiom/app/ToolAiService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ToolAiService.java
@@ -134,7 +134,8 @@ public class ToolAiService {
                     .executeWithSchema(agentRequest, RESPONSE_SCHEMA).join();
 
             // Record AI usage
-            recordAiUsage(result.costUsd(), result.inputTokens(), result.outputTokens());
+            recordAiUsage(result.costUsd(), result.inputTokens(), result.outputTokens(),
+                    result.engine(), result.model());
 
             if (!result.success()) {
                 LOG.errorf("Tool AI edit failed: %s", result.output());
@@ -198,12 +199,15 @@ public class ToolAiService {
     }
 
     @Transactional
-    void recordAiUsage(Double costUsd, Long inputTokens, Long outputTokens) {
+    void recordAiUsage(Double costUsd, Long inputTokens, Long outputTokens,
+                        String resultEngine, String resultModel) {
         AiUsageEntity usage = new AiUsageEntity();
         usage.invocationType = "tool-edit";
         usage.actionType = "tool-ai-edit";
-        usage.engine = helperEngine.orElse(agentRegistry.getDefaultAgentType());
-        usage.model = model.orElse(null);
+        usage.engine = resultEngine != null && !resultEngine.isBlank()
+                ? resultEngine : helperEngine.orElse(agentRegistry.getDefaultAgentType());
+        usage.model = resultModel != null && !resultModel.isBlank()
+                ? resultModel : model.orElse(null);
         usage.costUsd = costUsd;
         usage.inputTokens = inputTokens;
         usage.outputTokens = outputTokens;

--- a/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSessionManager.java
+++ b/app/src/main/java/io/apitomy/axiom/app/assistant/AssistantSessionManager.java
@@ -371,6 +371,11 @@ public class AssistantSessionManager {
         usage.invocationType = "assistant-session";
         usage.actionType = "assistant-session";
         usage.engine = agentRegistry.getDefaultAgentType();
+        SessionTemplateService.SessionTemplate template =
+                templateService.getTemplate(session.getTemplateId());
+        if (template != null && template.model() != null && !template.model().isBlank()) {
+            usage.model = template.model();
+        }
         usage.costUsd = session.getTotalCostUsd();
         usage.inputTokens = session.getTotalInputTokens();
         usage.outputTokens = session.getTotalOutputTokens();

--- a/manager/src/main/java/io/apitomy/axiom/manager/ManagerService.java
+++ b/manager/src/main/java/io/apitomy/axiom/manager/ManagerService.java
@@ -157,7 +157,8 @@ public class ManagerService {
             // Record AI usage for this Manager evaluation
             try {
                 recordAiUsage(event.id, ctx.project() != null ? ctx.project().id : null,
-                        result.costUsd(), result.inputTokens(), result.outputTokens());
+                        result.costUsd(), result.inputTokens(), result.outputTokens(),
+                        result.engine(), result.model());
             } catch (Exception e) {
                 LOG.warnf(e, "Failed to record AI usage for event %d", event.id);
             }
@@ -341,9 +342,12 @@ public class ManagerService {
     }
 
     void recordAiUsage(Long eventId, Long projectId,
-                        Double costUsd, Long inputTokens, Long outputTokens) {
-        String resolvedEngine = managerEngine.orElse(agentRegistry.getDefaultAgentType());
-        String resolvedModel = model.orElse(null);
+                        Double costUsd, Long inputTokens, Long outputTokens,
+                        String resultEngine, String resultModel) {
+        String resolvedEngine = resultEngine != null && !resultEngine.isBlank()
+                ? resultEngine : managerEngine.orElse(agentRegistry.getDefaultAgentType());
+        String resolvedModel = resultModel != null && !resultModel.isBlank()
+                ? resultModel : model.orElse(null);
         QuarkusTransaction.requiringNew().run(() -> {
             AiUsageEntity usage = new AiUsageEntity();
             usage.invocationType = "manager";


### PR DESCRIPTION
## Summary

- Added `engine` and `model` fields to `AgentResult` so agents can report what they actually used
- Each agent implementation now extracts the **actual model** from its runtime output:
  - **Claude Code**: captured from the `system/init` NDJSON event's `model` field
  - **OpenCode**: read from the `modelID` field in the API response's `info` object
  - **Copilot**: captured from the `assistant.usage` NDJSON event's `model` field
- Updated all 9 AI usage recording sites to prefer the agent-reported engine/model, falling back
  to entity config or registry defaults
- Previously, the Model column in `/metrics/ai-usage` was null whenever no model was explicitly
  configured for the workload — now it reflects the model that was actually used

### Resolution priority

stream/API-reported model > requested model (entity config or agent default) > null

### Files changed (17)

**SPI**: `AgentResult` — new `engine` and `model` record fields

**Agent internals**: `ClaudeCodeSubprocess`, `ClaudeCodeResult`, `CopilotSubprocess`,
`CopilotResult` — capture and propagate model from CLI output stream

**Agent implementations**: `ClaudeCodeAgent`, `OpenCodeAgent`, `CopilotAgent` — populate
engine/model on `AgentResult`, preferring stream-reported model over resolved config model

**Recording sites**: `TaskExecutionService`, `ManagerService`, `ReportExecutionService`,
`ScheduledJobExecutionService`, `AssistantSessionManager`, `ActionTypeAiService`,
`ScriptAiService`, `ToolAiService`, `ReportAiService` — use engine/model from result

## Test plan

- [ ] Run a task with no model configured on the action type — verify the Model column in
  AI Usage shows the actual model used (e.g. `claude-sonnet-4-20250514`)
- [ ] Run a task with an explicit model configured — verify it still records correctly
- [ ] Verify manager evaluations record the model
- [ ] Verify report generation records the model
- [ ] Verify assistant sessions record the template's model