### PR TITLE
feat: workflow execution observability

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>io.apitomy</groupId>
             <artifactId>apitomy-flow-engine</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.2</version>
         </dependency>
 
         <!-- Quarkus -->

--- a/app/src/main/java/io/apitomy/axiom/app/TaskExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/TaskExecutionService.java
@@ -451,7 +451,11 @@ public class TaskExecutionService {
                     traceService.completeNode(taskNode.id, statusText);
                 }
 
-                traceService.completeTrace(task.traceId, result.success() ? "completed" : "failed");
+                // Workflow runs own their trace lifecycle: WorkflowExecutionService
+                // completes the trace when the run reaches a terminal state.
+                if (task.workflowRunId == null) {
+                    traceService.completeTrace(task.traceId, result.success() ? "completed" : "failed");
+                }
             } catch (Exception e) {
                 LOG.warnf(e, "Failed to complete trace for task %d", task.id);
             }

--- a/app/src/main/java/io/apitomy/axiom/app/TaskExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/TaskExecutionService.java
@@ -467,7 +467,7 @@ public class TaskExecutionService {
         emitInternalEventIfNeeded(task);
 
         // Advance workflow if this task is part of one
-        if (task.workflowInstanceId != null) {
+        if (task.workflowRunId != null) {
             workflowExecutionService.onTaskCompleted(task.id);
         }
     }
@@ -489,7 +489,7 @@ public class TaskExecutionService {
             updateProjectStatusAfterTask(task.projectId);
 
             // Advance workflow if this task is part of one
-            if (task.workflowInstanceId != null) {
+            if (task.workflowRunId != null) {
                 workflowExecutionService.onTaskCompleted(task.id);
             }
         }

--- a/app/src/main/java/io/apitomy/axiom/app/WorkflowExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/WorkflowExecutionService.java
@@ -164,7 +164,8 @@ public class WorkflowExecutionService {
 
         logActivity(projectId, "workflow-started",
                 "Workflow started: " + definition.name);
-        sseEvents.fire(SseEvent.workflowUpdated(projectId));
+        sseEvents.fire(SseEvent.workflowUpdated(
+                entity.projectId, entity.id, entity.status));
 
         return entity;
     }
@@ -220,7 +221,8 @@ public class WorkflowExecutionService {
                     "Workflow failed for project", "error"));
         }
 
-        sseEvents.fire(SseEvent.workflowUpdated(entity.projectId));
+        sseEvents.fire(SseEvent.workflowUpdated(
+                entity.projectId, entity.id, entity.status));
     }
 
     /**
@@ -264,7 +266,8 @@ public class WorkflowExecutionService {
         }
 
         logActivity(projectId, "workflow-cancelled", "Workflow cancelled");
-        sseEvents.fire(SseEvent.workflowUpdated(projectId));
+        sseEvents.fire(SseEvent.workflowUpdated(
+                entity.projectId, entity.id, entity.status));
     }
 
     // -- Private helpers --

--- a/app/src/main/java/io/apitomy/axiom/app/WorkflowExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/WorkflowExecutionService.java
@@ -208,10 +208,12 @@ public class WorkflowExecutionService {
             createTaskForCurrentNode(entity, workflow, advanced);
         } else if (advanced.status() == InstanceStatus.COMPLETED) {
             entity.completedOn = Instant.now();
+            completeRunTrace(entity, "completed");
             logActivity(entity.projectId, "workflow-completed",
                     "Workflow completed");
         } else if (advanced.status() == InstanceStatus.FAILED) {
             entity.completedOn = Instant.now();
+            completeRunTrace(entity, "failed");
             logActivity(entity.projectId, "workflow-failed",
                     "Workflow failed: " + advanced.failureReason());
             sseEvents.fire(SseEvent.notification(
@@ -248,6 +250,7 @@ public class WorkflowExecutionService {
 
         persistInstanceState(entity, cancelled);
         entity.completedOn = Instant.now();
+        completeRunTrace(entity, "cancelled");
 
         TaskEntity activeTask = TaskEntity
                 .find("workflowRunId = ?1 and status in ?2",
@@ -282,6 +285,18 @@ public class WorkflowExecutionService {
             return null;
         }
         return new TraceContext(run.traceId, root.id);
+    }
+
+    /** Best-effort completion of a run's execution trace. */
+    private void completeRunTrace(WorkflowRunEntity run, String status) {
+        if (run.traceId == null) {
+            return;
+        }
+        try {
+            traceService.completeTrace(run.traceId, status);
+        } catch (Exception e) {
+            LOG.warnf(e, "Failed to complete trace for workflow run %d", run.id);
+        }
     }
 
     private void createTaskForCurrentNode(WorkflowRunEntity entity,

--- a/app/src/main/java/io/apitomy/axiom/app/WorkflowExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/WorkflowExecutionService.java
@@ -6,7 +6,7 @@ import io.apitomy.axiom.core.entities.ProjectEntity;
 import io.apitomy.axiom.core.entities.TaskEntity;
 import io.apitomy.axiom.core.entities.WorkflowDefinitionEntity;
 import io.apitomy.axiom.core.entities.WorkflowDefinitionVersionEntity;
-import io.apitomy.axiom.core.entities.WorkflowInstanceEntity;
+import io.apitomy.axiom.core.entities.WorkflowRunEntity;
 import io.apitomy.axiom.core.entities.ActivityLogEntity;
 import io.apitomy.axiom.core.events.SseEvent;
 import io.apitomy.flow.engine.WorkflowEngine;
@@ -72,13 +72,13 @@ public class WorkflowExecutionService {
      * Triggers a workflow on a project.
      */
     @Transactional
-    public WorkflowInstanceEntity triggerWorkflow(long projectId, long definitionId) {
+    public WorkflowRunEntity triggerWorkflow(long projectId, long definitionId) {
         ProjectEntity project = ProjectEntity.findById(projectId);
         if (project == null) {
             throw new WebApplicationException("Project not found", 404);
         }
 
-        WorkflowInstanceEntity existing = WorkflowInstanceEntity
+        WorkflowRunEntity existing = WorkflowRunEntity
                 .find("projectId", projectId).firstResult();
         if (existing != null) {
             throw new WebApplicationException(
@@ -131,7 +131,7 @@ public class WorkflowExecutionService {
                             .build());
         }
 
-        WorkflowInstanceEntity entity = new WorkflowInstanceEntity();
+        WorkflowRunEntity entity = new WorkflowRunEntity();
         entity.projectId = projectId;
         entity.definitionId = definitionId;
         entity.definitionVersion = definition.currentVersion;
@@ -156,15 +156,15 @@ public class WorkflowExecutionService {
     @Transactional
     public void onTaskCompleted(long taskId) {
         TaskEntity task = TaskEntity.findById(taskId);
-        if (task == null || task.workflowInstanceId == null) {
+        if (task == null || task.workflowRunId == null) {
             return;
         }
 
-        WorkflowInstanceEntity entity =
-                WorkflowInstanceEntity.findById(task.workflowInstanceId);
+        WorkflowRunEntity entity =
+                WorkflowRunEntity.findById(task.workflowRunId);
         if (entity == null) {
             LOG.warnf("Workflow instance %d not found for task %d",
-                    task.workflowInstanceId, taskId);
+                    task.workflowRunId, taskId);
             return;
         }
 
@@ -207,7 +207,7 @@ public class WorkflowExecutionService {
      */
     @Transactional
     public void cancelWorkflow(long projectId) {
-        WorkflowInstanceEntity entity = WorkflowInstanceEntity
+        WorkflowRunEntity entity = WorkflowRunEntity
                 .find("projectId", projectId).firstResult();
         if (entity == null) {
             throw new WebApplicationException("No workflow instance found", 404);
@@ -231,7 +231,7 @@ public class WorkflowExecutionService {
         entity.completedOn = Instant.now();
 
         TaskEntity activeTask = TaskEntity
-                .find("workflowInstanceId = ?1 and status in ?2",
+                .find("workflowRunId = ?1 and status in ?2",
                         entity.id,
                         List.of("Pending", "InProgress"))
                 .firstResult();
@@ -247,7 +247,7 @@ public class WorkflowExecutionService {
 
     // -- Private helpers --
 
-    private void createTaskForCurrentNode(WorkflowInstanceEntity entity,
+    private void createTaskForCurrentNode(WorkflowRunEntity entity,
             Workflow workflow, WorkflowInstance instance) {
         ActionInfo actionInfo = workflowEngine.getActionInfo(
                 workflow, instance);
@@ -263,7 +263,7 @@ public class WorkflowExecutionService {
         task.createdBy = "workflow";
         task.status = "Pending";
         task.input = serializeInputs(actionInfo);
-        task.workflowInstanceId = entity.id;
+        task.workflowRunId = entity.id;
         task.createdOn = Instant.now();
         task.persist();
 
@@ -274,7 +274,7 @@ public class WorkflowExecutionService {
                 entity.projectId, task.id, task.status));
     }
 
-    private void persistInstanceState(WorkflowInstanceEntity entity,
+    private void persistInstanceState(WorkflowRunEntity entity,
             WorkflowInstance instance) {
         try {
             entity.instanceState = objectMapper.writeValueAsString(instance);

--- a/app/src/main/java/io/apitomy/axiom/app/WorkflowExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/WorkflowExecutionService.java
@@ -266,6 +266,24 @@ public class WorkflowExecutionService {
 
     // -- Private helpers --
 
+    /**
+     * Rebuilds a {@link TraceContext} rooted at a run's trace root node, or
+     * null if the run has no trace or the root cannot be found.
+     */
+    private TraceContext traceContextFor(WorkflowRunEntity run) {
+        if (run.traceId == null) {
+            return null;
+        }
+        io.apitomy.axiom.core.entities.TraceNodeEntity root =
+                io.apitomy.axiom.core.entities.TraceNodeEntity.find(
+                        "traceId = ?1 and parentNodeId is null", run.traceId)
+                        .firstResult();
+        if (root == null) {
+            return null;
+        }
+        return new TraceContext(run.traceId, root.id);
+    }
+
     private void createTaskForCurrentNode(WorkflowRunEntity entity,
             Workflow workflow, WorkflowInstance instance) {
         ActionInfo actionInfo = workflowEngine.getActionInfo(
@@ -283,8 +301,20 @@ public class WorkflowExecutionService {
         task.status = "Pending";
         task.input = serializeInputs(actionInfo);
         task.workflowRunId = entity.id;
+        task.nodeId = instance.currentNodeId();
+        task.traceId = entity.traceId;
         task.createdOn = Instant.now();
         task.persist();
+
+        TraceContext traceCtx = traceContextFor(entity);
+        if (traceCtx != null) {
+            try {
+                traceService.addNode(traceCtx, "task", "in-progress",
+                        "Node: " + actionInfo.actionType(), "task", task.id);
+            } catch (Exception e) {
+                LOG.warnf(e, "Failed to add workflow task trace node");
+            }
+        }
 
         LOG.infof("Created task %d for workflow instance %d (action: %s)",
                 task.id, entity.id, actionInfo.actionType());

--- a/app/src/main/java/io/apitomy/axiom/app/WorkflowExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/WorkflowExecutionService.java
@@ -231,14 +231,14 @@ public class WorkflowExecutionService {
     @Transactional
     public void cancelWorkflow(long projectId) {
         WorkflowRunEntity entity = WorkflowRunEntity
-                .find("projectId", projectId).firstResult();
+                .find("projectId = ?1 and status in ?2", projectId,
+                        List.of("running", "waiting"))
+                .firstResult();
         if (entity == null) {
-            throw new WebApplicationException("No workflow instance found", 404);
-        }
-
-        if ("completed".equals(entity.status)
-                || "failed".equals(entity.status)
-                || "cancelled".equals(entity.status)) {
+            long runCount = WorkflowRunEntity.count("projectId", projectId);
+            if (runCount == 0) {
+                throw new WebApplicationException("No workflow instance found", 404);
+            }
             throw new WebApplicationException(
                     "Workflow instance is already in a terminal state", 409);
         }

--- a/app/src/main/java/io/apitomy/axiom/app/WorkflowExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/WorkflowExecutionService.java
@@ -9,6 +9,8 @@ import io.apitomy.axiom.core.entities.WorkflowDefinitionVersionEntity;
 import io.apitomy.axiom.core.entities.WorkflowRunEntity;
 import io.apitomy.axiom.core.entities.ActivityLogEntity;
 import io.apitomy.axiom.core.events.SseEvent;
+import io.apitomy.axiom.core.tracing.TraceService;
+import io.apitomy.axiom.core.tracing.TraceContext;
 import io.apitomy.flow.engine.WorkflowEngine;
 import io.apitomy.flow.engine.WorkflowValidationException;
 import io.apitomy.flow.model.InstanceStatus;
@@ -50,6 +52,9 @@ public class WorkflowExecutionService {
     @Inject
     Event<SseEvent> sseEvents;
 
+    @Inject
+    TraceService traceService;
+
     private WorkflowEngine workflowEngine;
 
     @PostConstruct
@@ -78,11 +83,13 @@ public class WorkflowExecutionService {
             throw new WebApplicationException("Project not found", 404);
         }
 
-        WorkflowRunEntity existing = WorkflowRunEntity
-                .find("projectId", projectId).firstResult();
-        if (existing != null) {
+        WorkflowRunEntity activeRun = WorkflowRunEntity
+                .find("projectId = ?1 and status in ?2",
+                        projectId, List.of("running", "waiting"))
+                .firstResult();
+        if (activeRun != null) {
             throw new WebApplicationException(
-                    "Project already has a workflow instance", 409);
+                    "Project already has an active workflow run", 409);
         }
 
         WorkflowDefinitionEntity definition =
@@ -138,6 +145,18 @@ public class WorkflowExecutionService {
         entity.startedOn = Instant.now();
         persistInstanceState(entity, instance);
         entity.persist();
+
+        try {
+            TraceContext traceCtx = traceService.createTrace(
+                    "workflow",
+                    "Workflow: " + definition.name,
+                    null, project.id, null,
+                    "workflow", "Workflow: " + definition.name,
+                    "workflow-run", entity.id);
+            entity.traceId = traceCtx.traceId();
+        } catch (Exception e) {
+            LOG.warnf(e, "Failed to create trace for workflow run %d", entity.id);
+        }
 
         if (instance.status() == InstanceStatus.WAITING) {
             createTaskForCurrentNode(entity, workflow, instance);

--- a/app/src/main/java/io/apitomy/axiom/app/WorkflowRunBeanMapper.java
+++ b/app/src/main/java/io/apitomy/axiom/app/WorkflowRunBeanMapper.java
@@ -122,6 +122,12 @@ public class WorkflowRunBeanMapper {
                 new io.apitomy.axiom.api.beans.HistoryEntry();
         bean.setNodeId(entry.nodeId());
         bean.setNodeName(entry.nodeName());
+        if (entry.edgeId() != null) {
+            bean.setEdgeId(entry.edgeId());
+        }
+        if (entry.edgeCondition() != null) {
+            bean.setEdgeCondition(entry.edgeCondition());
+        }
         if (entry.enteredOn() != null) {
             bean.setEnteredOn(Date.from(entry.enteredOn()));
         }

--- a/app/src/main/java/io/apitomy/axiom/app/WorkflowRunBeanMapper.java
+++ b/app/src/main/java/io/apitomy/axiom/app/WorkflowRunBeanMapper.java
@@ -1,0 +1,235 @@
+package io.apitomy.axiom.app;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.apitomy.axiom.api.beans.WorkflowContent;
+import io.apitomy.axiom.api.beans.WorkflowRunSearchResults;
+import io.apitomy.axiom.api.beans.WorkflowRunSummary;
+import io.apitomy.axiom.core.entities.ProjectEntity;
+import io.apitomy.axiom.core.entities.TaskEntity;
+import io.apitomy.axiom.core.entities.WorkflowDefinitionEntity;
+import io.apitomy.axiom.core.entities.WorkflowDefinitionVersionEntity;
+import io.apitomy.axiom.core.entities.WorkflowRunEntity;
+import io.apitomy.flow.model.Workflow;
+import io.apitomy.flow.model.WorkflowInstance;
+import io.quarkus.panache.common.Page;
+import io.quarkus.panache.common.Sort;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.math.BigInteger;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Maps {@link WorkflowRunEntity} rows to the generated REST beans, shared by the
+ * project workflow endpoint and the workflow-runs endpoints.
+ */
+@ApplicationScoped
+public class WorkflowRunBeanMapper {
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    /**
+     * Builds the enriched WorkflowInstance detail bean for a run.
+     *
+     * @param entity the workflow run entity
+     * @return the workflow instance bean with full details
+     */
+    public io.apitomy.axiom.api.beans.WorkflowInstance toBean(WorkflowRunEntity entity) {
+        io.apitomy.axiom.api.beans.WorkflowInstance bean =
+                new io.apitomy.axiom.api.beans.WorkflowInstance();
+
+        bean.setId(entity.id);
+        bean.setRunId(entity.id);
+        if (entity.traceId != null) {
+            bean.setTraceId(entity.traceId);
+        }
+        bean.setProjectId(entity.projectId);
+        bean.setDefinitionId(entity.definitionId);
+        bean.setDefinitionVersion(entity.definitionVersion);
+        bean.setStatus(entity.status);
+        bean.setCurrentNodeId(entity.currentNodeId);
+        bean.setFailureReason(entity.failureReason);
+        bean.setStartedOn(Date.from(entity.startedOn));
+        if (entity.completedOn != null) {
+            bean.setCompletedOn(Date.from(entity.completedOn));
+        }
+
+        WorkflowDefinitionEntity definition =
+                WorkflowDefinitionEntity.findById(entity.definitionId);
+        if (definition != null) {
+            bean.setDefinitionName(definition.name);
+        }
+
+        WorkflowDefinitionVersionEntity version =
+                WorkflowDefinitionVersionEntity
+                        .find("definitionId = ?1 and version = ?2",
+                                entity.definitionId,
+                                entity.definitionVersion)
+                        .firstResult();
+        if (version != null) {
+            try {
+                bean.setWorkflowContent(objectMapper.readValue(
+                        version.content, WorkflowContent.class));
+            } catch (JsonProcessingException e) {
+                bean.setWorkflowContent(null);
+            }
+
+            if (entity.currentNodeId != null) {
+                try {
+                    Workflow workflow = objectMapper.readValue(
+                            version.content, Workflow.class);
+                    workflow.findNodeById(entity.currentNodeId)
+                            .ifPresent(node ->
+                                    bean.setCurrentNodeName(node.name()));
+                } catch (JsonProcessingException ignored) {
+                }
+            }
+        }
+
+        try {
+            WorkflowInstance flowInstance = objectMapper.readValue(
+                    entity.instanceState, WorkflowInstance.class);
+            bean.setContext(objectMapper.convertValue(
+                    flowInstance.context(),
+                    io.apitomy.axiom.api.beans.Context.class));
+            List<TaskEntity> runTasks = TaskEntity
+                    .<TaskEntity>find("workflowRunId", entity.id).list();
+            Map<String, TaskEntity> tasksByNode = runTasks.stream()
+                    .filter(t -> t.nodeId != null)
+                    .collect(java.util.stream.Collectors.toMap(
+                            t -> t.nodeId, t -> t, (a, b) -> b));
+            bean.setHistory(flowInstance.history().stream()
+                    .map(h -> toHistoryEntryBean(h, tasksByNode))
+                    .toList());
+        } catch (JsonProcessingException e) {
+            bean.setHistory(List.of());
+        }
+
+        return bean;
+    }
+
+    private io.apitomy.axiom.api.beans.HistoryEntry toHistoryEntryBean(
+            io.apitomy.flow.model.HistoryEntry entry,
+            Map<String, TaskEntity> tasksByNode) {
+        io.apitomy.axiom.api.beans.HistoryEntry bean =
+                new io.apitomy.axiom.api.beans.HistoryEntry();
+        bean.setNodeId(entry.nodeId());
+        bean.setNodeName(entry.nodeName());
+        if (entry.enteredOn() != null) {
+            bean.setEnteredOn(Date.from(entry.enteredOn()));
+        }
+        if (entry.completedOn() != null) {
+            bean.setCompletedOn(Date.from(entry.completedOn()));
+        }
+        if (entry.output() != null && !entry.output().isEmpty()) {
+            bean.setOutput(objectMapper.convertValue(
+                    entry.output(),
+                    io.apitomy.axiom.api.beans.Output.class));
+        }
+        TaskEntity task = entry.nodeId() != null
+                ? tasksByNode.get(entry.nodeId()) : null;
+        if (task != null) {
+            bean.setTaskId(task.id);
+            bean.setTaskStatus(task.status);
+        }
+        return bean;
+    }
+
+    /**
+     * Searches runs with optional project/definition/status filters, newest first.
+     *
+     * @param projectId    optional project filter (nullable)
+     * @param definitionId optional definition filter (nullable; used by the per-definition endpoint)
+     * @param status       optional comma-separated status filter (nullable)
+     * @param page         1-based page number (nullable → 1)
+     * @param limit        page size (nullable → 20)
+     * @return paginated run summaries
+     */
+    public WorkflowRunSearchResults search(Long projectId, Long definitionId, String status,
+                                           BigInteger page, BigInteger limit) {
+        int pageNum = page != null ? Math.max(1, page.intValue()) : 1;
+        int pageSize = limit != null ? Math.max(1, limit.intValue()) : 20;
+
+        StringBuilder hql = new StringBuilder("1=1");
+        Map<String, Object> params = new HashMap<>();
+        if (projectId != null) {
+            hql.append(" and projectId = :projectId");
+            params.put("projectId", projectId);
+        }
+        if (definitionId != null) {
+            hql.append(" and definitionId = :definitionId");
+            params.put("definitionId", definitionId);
+        }
+        if (status != null && !status.isBlank()) {
+            hql.append(" and status in :statuses");
+            params.put("statuses", java.util.Arrays.stream(status.split(","))
+                    .map(String::trim).filter(s -> !s.isEmpty()).toList());
+        }
+
+        long totalCount = WorkflowRunEntity.count(hql.toString(), params);
+        List<WorkflowRunEntity> runs = WorkflowRunEntity
+                .<WorkflowRunEntity>find(hql.toString(), Sort.descending("startedOn"), params)
+                .page(Page.of(pageNum - 1, pageSize))
+                .list();
+
+        Map<Long, String> projectNames = resolveProjectNames(runs);
+        Map<Long, String> definitionNames = resolveDefinitionNames(runs);
+
+        WorkflowRunSearchResults results = new WorkflowRunSearchResults();
+        results.setItems(runs.stream()
+                .map(r -> toSummary(r, projectNames, definitionNames))
+                .toList());
+        results.setTotalCount(totalCount);
+        results.setPage(pageNum);
+        results.setLimit(pageSize);
+        return results;
+    }
+
+    private Map<Long, String> resolveProjectNames(List<WorkflowRunEntity> runs) {
+        Set<Long> ids = runs.stream().map(r -> r.projectId).collect(Collectors.toSet());
+        if (ids.isEmpty()) {
+            return Map.of();
+        }
+        return ProjectEntity.<ProjectEntity>find("id in :ids", Map.of("ids", ids)).list().stream()
+                .collect(Collectors.toMap(p -> p.id, p -> p.name));
+    }
+
+    private Map<Long, String> resolveDefinitionNames(List<WorkflowRunEntity> runs) {
+        Set<Long> ids = runs.stream().map(r -> r.definitionId).collect(Collectors.toSet());
+        if (ids.isEmpty()) {
+            return Map.of();
+        }
+        return WorkflowDefinitionEntity.<WorkflowDefinitionEntity>find("id in :ids", Map.of("ids", ids))
+                .list().stream()
+                .collect(Collectors.toMap(d -> d.id, d -> d.name));
+    }
+
+    private WorkflowRunSummary toSummary(WorkflowRunEntity run, Map<Long, String> projectNames,
+                                         Map<Long, String> definitionNames) {
+        WorkflowRunSummary summary = new WorkflowRunSummary();
+        summary.setRunId(run.id);
+        summary.setProjectId(run.projectId);
+        summary.setProjectName(projectNames.getOrDefault(run.projectId, "Unknown"));
+        summary.setDefinitionId(run.definitionId);
+        summary.setDefinitionName(definitionNames.getOrDefault(run.definitionId, "Unknown"));
+        summary.setDefinitionVersion(run.definitionVersion);
+        summary.setStatus(run.status);
+        if (run.traceId != null) {
+            summary.setTraceId(run.traceId);
+        }
+        summary.setStartedOn(Date.from(run.startedOn));
+        if (run.completedOn != null) {
+            summary.setCompletedOn(Date.from(run.completedOn));
+        }
+        // currentNodeName is intentionally omitted on the list to avoid an N+1 content
+        // read per row; the detail bean (toBean) carries it. Populate later if the UI needs it.
+        return summary;
+    }
+}

--- a/app/src/main/java/io/apitomy/axiom/app/rest/ProjectsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/ProjectsResourceImpl.java
@@ -525,7 +525,9 @@ public class ProjectsResourceImpl implements ProjectsResource {
     public io.apitomy.axiom.api.beans.WorkflowInstance getProjectWorkflowInstance(
             long projectId) {
         WorkflowRunEntity entity = WorkflowRunEntity
-                .find("projectId", projectId).firstResult();
+                .find("projectId", io.quarkus.panache.common.Sort.descending("startedOn"),
+                        projectId)
+                .firstResult();
         if (entity == null) {
             throw new WebApplicationException(404);
         }
@@ -543,6 +545,10 @@ public class ProjectsResourceImpl implements ProjectsResource {
                 new io.apitomy.axiom.api.beans.WorkflowInstance();
 
         bean.setId(entity.id);
+        bean.setRunId(entity.id);
+        if (entity.traceId != null) {
+            bean.setTraceId(entity.traceId);
+        }
         bean.setProjectId(entity.projectId);
         bean.setDefinitionId(entity.definitionId);
         bean.setDefinitionVersion(entity.definitionVersion);
@@ -592,8 +598,15 @@ public class ProjectsResourceImpl implements ProjectsResource {
             bean.setContext(objectMapper.convertValue(
                     flowInstance.context(),
                     io.apitomy.axiom.api.beans.Context.class));
+            List<TaskEntity> runTasks = TaskEntity
+                    .<TaskEntity>find("workflowRunId", entity.id).list();
+            Map<String, TaskEntity> tasksByNode = runTasks.stream()
+                    .filter(t -> t.nodeId != null)
+                    .collect(java.util.stream.Collectors.toMap(
+                            t -> t.nodeId, t -> t, (a, b) -> b));
             bean.setHistory(flowInstance.history().stream()
-                    .map(this::toHistoryEntryBean).toList());
+                    .map(h -> toHistoryEntryBean(h, tasksByNode))
+                    .toList());
         } catch (JsonProcessingException e) {
             bean.setHistory(List.of());
         }
@@ -602,7 +615,8 @@ public class ProjectsResourceImpl implements ProjectsResource {
     }
 
     private io.apitomy.axiom.api.beans.HistoryEntry toHistoryEntryBean(
-            io.apitomy.flow.model.HistoryEntry entry) {
+            io.apitomy.flow.model.HistoryEntry entry,
+            Map<String, TaskEntity> tasksByNode) {
         io.apitomy.axiom.api.beans.HistoryEntry bean =
                 new io.apitomy.axiom.api.beans.HistoryEntry();
         bean.setNodeId(entry.nodeId());
@@ -617,6 +631,12 @@ public class ProjectsResourceImpl implements ProjectsResource {
             bean.setOutput(objectMapper.convertValue(
                     entry.output(),
                     io.apitomy.axiom.api.beans.Output.class));
+        }
+        TaskEntity task = entry.nodeId() != null
+                ? tasksByNode.get(entry.nodeId()) : null;
+        if (task != null) {
+            bean.setTaskId(task.id);
+            bean.setTaskStatus(task.status);
         }
         return bean;
     }
@@ -668,6 +688,8 @@ public class ProjectsResourceImpl implements ProjectsResource {
         }
         task.setHumanContext(entity.humanContext);
         task.setOutputSchema(entity.outputSchema);
+        task.setWorkflowRunId(entity.workflowRunId);
+        task.setNodeId(entity.nodeId);
         return task;
     }
 

--- a/app/src/main/java/io/apitomy/axiom/app/rest/ProjectsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/ProjectsResourceImpl.java
@@ -18,8 +18,8 @@ import io.apitomy.axiom.api.beans.TaskResponse;
 import io.apitomy.axiom.api.beans.ThreadEntry;
 import io.apitomy.axiom.api.beans.TriggerWorkflow;
 import io.apitomy.axiom.api.beans.UpdateProject;
-import io.apitomy.axiom.api.beans.WorkflowContent;
 import io.apitomy.axiom.app.WorkflowExecutionService;
+import io.apitomy.axiom.app.WorkflowRunBeanMapper;
 import io.apitomy.axiom.core.entities.ActivityLogEntity;
 import io.apitomy.axiom.core.entities.AiUsageEntity;
 import io.apitomy.axiom.core.entities.EventEntity;
@@ -29,15 +29,12 @@ import io.apitomy.axiom.core.entities.TaskEntity;
 import io.apitomy.axiom.core.entities.TraceNodeEntity;
 import io.apitomy.axiom.core.entities.ThreadEntryEntity;
 import io.apitomy.axiom.core.entities.WorkflowDefinitionEntity;
-import io.apitomy.axiom.core.entities.WorkflowDefinitionVersionEntity;
 import io.apitomy.axiom.core.entities.WorkflowRunEntity;
 import io.apitomy.axiom.core.lifecycle.ProjectLifecycle;
 import io.apitomy.axiom.core.lifecycle.ProjectStatus;
 import io.apitomy.axiom.core.services.WorkspaceService;
 import io.apitomy.axiom.core.tracing.TraceContext;
 import io.apitomy.axiom.core.tracing.TraceService;
-import io.apitomy.flow.model.Workflow;
-import io.apitomy.flow.model.WorkflowInstance;
 import io.quarkus.panache.common.Page;
 import io.quarkus.panache.common.Sort;
 import io.smallrye.common.annotation.RunOnVirtualThread;
@@ -91,6 +88,9 @@ public class ProjectsResourceImpl implements ProjectsResource {
 
     @Inject
     TaskExecutionService taskExecutionService;
+
+    @Inject
+    WorkflowRunBeanMapper runBeanMapper;
 
     // ── Projects ──────────────────────────────────────────────────────
 
@@ -541,104 +541,7 @@ public class ProjectsResourceImpl implements ProjectsResource {
 
     private io.apitomy.axiom.api.beans.WorkflowInstance toWorkflowInstanceBean(
             WorkflowRunEntity entity) {
-        io.apitomy.axiom.api.beans.WorkflowInstance bean =
-                new io.apitomy.axiom.api.beans.WorkflowInstance();
-
-        bean.setId(entity.id);
-        bean.setRunId(entity.id);
-        if (entity.traceId != null) {
-            bean.setTraceId(entity.traceId);
-        }
-        bean.setProjectId(entity.projectId);
-        bean.setDefinitionId(entity.definitionId);
-        bean.setDefinitionVersion(entity.definitionVersion);
-        bean.setStatus(entity.status);
-        bean.setCurrentNodeId(entity.currentNodeId);
-        bean.setFailureReason(entity.failureReason);
-        bean.setStartedOn(Date.from(entity.startedOn));
-        if (entity.completedOn != null) {
-            bean.setCompletedOn(Date.from(entity.completedOn));
-        }
-
-        WorkflowDefinitionEntity definition =
-                WorkflowDefinitionEntity.findById(entity.definitionId);
-        if (definition != null) {
-            bean.setDefinitionName(definition.name);
-        }
-
-        WorkflowDefinitionVersionEntity version =
-                WorkflowDefinitionVersionEntity
-                        .find("definitionId = ?1 and version = ?2",
-                                entity.definitionId,
-                                entity.definitionVersion)
-                        .firstResult();
-        if (version != null) {
-            try {
-                bean.setWorkflowContent(objectMapper.readValue(
-                        version.content, WorkflowContent.class));
-            } catch (JsonProcessingException e) {
-                bean.setWorkflowContent(null);
-            }
-
-            if (entity.currentNodeId != null) {
-                try {
-                    Workflow workflow = objectMapper.readValue(
-                            version.content, Workflow.class);
-                    workflow.findNodeById(entity.currentNodeId)
-                            .ifPresent(node ->
-                                    bean.setCurrentNodeName(node.name()));
-                } catch (JsonProcessingException ignored) {
-                }
-            }
-        }
-
-        try {
-            WorkflowInstance flowInstance = objectMapper.readValue(
-                    entity.instanceState, WorkflowInstance.class);
-            bean.setContext(objectMapper.convertValue(
-                    flowInstance.context(),
-                    io.apitomy.axiom.api.beans.Context.class));
-            List<TaskEntity> runTasks = TaskEntity
-                    .<TaskEntity>find("workflowRunId", entity.id).list();
-            Map<String, TaskEntity> tasksByNode = runTasks.stream()
-                    .filter(t -> t.nodeId != null)
-                    .collect(java.util.stream.Collectors.toMap(
-                            t -> t.nodeId, t -> t, (a, b) -> b));
-            bean.setHistory(flowInstance.history().stream()
-                    .map(h -> toHistoryEntryBean(h, tasksByNode))
-                    .toList());
-        } catch (JsonProcessingException e) {
-            bean.setHistory(List.of());
-        }
-
-        return bean;
-    }
-
-    private io.apitomy.axiom.api.beans.HistoryEntry toHistoryEntryBean(
-            io.apitomy.flow.model.HistoryEntry entry,
-            Map<String, TaskEntity> tasksByNode) {
-        io.apitomy.axiom.api.beans.HistoryEntry bean =
-                new io.apitomy.axiom.api.beans.HistoryEntry();
-        bean.setNodeId(entry.nodeId());
-        bean.setNodeName(entry.nodeName());
-        if (entry.enteredOn() != null) {
-            bean.setEnteredOn(Date.from(entry.enteredOn()));
-        }
-        if (entry.completedOn() != null) {
-            bean.setCompletedOn(Date.from(entry.completedOn()));
-        }
-        if (entry.output() != null && !entry.output().isEmpty()) {
-            bean.setOutput(objectMapper.convertValue(
-                    entry.output(),
-                    io.apitomy.axiom.api.beans.Output.class));
-        }
-        TaskEntity task = entry.nodeId() != null
-                ? tasksByNode.get(entry.nodeId()) : null;
-        if (task != null) {
-            bean.setTaskId(task.id);
-            bean.setTaskStatus(task.status);
-        }
-        return bean;
+        return runBeanMapper.toBean(entity);
     }
 
     private ProjectEntity findProjectOrThrow(long id) {

--- a/app/src/main/java/io/apitomy/axiom/app/rest/ProjectsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/ProjectsResourceImpl.java
@@ -30,7 +30,7 @@ import io.apitomy.axiom.core.entities.TraceNodeEntity;
 import io.apitomy.axiom.core.entities.ThreadEntryEntity;
 import io.apitomy.axiom.core.entities.WorkflowDefinitionEntity;
 import io.apitomy.axiom.core.entities.WorkflowDefinitionVersionEntity;
-import io.apitomy.axiom.core.entities.WorkflowInstanceEntity;
+import io.apitomy.axiom.core.entities.WorkflowRunEntity;
 import io.apitomy.axiom.core.lifecycle.ProjectLifecycle;
 import io.apitomy.axiom.core.lifecycle.ProjectStatus;
 import io.apitomy.axiom.core.services.WorkspaceService;
@@ -516,7 +516,7 @@ public class ProjectsResourceImpl implements ProjectsResource {
     @Override
     public io.apitomy.axiom.api.beans.WorkflowInstance triggerProjectWorkflow(
             long projectId, TriggerWorkflow data) {
-        WorkflowInstanceEntity entity = workflowExecutionService
+        WorkflowRunEntity entity = workflowExecutionService
                 .triggerWorkflow(projectId, data.getWorkflowDefinitionId());
         return toWorkflowInstanceBean(entity);
     }
@@ -524,7 +524,7 @@ public class ProjectsResourceImpl implements ProjectsResource {
     @Override
     public io.apitomy.axiom.api.beans.WorkflowInstance getProjectWorkflowInstance(
             long projectId) {
-        WorkflowInstanceEntity entity = WorkflowInstanceEntity
+        WorkflowRunEntity entity = WorkflowRunEntity
                 .find("projectId", projectId).firstResult();
         if (entity == null) {
             throw new WebApplicationException(404);
@@ -538,7 +538,7 @@ public class ProjectsResourceImpl implements ProjectsResource {
     }
 
     private io.apitomy.axiom.api.beans.WorkflowInstance toWorkflowInstanceBean(
-            WorkflowInstanceEntity entity) {
+            WorkflowRunEntity entity) {
         io.apitomy.axiom.api.beans.WorkflowInstance bean =
                 new io.apitomy.axiom.api.beans.WorkflowInstance();
 
@@ -643,7 +643,7 @@ public class ProjectsResourceImpl implements ProjectsResource {
         project.setUpdatedOn(Date.from(entity.updatedOn));
         project.setLabels(entity.labels);
         project.setHasWorkflowInstance(
-                WorkflowInstanceEntity.count("projectId", entity.id) > 0);
+                WorkflowRunEntity.count("projectId", entity.id) > 0);
         return project;
     }
 

--- a/app/src/main/java/io/apitomy/axiom/app/rest/WorkflowDefinitionsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/WorkflowDefinitionsResourceImpl.java
@@ -432,12 +432,11 @@ public class WorkflowDefinitionsResourceImpl implements WorkflowResource {
 
     /**
      * {@inheritDoc}
-     * <p>
-     * Stub - to be implemented in Task 14.
      */
     @Override
     public io.apitomy.axiom.api.beans.WorkflowRunSearchResults listWorkflowDefinitionRuns(
             long workflowDefinitionId, String status, java.math.BigInteger page, java.math.BigInteger limit) {
-        throw new WebApplicationException("Not yet implemented", Response.Status.NOT_IMPLEMENTED);
+        findOrThrow(workflowDefinitionId);
+        return runBeanMapper.search(null, workflowDefinitionId, status, page, limit);
     }
 }

--- a/app/src/main/java/io/apitomy/axiom/app/rest/WorkflowDefinitionsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/WorkflowDefinitionsResourceImpl.java
@@ -400,4 +400,23 @@ public class WorkflowDefinitionsResourceImpl implements WorkflowResource {
             return "{}";
         }
     }
+
+    // ── Workflow Runs (Stub - to be implemented in Task 11) ──────────
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public io.apitomy.axiom.api.beans.WorkflowRunSearchResults listWorkflowRuns(
+            Long projectId, String status, java.math.BigInteger page, java.math.BigInteger limit) {
+        throw new WebApplicationException("Not yet implemented", Response.Status.NOT_IMPLEMENTED);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public io.apitomy.axiom.api.beans.WorkflowInstance getWorkflowRun(long runId) {
+        throw new WebApplicationException("Not yet implemented", Response.Status.NOT_IMPLEMENTED);
+    }
 }

--- a/app/src/main/java/io/apitomy/axiom/app/rest/WorkflowDefinitionsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/WorkflowDefinitionsResourceImpl.java
@@ -9,8 +9,10 @@ import io.apitomy.axiom.api.beans.UpdateWorkflowDefinition;
 import io.apitomy.axiom.api.beans.WorkflowDefinition;
 import io.apitomy.axiom.api.beans.WorkflowDefinitionSearchResults;
 import io.apitomy.axiom.api.beans.WorkflowDefinitionVersion;
+import io.apitomy.axiom.app.WorkflowRunBeanMapper;
 import io.apitomy.axiom.core.entities.WorkflowDefinitionEntity;
 import io.apitomy.axiom.core.entities.WorkflowDefinitionVersionEntity;
+import io.apitomy.axiom.core.entities.WorkflowRunEntity;
 import io.apitomy.flow.model.Workflow;
 import io.apitomy.flow.model.WorkflowNode;
 import io.apitomy.flow.validation.ValidationProblem;
@@ -44,6 +46,9 @@ public class WorkflowDefinitionsResourceImpl implements WorkflowResource {
 
     @Inject
     ObjectMapper objectMapper;
+
+    @Inject
+    WorkflowRunBeanMapper runBeanMapper;
 
     /** Inputs Axiom always injects when starting a workflow (may be marked required). */
     private static final Set<String> ALWAYS_PRESENT_INPUTS =
@@ -401,7 +406,7 @@ public class WorkflowDefinitionsResourceImpl implements WorkflowResource {
         }
     }
 
-    // ── Workflow Runs (Stub - to be implemented in Task 11) ──────────
+    // ── Workflow Runs ─────────────────────────────────────────────────
 
     /**
      * {@inheritDoc}
@@ -409,7 +414,7 @@ public class WorkflowDefinitionsResourceImpl implements WorkflowResource {
     @Override
     public io.apitomy.axiom.api.beans.WorkflowRunSearchResults listWorkflowRuns(
             Long projectId, String status, java.math.BigInteger page, java.math.BigInteger limit) {
-        throw new WebApplicationException("Not yet implemented", Response.Status.NOT_IMPLEMENTED);
+        return runBeanMapper.search(projectId, null, status, page, limit);
     }
 
     /**
@@ -417,11 +422,18 @@ public class WorkflowDefinitionsResourceImpl implements WorkflowResource {
      */
     @Override
     public io.apitomy.axiom.api.beans.WorkflowInstance getWorkflowRun(long runId) {
-        throw new WebApplicationException("Not yet implemented", Response.Status.NOT_IMPLEMENTED);
+        WorkflowRunEntity run = WorkflowRunEntity.findById(runId);
+        if (run == null) {
+            throw new WebApplicationException("Workflow run not found: " + runId,
+                    Response.Status.NOT_FOUND);
+        }
+        return runBeanMapper.toBean(run);
     }
 
     /**
      * {@inheritDoc}
+     * <p>
+     * Stub - to be implemented in Task 14.
      */
     @Override
     public io.apitomy.axiom.api.beans.WorkflowRunSearchResults listWorkflowDefinitionRuns(

--- a/app/src/main/java/io/apitomy/axiom/app/rest/WorkflowDefinitionsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/WorkflowDefinitionsResourceImpl.java
@@ -419,4 +419,13 @@ public class WorkflowDefinitionsResourceImpl implements WorkflowResource {
     public io.apitomy.axiom.api.beans.WorkflowInstance getWorkflowRun(long runId) {
         throw new WebApplicationException("Not yet implemented", Response.Status.NOT_IMPLEMENTED);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public io.apitomy.axiom.api.beans.WorkflowRunSearchResults listWorkflowDefinitionRuns(
+            long workflowDefinitionId, String status, java.math.BigInteger page, java.math.BigInteger limit) {
+        throw new WebApplicationException("Not yet implemented", Response.Status.NOT_IMPLEMENTED);
+    }
 }

--- a/app/src/main/resources/db/migration/V54__rename_workflow_instance_to_run.sql
+++ b/app/src/main/resources/db/migration/V54__rename_workflow_instance_to_run.sql
@@ -1,0 +1,22 @@
+-- Rename the single-instance-per-project table into a run-history table.
+ALTER TABLE workflow_instance RENAME TO workflow_run;
+
+-- Many runs per project: drop the uniqueness constraint on project_id.
+-- V53 created it inline, so Postgres named it workflow_instance_project_id_key.
+ALTER TABLE workflow_run DROP CONSTRAINT IF EXISTS workflow_instance_project_id_key;
+
+-- Link a run to its execution trace (nullable; trace creation is best-effort).
+ALTER TABLE workflow_run ADD COLUMN trace_id UUID;
+
+-- Rename the Hibernate sequence to match the new table name.
+ALTER SEQUENCE IF EXISTS workflow_instance_SEQ RENAME TO workflow_run_SEQ;
+
+-- Replace the status-only index with one that supports latest-run and
+-- per-project history queries.
+DROP INDEX IF EXISTS idx_wf_instance_status;
+CREATE INDEX idx_wf_run_project_started ON workflow_run(project_id, started_on DESC);
+CREATE INDEX idx_wf_run_status ON workflow_run(status);
+
+-- Task → run linkage rename, plus the node this task represents.
+ALTER TABLE task RENAME COLUMN workflow_instance_id TO workflow_run_id;
+ALTER TABLE task ADD COLUMN node_id VARCHAR(255);

--- a/app/src/test/java/io/apitomy/axiom/app/WorkflowDefinitionsResourceTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/WorkflowDefinitionsResourceTest.java
@@ -10,7 +10,7 @@ import static org.hamcrest.Matchers.*;
 @QuarkusTest
 class WorkflowDefinitionsResourceTest {
 
-    private static final String BASE_PATH = "/api/v1/workflow-definitions";
+    private static final String BASE_PATH = "/api/v1/workflow/definitions";
 
     @Test
     void testCreateAndGetWorkflowDefinition() {

--- a/app/src/test/java/io/apitomy/axiom/app/WorkflowInstanceResourceTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/WorkflowInstanceResourceTest.java
@@ -53,7 +53,7 @@ class WorkflowInstanceResourceTest {
     @Test
     void testTriggerDuplicateReturns409() {
         int projectId = createProject("WF Dup Test Project");
-        int definitionId = createAndPublishDefinition(
+        int definitionId = createAndPublishActionWorkflow(
                 "Dup Test WF");
 
         given()
@@ -66,7 +66,8 @@ class WorkflowInstanceResourceTest {
                 .when()
                     .post(PROJECTS_PATH + "/" + projectId + "/workflow")
                 .then()
-                    .statusCode(200);
+                    .statusCode(200)
+                    .body("status", equalTo("waiting"));
 
         given()
                 .contentType(ContentType.JSON)

--- a/app/src/test/java/io/apitomy/axiom/app/WorkflowInstanceResourceTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/WorkflowInstanceResourceTest.java
@@ -216,6 +216,58 @@ class WorkflowInstanceResourceTest {
     }
 
     @Test
+    void testCancelActiveRunCancelsLatestNotPriorTerminal() {
+        int projectId = createProject("WF Cancel Active Run Project");
+        int definitionId = createAndPublishActionWorkflow(
+                "Cancel Active Run WF");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                    {
+                        "workflowDefinitionId": %d
+                    }
+                    """.formatted(definitionId))
+                .when()
+                    .post(PROJECTS_PATH + "/" + projectId + "/workflow")
+                .then()
+                    .statusCode(200)
+                    .body("status", equalTo("waiting"));
+
+        given()
+                .when()
+                    .delete(PROJECTS_PATH + "/" + projectId + "/workflow")
+                .then()
+                    .statusCode(204);
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                    {
+                        "workflowDefinitionId": %d
+                    }
+                    """.formatted(definitionId))
+                .when()
+                    .post(PROJECTS_PATH + "/" + projectId + "/workflow")
+                .then()
+                    .statusCode(200)
+                    .body("status", equalTo("waiting"));
+
+        given()
+                .when()
+                    .delete(PROJECTS_PATH + "/" + projectId + "/workflow")
+                .then()
+                    .statusCode(204);
+
+        given()
+                .when()
+                    .get(PROJECTS_PATH + "/" + projectId + "/workflow")
+                .then()
+                    .statusCode(200)
+                    .body("status", equalTo("cancelled"));
+    }
+
+    @Test
     void testGetNoInstanceReturns404() {
         int projectId = createProject("WF No Instance Project");
 

--- a/app/src/test/java/io/apitomy/axiom/app/WorkflowInstanceResourceTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/WorkflowInstanceResourceTest.java
@@ -11,7 +11,7 @@ import static org.hamcrest.Matchers.*;
 class WorkflowInstanceResourceTest {
 
     private static final String PROJECTS_PATH = "/api/v1/projects";
-    private static final String WORKFLOWS_PATH = "/api/v1/workflow-definitions";
+    private static final String WORKFLOWS_PATH = "/api/v1/workflow/definitions";
 
     @Test
     void testTriggerAndGetWorkflow() {

--- a/app/src/test/java/io/apitomy/axiom/app/WorkflowRunsResourceTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/WorkflowRunsResourceTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 class WorkflowRunsResourceTest {
 
     private static final String PROJECTS_PATH = "/api/v1/projects";
-    private static final String WORKFLOWS_PATH = "/api/v1/workflow-definitions";
+    private static final String WORKFLOWS_PATH = "/api/v1/workflow/definitions";
 
     @Inject
     TaskExecutionService taskExecutionService;

--- a/app/src/test/java/io/apitomy/axiom/app/WorkflowRunsResourceTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/WorkflowRunsResourceTest.java
@@ -1,5 +1,7 @@
 package io.apitomy.axiom.app;
 
+import io.apitomy.axiom.core.entities.TaskEntity;
+import io.apitomy.axiom.core.entities.TraceNodeEntity;
 import io.apitomy.axiom.core.entities.WorkflowRunEntity;
 import io.quarkus.narayana.jta.QuarkusTransaction;
 import io.quarkus.test.junit.QuarkusTest;
@@ -109,6 +111,46 @@ class WorkflowRunsResourceTest {
                     .post(PROJECTS_PATH + "/" + projectId + "/workflow")
                 .then()
                     .statusCode(409);
+    }
+
+    /**
+     * Verifies that the workflow node task is stamped with workflowRunId,
+     * nodeId, and traceId, and that a matching "task" trace node exists.
+     */
+    @Test
+    void nodeTaskCarriesRunNodeAndTrace() {
+        int projectId = createProject("WF Node Task Project");
+        int definitionId = createAndPublishActionWorkflow("Node Task WF");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"workflowDefinitionId\": %d}".formatted(definitionId))
+                .when()
+                    .post(PROJECTS_PATH + "/" + projectId + "/workflow")
+                .then()
+                    .statusCode(200)
+                    .body("status", equalTo("waiting"));
+
+        // Query the spawned task entity directly
+        TaskEntity task = QuarkusTransaction.requiringNew().call(() ->
+                TaskEntity.find("projectId", (long) projectId).firstResult());
+        assertNotNull(task, "Task should exist");
+        assertNotNull(task.workflowRunId, "Task should have workflowRunId");
+        assertNotNull(task.nodeId, "Task should have nodeId");
+        assertNotNull(task.traceId, "Task should have traceId");
+
+        // Query the run to get its traceId
+        WorkflowRunEntity run = QuarkusTransaction.requiringNew().call(() ->
+                WorkflowRunEntity.findById(task.workflowRunId));
+        assertNotNull(run, "Run should exist");
+
+        // Verify a matching "task" trace node exists
+        TraceNodeEntity traceNode = QuarkusTransaction.requiringNew().call(() ->
+                TraceNodeEntity.find("traceId = ?1 and nodeType = ?2", run.traceId, "task")
+                        .firstResult());
+        assertNotNull(traceNode, "Task trace node should exist");
+        assertEquals(task.id, traceNode.entityId,
+                "Trace node entityId should match task id");
     }
 
     // -- Helpers copied from WorkflowInstanceResourceTest --

--- a/app/src/test/java/io/apitomy/axiom/app/WorkflowRunsResourceTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/WorkflowRunsResourceTest.java
@@ -1,0 +1,245 @@
+package io.apitomy.axiom.app;
+
+import io.apitomy.axiom.core.entities.WorkflowRunEntity;
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Tests workflow run history and trace creation.
+ */
+@QuarkusTest
+class WorkflowRunsResourceTest {
+
+    private static final String PROJECTS_PATH = "/api/v1/projects";
+    private static final String WORKFLOWS_PATH = "/api/v1/workflow-definitions";
+
+    /**
+     * Verifies that triggering an ACTION workflow creates a trace root.
+     * The traceId field is stored in the entity but not yet exposed in the
+     * response bean (that happens in Task 9/12).
+     */
+    @Test
+    void triggeringActionWorkflowStoresTraceId() {
+        int projectId = createProject("WF Trace Project");
+        int definitionId = createAndPublishActionWorkflow("Trace WF");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"workflowDefinitionId\": %d}".formatted(definitionId))
+                .when()
+                    .post(PROJECTS_PATH + "/" + projectId + "/workflow")
+                .then()
+                    .statusCode(200)
+                    .body("status", equalTo("waiting"));
+
+        // Verify trace was created by querying the entity directly
+        WorkflowRunEntity run = QuarkusTransaction.requiringNew().call(() ->
+                WorkflowRunEntity.find("projectId", (long) projectId).firstResult());
+        assertNotNull(run, "Run should exist");
+        assertNotNull(run.traceId, "Trace ID should be set on the run entity");
+    }
+
+    /**
+     * Verifies that after a start→end run completes immediately, a second
+     * trigger is allowed and creates a new run row (history accumulation).
+     */
+    @Test
+    void completedRunAllowsNewTrigger() {
+        int projectId = createProject("WF History Project");
+        int definitionId = createAndPublishDefinition("History WF");
+
+        // First trigger completes immediately (start→end)
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"workflowDefinitionId\": %d}".formatted(definitionId))
+                .when()
+                    .post(PROJECTS_PATH + "/" + projectId + "/workflow")
+                .then()
+                    .statusCode(200)
+                    .body("status", equalTo("completed"));
+
+        // Second trigger should succeed
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"workflowDefinitionId\": %d}".formatted(definitionId))
+                .when()
+                    .post(PROJECTS_PATH + "/" + projectId + "/workflow")
+                .then()
+                    .statusCode(200)
+                    .body("status", equalTo("completed"));
+
+        // Verify 2 run rows exist
+        long count = QuarkusTransaction.requiringNew().call(() ->
+                WorkflowRunEntity.count("projectId", (long) projectId));
+        assertEquals(2, count, "Should have 2 run rows (history)");
+    }
+
+    /**
+     * Verifies that while a run is ACTIVE (waiting), a second trigger
+     * returns 409.
+     */
+    @Test
+    void activeRunRejectsDuplicate() {
+        int projectId = createProject("WF Active Run Project");
+        int definitionId = createAndPublishActionWorkflow("Active Run WF");
+
+        // First trigger stays active (waiting at action node)
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"workflowDefinitionId\": %d}".formatted(definitionId))
+                .when()
+                    .post(PROJECTS_PATH + "/" + projectId + "/workflow")
+                .then()
+                    .statusCode(200)
+                    .body("status", equalTo("waiting"));
+
+        // Second trigger should fail with 409
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"workflowDefinitionId\": %d}".formatted(definitionId))
+                .when()
+                    .post(PROJECTS_PATH + "/" + projectId + "/workflow")
+                .then()
+                    .statusCode(409);
+    }
+
+    // -- Helpers copied from WorkflowInstanceResourceTest --
+
+    private int createProject(String name) {
+        return given()
+                .contentType(ContentType.JSON)
+                .body(String.format("""
+                    {
+                        "name": "%s",
+                        "type": "other",
+                        "ref": "%s"
+                    }
+                    """, name,
+                        "test/" + name.toLowerCase().replace(" ", "-")))
+                .when()
+                    .post(PROJECTS_PATH)
+                .then()
+                    .statusCode(200)
+                    .extract().path("id");
+    }
+
+    private int createDefinition(String name) {
+        return given()
+                .contentType(ContentType.JSON)
+                .body(String.format("""
+                    {
+                        "name": "%s"
+                    }
+                    """, name))
+                .when()
+                    .post(WORKFLOWS_PATH)
+                .then()
+                    .statusCode(200)
+                    .extract().path("id");
+    }
+
+    /**
+     * Creates and publishes a simple start→end workflow (completes
+     * immediately on trigger).
+     */
+    private int createAndPublishDefinition(String name) {
+        int id = createDefinition(name);
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                    {
+                        "id": "wf-test",
+                        "name": "Test",
+                        "nodes": [
+                            {"id": "s1", "type": "start",
+                             "name": "Start",
+                             "config": {},
+                             "position": {"x": 100, "y": 100}},
+                            {"id": "e1", "type": "end",
+                             "name": "End",
+                             "config": {},
+                             "position": {"x": 100, "y": 300}}
+                        ],
+                        "edges": [
+                            {"id": "edge1", "source": "s1",
+                             "target": "e1",
+                             "priority": 0, "isDefault": true}
+                        ]
+                    }
+                    """)
+                .when()
+                    .put(WORKFLOWS_PATH + "/" + id + "/content")
+                .then()
+                    .statusCode(204);
+
+        given()
+                .when()
+                    .post(WORKFLOWS_PATH + "/" + id + "/publish")
+                .then()
+                    .statusCode(200);
+
+        return id;
+    }
+
+    /**
+     * Creates and publishes a start→action→end workflow (stops at the
+     * action node with status "waiting").
+     */
+    private int createAndPublishActionWorkflow(String name) {
+        int id = createDefinition(name);
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                    {
+                        "id": "wf-action",
+                        "name": "Action Test",
+                        "nodes": [
+                            {"id": "s1", "type": "start",
+                             "name": "Start",
+                             "config": {},
+                             "position": {"x": 100, "y": 100}},
+                            {"id": "a1", "type": "action",
+                             "name": "Do Something",
+                             "config": {
+                                 "actionType": "test-action"
+                             },
+                             "position": {"x": 100, "y": 200}},
+                            {"id": "e1", "type": "end",
+                             "name": "End",
+                             "config": {},
+                             "position": {"x": 100, "y": 300}}
+                        ],
+                        "edges": [
+                            {"id": "edge1", "source": "s1",
+                             "target": "a1",
+                             "priority": 0, "isDefault": true},
+                            {"id": "edge2", "source": "a1",
+                             "target": "e1",
+                             "priority": 0, "isDefault": true}
+                        ]
+                    }
+                    """)
+                .when()
+                    .put(WORKFLOWS_PATH + "/" + id + "/content")
+                .then()
+                    .statusCode(204);
+
+        given()
+                .when()
+                    .post(WORKFLOWS_PATH + "/" + id + "/publish")
+                .then()
+                    .statusCode(200);
+
+        return id;
+    }
+}

--- a/app/src/test/java/io/apitomy/axiom/app/WorkflowRunsResourceTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/WorkflowRunsResourceTest.java
@@ -1,17 +1,21 @@
 package io.apitomy.axiom.app;
 
+import io.apitomy.axiom.agents.spi.AgentResult;
 import io.apitomy.axiom.core.entities.TaskEntity;
+import io.apitomy.axiom.core.entities.TraceEntity;
 import io.apitomy.axiom.core.entities.TraceNodeEntity;
 import io.apitomy.axiom.core.entities.WorkflowRunEntity;
 import io.quarkus.narayana.jta.QuarkusTransaction;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
@@ -22,6 +26,9 @@ class WorkflowRunsResourceTest {
 
     private static final String PROJECTS_PATH = "/api/v1/projects";
     private static final String WORKFLOWS_PATH = "/api/v1/workflow-definitions";
+
+    @Inject
+    TaskExecutionService taskExecutionService;
 
     /**
      * Verifies that triggering an ACTION workflow creates a trace root.
@@ -153,6 +160,60 @@ class WorkflowRunsResourceTest {
                 "Trace node entityId should match task id");
     }
 
+    /**
+     * Verifies that completing the first node of a multi-node workflow does
+     * NOT complete the run's trace. The trace must remain open until the
+     * entire run reaches a terminal state.
+     */
+    @Test
+    void runTraceStaysOpenUntilRunCompletes() {
+        int projectId = createProject("WF Trace Lifecycle Project");
+        int definitionId = createAndPublishTwoActionWorkflow("Trace Lifecycle WF");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"workflowDefinitionId\": %d}".formatted(definitionId))
+                .when()
+                    .post(PROJECTS_PATH + "/" + projectId + "/workflow")
+                .then()
+                    .statusCode(200)
+                    .body("status", equalTo("waiting"));
+
+        // Query the run and the first action node's task
+        Object[] runAndTask = QuarkusTransaction.requiringNew().call(() -> {
+            WorkflowRunEntity run = WorkflowRunEntity.find("projectId", (long) projectId)
+                    .firstResult();
+            assertNotNull(run, "Run should exist");
+            assertNotNull(run.traceId, "Run should have traceId");
+
+            TaskEntity a1Task = TaskEntity.find(
+                    "workflowRunId = ?1 and nodeId = ?2", run.id, "a1")
+                    .firstResult();
+            assertNotNull(a1Task, "Action a1 task should exist");
+
+            return new Object[] { run.traceId, a1Task.id };
+        });
+
+        java.util.UUID runTraceId = (java.util.UUID) runAndTask[0];
+        Long a1TaskId = (Long) runAndTask[1];
+
+        // Simulate the first action node completing successfully
+        AgentResult successResult = AgentResult.success("Test action completed");
+        QuarkusTransaction.requiringNew().run(() ->
+                taskExecutionService.onTaskCompleted(a1TaskId, successResult));
+
+        // After node a1 completes, the run should have advanced to a2 and
+        // still be active (non-terminal). The trace must remain open because
+        // WorkflowExecutionService owns the trace lifecycle and only completes
+        // it when the run reaches a terminal state.
+        TraceEntity trace = QuarkusTransaction.requiringNew().call(() ->
+                TraceEntity.findById(runTraceId));
+        assertNotNull(trace, "Trace should exist");
+        assertNotEquals("completed", trace.status,
+                "Trace should NOT be completed after first node finishes "
+                        + "(workflow trace lifecycle is owned by WorkflowExecutionService)");
+    }
+
     // -- Helpers copied from WorkflowInstanceResourceTest --
 
     private int createProject(String name) {
@@ -266,6 +327,68 @@ class WorkflowRunsResourceTest {
                              "target": "a1",
                              "priority": 0, "isDefault": true},
                             {"id": "edge2", "source": "a1",
+                             "target": "e1",
+                             "priority": 0, "isDefault": true}
+                        ]
+                    }
+                    """)
+                .when()
+                    .put(WORKFLOWS_PATH + "/" + id + "/content")
+                .then()
+                    .statusCode(204);
+
+        given()
+                .when()
+                    .post(WORKFLOWS_PATH + "/" + id + "/publish")
+                .then()
+                    .statusCode(200);
+
+        return id;
+    }
+
+    /**
+     * Creates and publishes a start→action→action→end workflow with two
+     * action nodes (a1, a2) in series. Stops at the first action node.
+     */
+    private int createAndPublishTwoActionWorkflow(String name) {
+        int id = createDefinition(name);
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                    {
+                        "id": "wf-two-action",
+                        "name": "Two Action Test",
+                        "nodes": [
+                            {"id": "s1", "type": "start",
+                             "name": "Start",
+                             "config": {},
+                             "position": {"x": 100, "y": 100}},
+                            {"id": "a1", "type": "action",
+                             "name": "Action 1",
+                             "config": {
+                                 "actionType": "test-action"
+                             },
+                             "position": {"x": 100, "y": 200}},
+                            {"id": "a2", "type": "action",
+                             "name": "Action 2",
+                             "config": {
+                                 "actionType": "test-action"
+                             },
+                             "position": {"x": 100, "y": 300}},
+                            {"id": "e1", "type": "end",
+                             "name": "End",
+                             "config": {},
+                             "position": {"x": 100, "y": 400}}
+                        ],
+                        "edges": [
+                            {"id": "edge1", "source": "s1",
+                             "target": "a1",
+                             "priority": 0, "isDefault": true},
+                            {"id": "edge2", "source": "a1",
+                             "target": "a2",
+                             "priority": 0, "isDefault": true},
+                            {"id": "edge3", "source": "a2",
                              "target": "e1",
                              "priority": 0, "isDefault": true}
                         ]

--- a/app/src/test/java/io/apitomy/axiom/app/WorkflowRunsResourceTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/WorkflowRunsResourceTest.java
@@ -463,4 +463,30 @@ class WorkflowRunsResourceTest {
                 .when().get("/api/v1/workflow/runs/999999")
                 .then().statusCode(404);
     }
+
+    @Test
+    void listRunsForDefinition() {
+        int projectId = createProject("WF DefRuns Project");
+        int definitionId = createAndPublishActionWorkflow("DefRuns WF");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"workflowDefinitionId\": %d}".formatted(definitionId))
+                .when().post(PROJECTS_PATH + "/" + projectId + "/workflow")
+                .then().statusCode(200);
+
+        given()
+                .when().get(WORKFLOWS_PATH + "/" + definitionId + "/runs")
+                .then()
+                    .statusCode(200)
+                    .body("totalCount", equalTo(1))
+                    .body("items[0].definitionId", equalTo(definitionId));
+    }
+
+    @Test
+    void listRunsForMissingDefinitionReturns404() {
+        given()
+                .when().get(WORKFLOWS_PATH + "/999999/runs")
+                .then().statusCode(404);
+    }
 }

--- a/app/src/test/java/io/apitomy/axiom/app/WorkflowRunsResourceTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/WorkflowRunsResourceTest.java
@@ -161,6 +161,30 @@ class WorkflowRunsResourceTest {
     }
 
     /**
+     * Verifies that the project workflow instance returns the latest run and
+     * includes runId and traceId fields.
+     */
+    @Test
+    void projectWorkflowReturnsLatestRunWithRunIdAndTrace() {
+        int projectId = createProject("WF Latest Run Project");
+        int definitionId = createAndPublishActionWorkflow("Latest Run WF");
+
+        Integer firstRunId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"workflowDefinitionId\": %d}".formatted(definitionId))
+                .when().post(PROJECTS_PATH + "/" + projectId + "/workflow")
+                .then().statusCode(200).extract().path("runId");
+
+        given()
+                .when()
+                    .get(PROJECTS_PATH + "/" + projectId + "/workflow")
+                .then()
+                    .statusCode(200)
+                    .body("runId", equalTo(firstRunId))
+                    .body("traceId", notNullValue());
+    }
+
+    /**
      * Verifies that completing the first node of a multi-node workflow does
      * NOT complete the run's trace. The trace must remain open until the
      * entire run reaches a terminal state.

--- a/app/src/test/java/io/apitomy/axiom/app/WorkflowRunsResourceTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/WorkflowRunsResourceTest.java
@@ -431,4 +431,36 @@ class WorkflowRunsResourceTest {
 
         return id;
     }
+
+    @Test
+    void listAndGetWorkflowRuns() {
+        int projectId = createProject("WF Runs List Project");
+        int definitionId = createAndPublishActionWorkflow("Runs List WF");
+
+        Integer runId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"workflowDefinitionId\": %d}".formatted(definitionId))
+                .when().post(PROJECTS_PATH + "/" + projectId + "/workflow")
+                .then().statusCode(200).extract().path("runId");
+
+        given()
+                .when().get("/api/v1/workflow/runs?projectId=" + projectId)
+                .then()
+                    .statusCode(200)
+                    .body("totalCount", equalTo(1))
+                    .body("items[0].runId", equalTo(runId))
+                    .body("items[0].projectName", equalTo("WF Runs List Project"))
+                    .body("items[0].definitionName", equalTo("Runs List WF"));
+
+        given()
+                .when().get("/api/v1/workflow/runs/" + runId)
+                .then()
+                    .statusCode(200)
+                    .body("runId", equalTo(runId))
+                    .body("projectId", equalTo(projectId));
+
+        given()
+                .when().get("/api/v1/workflow/runs/999999")
+                .then().statusCode(404);
+    }
 }

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -5548,6 +5548,56 @@
           }
         }
       }
+    },
+    "/workflow/definitions/{workflowDefinitionId}/runs": {
+      "get": {
+        "tags": [
+          "WorkflowDefinitions"
+        ],
+        "summary": "List runs for a specific workflow definition (all versions)",
+        "operationId": "listWorkflowDefinitionRuns",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Filter by status (comma-separated)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of runs for the definition",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowRunSearchResults"
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/WorkflowDefinitionId"
+        }
+      ]
     }
   },
   "components": {

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -9455,6 +9455,12 @@
           },
           "taskStatus": {
             "type": "string"
+          },
+          "edgeId": {
+            "type": "string"
+          },
+          "edgeCondition": {
+            "type": "string"
           }
         }
       },

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -5798,6 +5798,13 @@
           "outputSchema": {
             "description": "Schema defining form fields for human response (JSON string)",
             "type": "string"
+          },
+          "workflowRunId": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "nodeId": {
+            "type": "string"
           }
         }
       },
@@ -9302,6 +9309,13 @@
           "output": {
             "type": "object",
             "additionalProperties": {}
+          },
+          "taskId": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "taskStatus": {
+            "type": "string"
           }
         }
       },
@@ -9367,6 +9381,14 @@
           },
           "completedOn": {
             "format": "date-time",
+            "type": "string"
+          },
+          "runId": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "traceId": {
+            "format": "uuid",
             "type": "string"
           }
         }

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -5161,7 +5161,225 @@
         }
       ]
     },
-    "/workflow-definitions": {
+    "/workflow/definitions/{workflowDefinitionId}/versions/{version}": {
+      "get": {
+        "tags": [
+          "WorkflowDefinitions"
+        ],
+        "summary": "Get a specific version",
+        "operationId": "getWorkflowDefinitionVersion",
+        "responses": {
+          "200": {
+            "description": "The workflow definition version",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowDefinitionVersion"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/WorkflowDefinitionId"
+        },
+        {
+          "name": "version",
+          "in": "path",
+          "description": "Version number",
+          "required": true,
+          "schema": {
+            "format": "int32",
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/workflow/definitions/{workflowDefinitionId}/versions": {
+      "get": {
+        "tags": [
+          "WorkflowDefinitions"
+        ],
+        "summary": "List all published versions",
+        "operationId": "listWorkflowDefinitionVersions",
+        "responses": {
+          "200": {
+            "description": "List of published versions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkflowDefinitionVersion"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/WorkflowDefinitionId"
+        }
+      ]
+    },
+    "/workflow/definitions/{workflowDefinitionId}/publish": {
+      "post": {
+        "tags": [
+          "WorkflowDefinitions"
+        ],
+        "summary": "Publish current draft as a new version",
+        "operationId": "publishWorkflowDefinition",
+        "responses": {
+          "200": {
+            "description": "New version published",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowDefinitionVersion"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/WorkflowDefinitionId"
+        }
+      ]
+    },
+    "/workflow/definitions/{workflowDefinitionId}/content": {
+      "put": {
+        "tags": [
+          "WorkflowDefinitions"
+        ],
+        "summary": "Update draft workflow content",
+        "operationId": "updateWorkflowDefinitionContent",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Content updated"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/WorkflowDefinitionId"
+        }
+      ]
+    },
+    "/workflow/definitions/{workflowDefinitionId}": {
+      "get": {
+        "tags": [
+          "WorkflowDefinitions"
+        ],
+        "summary": "Get a workflow definition",
+        "operationId": "getWorkflowDefinition",
+        "responses": {
+          "200": {
+            "description": "The workflow definition",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowDefinition"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "WorkflowDefinitions"
+        ],
+        "summary": "Update workflow definition metadata",
+        "operationId": "updateWorkflowDefinition",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateWorkflowDefinition"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Workflow definition updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowDefinition"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "WorkflowDefinitions"
+        ],
+        "summary": "Delete a workflow definition",
+        "operationId": "deleteWorkflowDefinition",
+        "responses": {
+          "204": {
+            "description": "Workflow definition deleted"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/WorkflowDefinitionId"
+        }
+      ]
+    },
+    "/workflow/definitions": {
       "get": {
         "tags": [
           "WorkflowDefinitions"
@@ -5242,141 +5460,20 @@
         }
       }
     },
-    "/workflow-definitions/{workflowDefinitionId}": {
+    "/workflow/runs/{runId}": {
       "get": {
         "tags": [
-          "WorkflowDefinitions"
+          "WorkflowRuns"
         ],
-        "summary": "Get a workflow definition",
-        "operationId": "getWorkflowDefinition",
+        "summary": "Get a single workflow run by ID",
+        "operationId": "getWorkflowRun",
         "responses": {
           "200": {
-            "description": "The workflow definition",
+            "description": "The workflow run",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/WorkflowDefinition"
-                }
-              }
-            }
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "WorkflowDefinitions"
-        ],
-        "summary": "Update workflow definition metadata",
-        "operationId": "updateWorkflowDefinition",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateWorkflowDefinition"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Workflow definition updated",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowDefinition"
-                }
-              }
-            }
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "WorkflowDefinitions"
-        ],
-        "summary": "Delete a workflow definition",
-        "operationId": "deleteWorkflowDefinition",
-        "responses": {
-          "204": {
-            "description": "Workflow definition deleted"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/WorkflowDefinitionId"
-        }
-      ]
-    },
-    "/workflow-definitions/{workflowDefinitionId}/content": {
-      "put": {
-        "tags": [
-          "WorkflowDefinitions"
-        ],
-        "summary": "Update draft workflow content",
-        "operationId": "updateWorkflowDefinitionContent",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "204": {
-            "description": "Content updated"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/WorkflowDefinitionId"
-        }
-      ]
-    },
-    "/workflow-definitions/{workflowDefinitionId}/publish": {
-      "post": {
-        "tags": [
-          "WorkflowDefinitions"
-        ],
-        "summary": "Publish current draft as a new version",
-        "operationId": "publishWorkflowDefinition",
-        "responses": {
-          "200": {
-            "description": "New version published",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowDefinitionVersion"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object"
-                  }
+                  "$ref": "#/components/schemas/WorkflowInstance"
                 }
               }
             }
@@ -5388,79 +5485,18 @@
       },
       "parameters": [
         {
-          "$ref": "#/components/parameters/WorkflowDefinitionId"
-        }
-      ]
-    },
-    "/workflow-definitions/{workflowDefinitionId}/versions": {
-      "get": {
-        "tags": [
-          "WorkflowDefinitions"
-        ],
-        "summary": "List all published versions",
-        "operationId": "listWorkflowDefinitionVersions",
-        "responses": {
-          "200": {
-            "description": "List of published versions",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/WorkflowDefinitionVersion"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/WorkflowDefinitionId"
-        }
-      ]
-    },
-    "/workflow-definitions/{workflowDefinitionId}/versions/{version}": {
-      "get": {
-        "tags": [
-          "WorkflowDefinitions"
-        ],
-        "summary": "Get a specific version",
-        "operationId": "getWorkflowDefinitionVersion",
-        "responses": {
-          "200": {
-            "description": "The workflow definition version",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowDefinitionVersion"
-                }
-              }
-            }
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/WorkflowDefinitionId"
-        },
-        {
-          "name": "version",
+          "name": "runId",
           "in": "path",
-          "description": "Version number",
+          "description": "Workflow run ID",
           "required": true,
           "schema": {
-            "format": "int32",
+            "format": "int64",
             "type": "integer"
           }
         }
       ]
     },
-    "/workflow-runs": {
+    "/workflow/runs": {
       "get": {
         "tags": [
           "WorkflowRuns"
@@ -5512,42 +5548,6 @@
           }
         }
       }
-    },
-    "/workflow-runs/{runId}": {
-      "get": {
-        "tags": [
-          "WorkflowRuns"
-        ],
-        "summary": "Get a single workflow run by ID",
-        "operationId": "getWorkflowRun",
-        "responses": {
-          "200": {
-            "description": "The workflow run",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkflowInstance"
-                }
-              }
-            }
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      },
-      "parameters": [
-        {
-          "name": "runId",
-          "in": "path",
-          "description": "Workflow run ID",
-          "required": true,
-          "schema": {
-            "format": "int64",
-            "type": "integer"
-          }
-        }
-      ]
     }
   },
   "components": {

--- a/common/api/src/main/resources/openapi.json
+++ b/common/api/src/main/resources/openapi.json
@@ -5459,6 +5459,95 @@
           }
         }
       ]
+    },
+    "/workflow-runs": {
+      "get": {
+        "tags": [
+          "WorkflowRuns"
+        ],
+        "summary": "List workflow runs across all projects",
+        "operationId": "listWorkflowRuns",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "query",
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Filter by status (comma-separated)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of workflow runs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowRunSearchResults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workflow-runs/{runId}": {
+      "get": {
+        "tags": [
+          "WorkflowRuns"
+        ],
+        "summary": "Get a single workflow run by ID",
+        "operationId": "getWorkflowRun",
+        "responses": {
+          "200": {
+            "description": "The workflow run",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowInstance"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "runId",
+          "in": "path",
+          "description": "Workflow run ID",
+          "required": true,
+          "schema": {
+            "format": "int64",
+            "type": "integer"
+          }
+        }
+      ]
     }
   },
   "components": {
@@ -9404,6 +9493,72 @@
             "type": "integer"
           }
         }
+      },
+      "WorkflowRunSummary": {
+        "type": "object",
+        "properties": {
+          "runId": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "projectId": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "projectName": {
+            "type": "string"
+          },
+          "definitionId": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "definitionName": {
+            "type": "string"
+          },
+          "definitionVersion": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "status": {
+            "type": "string"
+          },
+          "currentNodeName": {
+            "type": "string"
+          },
+          "traceId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "startedOn": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "completedOn": {
+            "format": "date-time",
+            "type": "string"
+          }
+        }
+      },
+      "WorkflowRunSearchResults": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkflowRunSummary"
+            }
+          },
+          "totalCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "page": {
+            "type": "integer"
+          },
+          "limit": {
+            "type": "integer"
+          }
+        }
       }
     },
     "responses": {
@@ -9553,6 +9708,10 @@
     {
       "name": "WorkflowInstances",
       "description": "Workflow instance execution and monitoring"
+    },
+    {
+      "name": "WorkflowRuns",
+      "description": "Workflow run history and execution observability"
     }
   ]
 }

--- a/core/src/main/java/io/apitomy/axiom/core/entities/TaskEntity.java
+++ b/core/src/main/java/io/apitomy/axiom/core/entities/TaskEntity.java
@@ -52,8 +52,12 @@ public class TaskEntity extends PanacheEntity {
     @Column(name = "session_id")
     public String sessionId;
 
-    @Column(name = "workflow_instance_id")
-    public Long workflowInstanceId;
+    @Column(name = "workflow_run_id")
+    public Long workflowRunId;
+
+    /** The workflow node id this task represents (null for non-workflow tasks). */
+    @Column(name = "node_id")
+    public String nodeId;
 
     /**
      * Structured context for human tasks: title, description, reference links.

--- a/core/src/main/java/io/apitomy/axiom/core/entities/WorkflowRunEntity.java
+++ b/core/src/main/java/io/apitomy/axiom/core/entities/WorkflowRunEntity.java
@@ -6,12 +6,17 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 
 import java.time.Instant;
+import java.util.UUID;
 
+/**
+ * A single execution (run) of a workflow definition against a project.
+ * Runs accumulate as history; at most one non-terminal run exists per project.
+ */
 @Entity
-@Table(name = "workflow_instance")
-public class WorkflowInstanceEntity extends PanacheEntity {
+@Table(name = "workflow_run")
+public class WorkflowRunEntity extends PanacheEntity {
 
-    @Column(name = "project_id", nullable = false, unique = true)
+    @Column(name = "project_id", nullable = false)
     public Long projectId;
 
     @Column(name = "definition_id", nullable = false)
@@ -31,6 +36,10 @@ public class WorkflowInstanceEntity extends PanacheEntity {
 
     @Column(name = "failure_reason", columnDefinition = "TEXT")
     public String failureReason;
+
+    /** Links this run to its execution trace; null if trace creation failed. */
+    @Column(name = "trace_id")
+    public UUID traceId;
 
     @Column(name = "started_on", nullable = false)
     public Instant startedOn;

--- a/core/src/main/java/io/apitomy/axiom/core/events/SseEvent.java
+++ b/core/src/main/java/io/apitomy/axiom/core/events/SseEvent.java
@@ -165,11 +165,22 @@ public record SseEvent(
     }
 
     /**
-     * Fires when a workflow instance changes state.
+     * Fires when a workflow run changes state.
+     *
+     * @param projectId the project the run belongs to
+     * @param runId the workflow run that changed (nullable)
+     * @param status the run status (nullable)
      */
-    public static SseEvent workflowUpdated(long projectId) {
-        return new SseEvent("workflow-updated",
-                "{\"projectId\":" + projectId + "}");
+    public static SseEvent workflowUpdated(long projectId, Long runId, String status) {
+        StringBuilder json = new StringBuilder("{\"projectId\":").append(projectId);
+        if (runId != null) {
+            json.append(",\"runId\":").append(runId);
+        }
+        if (status != null) {
+            json.append(",\"status\":\"").append(escapeJson(status)).append("\"");
+        }
+        json.append("}");
+        return new SseEvent("workflow-updated", json.toString());
     }
 
     /**

--- a/docs/superpowers/plans/2026-08-27-workflow-execution-observability.md
+++ b/docs/superpowers/plans/2026-08-27-workflow-execution-observability.md
@@ -1,0 +1,2287 @@
+# Workflow Execution Observability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user review a workflow execution — live and after completion — with per-run history, a
+node→task→execution-log drill-down, and the full agent-activity trace, surfaced on the project page and
+in a new **Logs → Workflow Runs** area.
+
+**Architecture:** A renamed run-history table (`workflow_run`) is the source of truth for run
+identity/status, wired into the existing tracing subsystem so the deep tool-call drill-down comes for
+free. Each run gets a trace root; each workflow-spawned task gets a `trace_id`, a `node_id`, and a task
+trace node, so MCP tool calls nest automatically. New contract-first REST endpoints expose run identity
+and the node→task→trace linkage; new React pages render the list and a tabbed run-detail view.
+
+**Tech Stack:** Java 25 / Quarkus 3.33 (Panache, Hibernate ORM, Flyway, JAX-RS generated from
+`openapi.json`), `apitomy-flow-engine` 1.0.1, React 19 / PatternFly 6 / Vite, `@apitomy/flow-ui`,
+`@xyflow/react`.
+
+**Spec:** `docs/superpowers/specs/2026-08-27-workflow-execution-observability-design.md`
+
+## Global Constraints
+
+These apply to **every** task. Copied verbatim from the user's standing rules and the spec.
+
+- **Contract-first:** All REST changes start in `common/api/src/main/resources/openapi.json`. Prefer the
+  **apicurio-data-models MCP tools** for every edit to that file. JAX-RS interfaces and beans regenerate
+  from the spec into `common/api/target/generated-sources/jaxrs/`.
+- **Never add `@Path` on impl classes** — paths come from the generated interface. Impls `implement` the
+  generated interface and use generated beans from `io.apitomy.axiom.api.beans` (never raw `JsonNode`).
+- **The developer runs all builds and tests manually.** Do **NOT** auto-run `mvn`/`./build.sh` or the
+  test suite. Every "verify" step below is a **developer checkpoint**: pause and ask the user to build
+  (`./build.sh` — regenerates beans), run the named test, or exercise the UI, then report back. Do not
+  invoke Maven yourself.
+- **Serena is not activated** in this session; do not activate/onboard it. Prefer Serena symbolic tools
+  only if the user has activated the project; otherwise use `Edit`/`Write`.
+- **Java style:** 4-space indent, explicit types (avoid ambiguous `var`), Javadoc on public methods,
+  camelCase vars / PascalCase classes, functional style (streams/lambdas) where it reads well. Tests are
+  JUnit 5 (`@QuarkusTest` + RestAssured, black-box HTTP — model on `WorkflowInstanceResourceTest`).
+- **Markdown** wraps at 110 chars (except tables/structured content).
+- **Git:** never include Claude attribution in commit messages or PR descriptions. Branch:
+  `feat/workflow-execution-observability`. Commit after each task.
+- **Upstream known limitation:** run *status* is derived from the engine instance; until
+  [apitomy-flow#38](https://github.com/Apitomy/apitomy-flow/issues/38) is fixed and a new Flow is
+  released, a failed node still yields a "completed" run badge. The failed task and its trace node are
+  recorded truthfully, so drill-down stays honest. Do not duplicate engine logic in Axiom to work around
+  this.
+
+---
+
+## File Structure
+
+**Backend — create:**
+- `app/src/main/resources/db/migration/V54__rename_workflow_instance_to_run.sql` — schema migration.
+- `app/src/main/java/io/apitomy/axiom/app/rest/WorkflowRunsResourceImpl.java` — new `/workflow-runs`
+  resource (list + get-by-id).
+- `app/src/test/java/io/apitomy/axiom/app/WorkflowRunsResourceTest.java` — run-history + REST tests.
+
+**Backend — rename/modify:**
+- `core/.../entities/WorkflowInstanceEntity.java` → **`WorkflowRunEntity.java`** (`@Table("workflow_run")`,
+  drop `unique`, add `traceId`).
+- `core/.../entities/TaskEntity.java` — `workflowInstanceId` → **`workflowRunId`**; add **`nodeId`**.
+- `core/.../events/SseEvent.java` — enrich `workflowUpdated`.
+- `app/.../WorkflowExecutionService.java` — lifecycle + trace wiring; all entity references.
+- `app/.../TaskExecutionService.java` — field rename; defer trace completion for workflow tasks.
+- `app/.../rest/ProjectsResourceImpl.java` — enrich `toWorkflowInstanceBean` (latest run + history
+  taskId/taskStatus); entity references.
+- `app/.../rest/WorkflowDefinitionsResourceImpl.java` — add `listWorkflowDefinitionRuns`.
+- `common/api/src/main/resources/openapi.json` — schemas, paths, tag.
+
+**Frontend — create:**
+- `ui/src/pages/WorkflowRunsPage.tsx` — runs list.
+- `ui/src/pages/WorkflowRunDetailPage.tsx` — tabbed run detail.
+- `ui/src/components/WorkflowStepTimeline.tsx` — shared step-timeline component.
+
+**Frontend — modify:**
+- `ui/src/config/api.ts` — types + fetch functions; enrich existing workflow types.
+- `ui/src/App.tsx` — two routes.
+- `ui/src/components/AppSidebar.tsx` — "Workflow Runs" nav item.
+- `ui/src/components/WorkflowTab.tsx` — "View run details →" link.
+
+**Side-deliverable:** GitHub issues on `Apitomy/apitomy-flow` for the flow-ui node-click callback and
+history `edgeId`/`edgeCondition` exposure (Task 19).
+
+---
+
+## Phase 1 — Data Model & Entity Rename
+
+### Task 1: Flyway migration V54 (rename table, add columns, run history)
+
+**Files:**
+- Create: `app/src/main/resources/db/migration/V54__rename_workflow_instance_to_run.sql`
+- Reference (do not edit): `app/src/main/resources/db/migration/V53__create_workflow_instance.sql`
+
+**Interfaces:**
+- Produces: table `workflow_run` (no `UNIQUE(project_id)`, new `trace_id UUID`), sequence
+  `workflow_run_SEQ`, index `idx_wf_run_project_started`, `task.workflow_run_id`, `task.node_id`.
+
+- [ ] **Step 1: Write the migration**
+
+Create `app/src/main/resources/db/migration/V54__rename_workflow_instance_to_run.sql`:
+
+```sql
+-- Rename the single-instance-per-project table into a run-history table.
+ALTER TABLE workflow_instance RENAME TO workflow_run;
+
+-- Many runs per project: drop the uniqueness constraint on project_id.
+-- V53 created it inline, so Postgres named it workflow_instance_project_id_key.
+ALTER TABLE workflow_run DROP CONSTRAINT IF EXISTS workflow_instance_project_id_key;
+
+-- Link a run to its execution trace (nullable; trace creation is best-effort).
+ALTER TABLE workflow_run ADD COLUMN trace_id UUID;
+
+-- Rename the Hibernate sequence to match the new table name.
+ALTER SEQUENCE IF EXISTS workflow_instance_SEQ RENAME TO workflow_run_SEQ;
+
+-- Replace the status-only index with one that supports latest-run and
+-- per-project history queries.
+DROP INDEX IF EXISTS idx_wf_instance_status;
+CREATE INDEX idx_wf_run_project_started ON workflow_run(project_id, started_on DESC);
+CREATE INDEX idx_wf_run_status ON workflow_run(status);
+
+-- Task → run linkage rename, plus the node this task represents.
+ALTER TABLE task RENAME COLUMN workflow_instance_id TO workflow_run_id;
+ALTER TABLE task ADD COLUMN node_id VARCHAR(255);
+```
+
+- [ ] **Step 2: Developer checkpoint — verify migration applies**
+
+Ask the developer to start the app (dev mode) or run the migration so Flyway applies V54, and confirm
+there are no errors and the schema reflects `workflow_run` + new columns. Do **not** run Maven yourself.
+Expected: app boots; `\d workflow_run` shows `trace_id`, no unique on `project_id`; `\d task` shows
+`workflow_run_id` and `node_id`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/resources/db/migration/V54__rename_workflow_instance_to_run.sql
+git commit -m "feat(db): migrate workflow_instance to workflow_run history table"
+```
+
+---
+
+### Task 2: Rename entity + task fields
+
+Renames `WorkflowInstanceEntity` → `WorkflowRunEntity`, adds `traceId`, and renames/extends the task
+linkage fields. This task deliberately leaves the codebase **non-compiling** until Task 3 updates the
+references — they are one reviewable unit (entity shape) but split so a reviewer can gate the schema
+mapping independently. Execute Task 2 and Task 3 back-to-back before the compile checkpoint.
+
+**Files:**
+- Rename: `core/src/main/java/io/apitomy/axiom/core/entities/WorkflowInstanceEntity.java` →
+  `core/src/main/java/io/apitomy/axiom/core/entities/WorkflowRunEntity.java`
+- Modify: `core/src/main/java/io/apitomy/axiom/core/entities/TaskEntity.java`
+
+**Interfaces:**
+- Produces: class `WorkflowRunEntity extends PanacheEntity` with public fields `projectId`,
+  `definitionId`, `definitionVersion`, `instanceState`, `status`, `currentNodeId`, `failureReason`,
+  `startedOn`, `completedOn`, and new `public java.util.UUID traceId`. `TaskEntity.workflowRunId`
+  (was `workflowInstanceId`) and new `public String nodeId`.
+
+- [ ] **Step 1: Create `WorkflowRunEntity.java`**
+
+Create `core/src/main/java/io/apitomy/axiom/core/entities/WorkflowRunEntity.java` (delete the old
+`WorkflowInstanceEntity.java` after):
+
+```java
+package io.apitomy.axiom.core.entities;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * A single execution (run) of a workflow definition against a project.
+ * Runs accumulate as history; at most one non-terminal run exists per project.
+ */
+@Entity
+@Table(name = "workflow_run")
+public class WorkflowRunEntity extends PanacheEntity {
+
+    @Column(name = "project_id", nullable = false)
+    public Long projectId;
+
+    @Column(name = "definition_id", nullable = false)
+    public Long definitionId;
+
+    @Column(name = "definition_version", nullable = false)
+    public int definitionVersion;
+
+    @Column(name = "instance_state", columnDefinition = "TEXT", nullable = false)
+    public String instanceState;
+
+    @Column(length = 20, nullable = false)
+    public String status;
+
+    @Column(name = "current_node_id")
+    public String currentNodeId;
+
+    @Column(name = "failure_reason", columnDefinition = "TEXT")
+    public String failureReason;
+
+    /** Links this run to its execution trace; null if trace creation failed. */
+    @Column(name = "trace_id")
+    public UUID traceId;
+
+    @Column(name = "started_on", nullable = false)
+    public Instant startedOn;
+
+    @Column(name = "completed_on")
+    public Instant completedOn;
+}
+```
+
+- [ ] **Step 2: Delete the old entity file**
+
+```bash
+git rm core/src/main/java/io/apitomy/axiom/core/entities/WorkflowInstanceEntity.java
+```
+
+- [ ] **Step 3: Rename + extend the task linkage fields**
+
+In `core/src/main/java/io/apitomy/axiom/core/entities/TaskEntity.java`, replace the
+`workflow_instance_id` field (currently lines 55-56) with:
+
+```java
+    @Column(name = "workflow_run_id")
+    public Long workflowRunId;
+
+    /** The workflow node id this task represents (null for non-workflow tasks). */
+    @Column(name = "node_id")
+    public String nodeId;
+```
+
+- [ ] **Step 4: (Checkpoint deferred to Task 3)** — the project will not compile until references are
+  updated. Proceed directly to Task 3.
+
+---
+
+### Task 3: Update all references to the renamed entity/fields
+
+**Files:**
+- Modify: `app/src/main/java/io/apitomy/axiom/app/WorkflowExecutionService.java`
+- Modify: `app/src/main/java/io/apitomy/axiom/app/TaskExecutionService.java`
+- Modify: `app/src/main/java/io/apitomy/axiom/app/rest/ProjectsResourceImpl.java`
+- (Search the whole repo for any other `WorkflowInstanceEntity` / `workflowInstanceId` usages.)
+
+**Interfaces:**
+- Consumes: `WorkflowRunEntity`, `TaskEntity.workflowRunId`, `TaskEntity.nodeId` (Task 2).
+- Produces: a compiling backend with all references migrated. Behavior unchanged in this task except the
+  identifier rename.
+
+- [ ] **Step 1: Update `WorkflowExecutionService.java`**
+
+Replace the import (line 9) `import io.apitomy.axiom.core.entities.WorkflowInstanceEntity;` with:
+
+```java
+import io.apitomy.axiom.core.entities.WorkflowRunEntity;
+```
+
+Then replace every `WorkflowInstanceEntity` type reference in the file with `WorkflowRunEntity`, and
+every `task.workflowInstanceId` with `task.workflowRunId`. Concretely, these sites (as of the current
+file): the `triggerWorkflow` `existing`/insert block, `onTaskCompleted` (`task.workflowInstanceId`
+guard at ~line 159 and the `WorkflowInstanceEntity entity = ... .findById(task.workflowInstanceId)` at
+~line 164), `cancelWorkflow` (~line 210), `createTaskForCurrentNode` (`task.workflowInstanceId =
+entity.id` at ~line 266 becomes `task.workflowRunId = entity.id`), and `persistInstanceState`
+signatures. Do a file-wide find/replace of the two identifiers; leave the flow-engine
+`WorkflowInstance` (from `io.apitomy.flow.model`) untouched — only the Axiom entity is renamed.
+
+- [ ] **Step 2: Update `TaskExecutionService.java` references**
+
+Replace both `task.workflowInstanceId != null` guards (in `onTaskCompleted` ~line 469 and `failTask`
+~line 491) with `task.workflowRunId != null`. Leave the `workflowExecutionService.onTaskCompleted(...)`
+calls as-is.
+
+- [ ] **Step 3: Update `ProjectsResourceImpl.java` references**
+
+Replace the `WorkflowInstanceEntity` import and all type references (in `getProjectWorkflowInstance`
+~line 527 and `toWorkflowInstanceBean` ~line 540) with `WorkflowRunEntity`. Leave the API bean type
+`io.apitomy.axiom.api.beans.WorkflowInstance` and the flow-model `WorkflowInstance` untouched.
+
+- [ ] **Step 4: Sweep for stragglers**
+
+Search the repo for remaining `WorkflowInstanceEntity` and `workflowInstanceId` identifiers and update
+any found (e.g. other resources, tests). Use Grep:
+
+```
+Grep pattern: WorkflowInstanceEntity|workflowInstanceId
+```
+
+Update each hit to `WorkflowRunEntity` / `workflowRunId`. Update `WorkflowInstanceResourceTest` only for
+identifiers if it references the entity directly (it is black-box HTTP, so likely no change needed).
+
+- [ ] **Step 5: Developer checkpoint — compile**
+
+Ask the developer to build (`./build.sh`) and confirm the project compiles with no unresolved
+`WorkflowInstanceEntity`/`workflowInstanceId` references. Expected: clean compile; existing
+`WorkflowInstanceResourceTest` still passes (behavior unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "refactor: rename WorkflowInstanceEntity to WorkflowRunEntity and task linkage fields"
+```
+
+---
+
+## Phase 2 — Run Lifecycle & Trace Wiring
+
+### Task 4: Allow run history; create a trace root on trigger
+
+**Files:**
+- Modify: `app/src/main/java/io/apitomy/axiom/app/WorkflowExecutionService.java`
+- Test: `app/src/test/java/io/apitomy/axiom/app/WorkflowRunsResourceTest.java` (created here, extended
+  later)
+
+**Interfaces:**
+- Consumes: `TraceService.createTrace(traceType, summary, eventId, projectId, reportId, rootNodeType,
+  rootNodeSummary, rootEntityType, rootEntityId)` → `TraceContext` with `traceId()`; `WorkflowRunEntity`.
+- Produces: `triggerWorkflow` inserts a new run each call (409 only when an **active** run exists) and
+  stores `run.traceId`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `app/src/test/java/io/apitomy/axiom/app/WorkflowRunsResourceTest.java`. Model setup helpers on
+`WorkflowInstanceResourceTest` (`createProject`, `createAndPublishDefinition`,
+`createAndPublishActionWorkflow`). Add this first test:
+
+```java
+package io.apitomy.axiom.app;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+@QuarkusTest
+class WorkflowRunsResourceTest {
+
+    private static final String PROJECTS_PATH = "/api/v1/projects";
+    private static final String WORKFLOWS_PATH = "/api/v1/workflow-definitions";
+
+    @Test
+    void triggeringActionWorkflowStoresTraceId() {
+        int projectId = createProject("WF Trace Project");
+        int definitionId = createAndPublishActionWorkflow("Trace WF");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"workflowDefinitionId\": %d}".formatted(definitionId))
+                .when()
+                    .post(PROJECTS_PATH + "/" + projectId + "/workflow")
+                .then()
+                    .statusCode(200)
+                    .body("status", equalTo("waiting"))
+                    .body("traceId", notNullValue());
+    }
+
+    // --- helpers copied/adapted from WorkflowInstanceResourceTest ---
+    // createProject(name), createDefinition(name),
+    // createAndPublishActionWorkflow(name)
+}
+```
+
+Copy the `createProject`, `createDefinition`, and `createAndPublishActionWorkflow` private helpers
+verbatim from `WorkflowInstanceResourceTest` into this class. (The `traceId` assertion requires the
+openapi `WorkflowInstance.traceId` property added in Task 9 to be returned — if running this test before
+Task 9/12, assert only `status`; add the `traceId` assertion once Task 12 is done. Note this dependency
+in the commit.)
+
+- [ ] **Step 2: Developer checkpoint — verify it fails**
+
+Ask the developer to run `WorkflowRunsResourceTest#triggeringActionWorkflowStoresTraceId`. Expected:
+FAIL — `traceId` is null (not yet created/returned).
+
+- [ ] **Step 3: Inject `TraceService` and relax the active-run guard**
+
+In `WorkflowExecutionService.java`, add the import and injection:
+
+```java
+import io.apitomy.axiom.core.tracing.TraceService;
+import io.apitomy.axiom.core.tracing.TraceContext;
+```
+
+```java
+    @Inject
+    TraceService traceService;
+```
+
+Replace the existing single-instance guard in `triggerWorkflow` (current lines 81-86) with an
+active-run guard:
+
+```java
+        WorkflowRunEntity activeRun = WorkflowRunEntity
+                .find("projectId = ?1 and status in ?2",
+                        projectId, List.of("running", "waiting"))
+                .firstResult();
+        if (activeRun != null) {
+            throw new WebApplicationException(
+                    "Project already has an active workflow run", 409);
+        }
+```
+
+- [ ] **Step 4: Create the trace root after the run entity is persisted**
+
+In `triggerWorkflow`, immediately after the `WorkflowRunEntity` is persisted (find the existing
+`entity.persist()` call that saves the new run — it is after `persistInstanceState` and before
+`createTaskForCurrentNode`), add best-effort trace creation:
+
+```java
+        try {
+            TraceContext traceCtx = traceService.createTrace(
+                    "workflow",
+                    "Workflow: " + definition.name,
+                    null, project.id, null,
+                    "workflow", "Workflow: " + definition.name,
+                    "workflow-run", entity.id);
+            entity.traceId = traceCtx.traceId();
+        } catch (Exception e) {
+            LOG.warnf(e, "Failed to create trace for workflow run %d", entity.id);
+        }
+```
+
+> Note: `entity.traceId` is set on the managed entity within the `@Transactional` method, so it flushes
+> without an explicit update. `TraceService` runs in `requiringNew()`, so a trace failure does not roll
+> back the run.
+
+- [ ] **Step 5: Developer checkpoint — verify it passes**
+
+Ask the developer to build (`./build.sh`, regenerates the `traceId` bean field from Task 9) then run the
+test. Expected: PASS once Tasks 9 & 12 are also in place. If sequencing strictly, land Step 3-4 now and
+flip the `traceId` assertion on after Task 12.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/io/apitomy/axiom/app/WorkflowExecutionService.java \
+        app/src/test/java/io/apitomy/axiom/app/WorkflowRunsResourceTest.java
+git commit -m "feat: allow workflow run history and create a trace root per run"
+```
+
+---
+
+### Task 5: Wire the node task into the trace (traceId, nodeId, task node)
+
+**Files:**
+- Modify: `app/src/main/java/io/apitomy/axiom/app/WorkflowExecutionService.java`
+- Test: `app/src/test/java/io/apitomy/axiom/app/WorkflowRunsResourceTest.java`
+
+**Interfaces:**
+- Consumes: `TraceService.addNode(TraceContext ctx, String nodeType, String status, String summary,
+  String entityType, Long entityId)` → `Long` (node id). `TraceContext(UUID traceId, Long rootNodeId)`.
+- Produces: each workflow node-task carries `workflowRunId`, `nodeId`, `traceId`, and has a matching
+  `"task"` trace node under the run root (so `TaskExecutionService` injects `AXIOM_TRACE_ID` /
+  `AXIOM_PARENT_NODE_ID` generically).
+
+The trace root node id is not persisted on the run; reconstruct the `TraceContext` from `run.traceId`
+plus a lookup of the root node. Add a private helper.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `WorkflowRunsResourceTest`:
+
+```java
+    @Test
+    void nodeTaskCarriesRunNodeAndTrace() {
+        int projectId = createProject("WF Node Task Project");
+        int definitionId = createAndPublishActionWorkflow("Node Task WF");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"workflowDefinitionId\": %d}".formatted(definitionId))
+                .when()
+                    .post(PROJECTS_PATH + "/" + projectId + "/workflow")
+                .then()
+                    .statusCode(200)
+                    .body("status", equalTo("waiting"));
+
+        // The spawned action task should expose its nodeId and workflowRunId.
+        given()
+                .when()
+                    .get(PROJECTS_PATH + "/" + projectId + "/tasks")
+                .then()
+                    .statusCode(200)
+                    .body("[0].nodeId", notNullValue())
+                    .body("[0].workflowRunId", notNullValue())
+                    .body("[0].traceId", notNullValue());
+    }
+```
+
+> This relies on the `Task` bean gaining `nodeId` / `workflowRunId` (Task 9) and the tasks-list endpoint
+> mapping them (verify `ProjectsResourceImpl` task mapping sets these — add if missing in Task 9 wiring).
+> If the tasks-list order is not guaranteed, adjust the matcher to `find`/`hasItem`.
+
+- [ ] **Step 2: Developer checkpoint — verify it fails**
+
+Ask the developer to run `nodeTaskCarriesRunNodeAndTrace`. Expected: FAIL — `nodeId`/`traceId` null on
+the task.
+
+- [ ] **Step 3: Add a `TraceContext` reconstruction helper**
+
+In `WorkflowExecutionService.java` add:
+
+```java
+    /**
+     * Rebuilds a {@link TraceContext} rooted at a run's trace root node, or
+     * null if the run has no trace or the root cannot be found.
+     */
+    private TraceContext traceContextFor(WorkflowRunEntity run) {
+        if (run.traceId == null) {
+            return null;
+        }
+        io.apitomy.axiom.core.entities.TraceNodeEntity root =
+                io.apitomy.axiom.core.entities.TraceNodeEntity.find(
+                        "traceId = ?1 and parentNodeId is null", run.traceId)
+                        .firstResult();
+        if (root == null) {
+            return null;
+        }
+        return new TraceContext(run.traceId, root.id);
+    }
+```
+
+- [ ] **Step 4: Stamp the task and add its trace node in `createTaskForCurrentNode`**
+
+In `createTaskForCurrentNode`, set the new fields before `task.persist()` (the method currently sets
+`task.workflowInstanceId = entity.id` — already renamed to `workflowRunId` in Task 3):
+
+```java
+        task.workflowRunId = entity.id;
+        task.nodeId = instance.currentNodeId();
+        task.traceId = entity.traceId;
+```
+
+Then, after `task.persist()`, add the task trace node (mirroring
+`PipelineOrchestrator.handleCreateTask`):
+
+```java
+        TraceContext traceCtx = traceContextFor(entity);
+        if (traceCtx != null) {
+            try {
+                traceService.addNode(traceCtx, "task", "in-progress",
+                        "Node: " + actionInfo.actionType(), "task", task.id);
+            } catch (Exception e) {
+                LOG.warnf(e, "Failed to add workflow task trace node");
+            }
+        }
+```
+
+- [ ] **Step 5: Developer checkpoint — verify it passes**
+
+Ask the developer to build and run `nodeTaskCarriesRunNodeAndTrace`. Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/io/apitomy/axiom/app/WorkflowExecutionService.java \
+        app/src/test/java/io/apitomy/axiom/app/WorkflowRunsResourceTest.java
+git commit -m "feat: stamp workflow node tasks with run/node/trace and add task trace node"
+```
+
+---
+
+### Task 6: Complete the trace and set completedOn on terminal runs
+
+**Files:**
+- Modify: `app/src/main/java/io/apitomy/axiom/app/WorkflowExecutionService.java`
+
+**Interfaces:**
+- Consumes: `TraceService.completeTrace(UUID traceId, String status)`.
+- Produces: `onTaskCompleted` and `cancelWorkflow` call `completeTrace` when the run reaches a terminal
+  state; `completedOn` is already set in those branches.
+
+- [ ] **Step 1: Complete the trace in `onTaskCompleted` terminal branches**
+
+In `onTaskCompleted`, the COMPLETED and FAILED branches already set `entity.completedOn`. Add trace
+completion. Replace the `advanced.status() == InstanceStatus.COMPLETED` and `== InstanceStatus.FAILED`
+branches (current lines 190-200) with:
+
+```java
+        } else if (advanced.status() == InstanceStatus.COMPLETED) {
+            entity.completedOn = Instant.now();
+            completeRunTrace(entity, "completed");
+            logActivity(entity.projectId, "workflow-completed",
+                    "Workflow completed");
+        } else if (advanced.status() == InstanceStatus.FAILED) {
+            entity.completedOn = Instant.now();
+            completeRunTrace(entity, "failed");
+            logActivity(entity.projectId, "workflow-failed",
+                    "Workflow failed: " + advanced.failureReason());
+            sseEvents.fire(SseEvent.notification(
+                    "Workflow failed for project", "error"));
+        }
+```
+
+- [ ] **Step 2: Complete the trace in `cancelWorkflow`**
+
+In `cancelWorkflow`, after `entity.completedOn = Instant.now();` (current line 231) add:
+
+```java
+        completeRunTrace(entity, "cancelled");
+```
+
+- [ ] **Step 3: Add the `completeRunTrace` helper**
+
+```java
+    /** Best-effort completion of a run's execution trace. */
+    private void completeRunTrace(WorkflowRunEntity run, String status) {
+        if (run.traceId == null) {
+            return;
+        }
+        try {
+            traceService.completeTrace(run.traceId, status);
+        } catch (Exception e) {
+            LOG.warnf(e, "Failed to complete trace for workflow run %d", run.id);
+        }
+    }
+```
+
+- [ ] **Step 4: Developer checkpoint**
+
+Ask the developer to build. Behavior verified end-to-end after Task 7 (which stops premature trace
+completion). No standalone test here; covered by Task 7's test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/io/apitomy/axiom/app/WorkflowExecutionService.java
+git commit -m "feat: complete workflow run trace when the run reaches a terminal state"
+```
+
+---
+
+### Task 7: Stop TaskExecutionService from prematurely completing workflow traces
+
+`TaskExecutionService.onTaskCompleted` unconditionally calls `traceService.completeTrace(task.traceId,
+...)` for any traced task. A workflow shares one trace across many node-tasks, so this would finalize the
+run's trace after the first node. Workflow tasks must complete only their **node**, deferring trace
+completion to `WorkflowExecutionService` (Task 6).
+
+**Files:**
+- Modify: `app/src/main/java/io/apitomy/axiom/app/TaskExecutionService.java`
+- Test: `app/src/test/java/io/apitomy/axiom/app/WorkflowRunsResourceTest.java`
+
+**Interfaces:**
+- Consumes: `TaskEntity.workflowRunId`; existing generic task-node lookup by `traceId`/`entityId`.
+- Produces: for tasks with `workflowRunId != null`, the task **node** is completed but the **trace** is
+  not; non-workflow tasks are unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `WorkflowRunsResourceTest` a test that a multi-node run keeps its trace open until the run
+finishes. Use the two-action helper if available, or assert on trace status via the traces endpoint after
+the first node completes. Minimal version asserting the trace is not prematurely completed:
+
+```java
+    @Test
+    void runTraceStaysOpenUntilRunCompletes() {
+        int projectId = createProject("WF Trace Lifecycle Project");
+        int definitionId = createAndPublishActionWorkflow("Trace Lifecycle WF");
+
+        String traceId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"workflowDefinitionId\": %d}".formatted(definitionId))
+                .when()
+                    .post(PROJECTS_PATH + "/" + projectId + "/workflow")
+                .then()
+                    .statusCode(200)
+                    .extract().path("traceId");
+
+        // While the single action node is still waiting, its trace must be
+        // in-progress (not completed).
+        given()
+                .when()
+                    .get("/api/v1/traces/" + traceId)
+                .then()
+                    .statusCode(200)
+                    .body("trace.status", equalTo("in-progress"));
+    }
+```
+
+> Confirm the trace-detail endpoint path/shape (`GET /api/v1/traces/{traceId}` → `{ trace, nodes }`) and
+> the root trace initial status string (`createTrace` sets nodes; the trace's own status is its initial
+> value — verify whether it is `"in-progress"` and adjust the matcher). If the created trace's status is
+> a different initial string, assert `not(equalTo("completed"))` instead.
+
+- [ ] **Step 2: Developer checkpoint — verify it fails**
+
+Ask the developer to run `runTraceStaysOpenUntilRunCompletes`. Expected: FAIL — trace already
+`completed` because the task path finalized it.
+
+- [ ] **Step 3: Guard trace completion for workflow tasks**
+
+In `TaskExecutionService.onTaskCompleted` (the trace-finalization block, ~lines 443-458), keep the task
+**node** completion but skip `completeTrace` for workflow tasks. Replace the block with:
+
+```java
+        // Complete the trace (async traces are finalized here).
+        if (task.traceId != null) {
+            try {
+                // Complete the task node with final status.
+                TraceNodeEntity taskNode = TraceNodeEntity.find(
+                        "traceId = ?1 and nodeType = 'task' and entityType = 'task' and entityId = ?2",
+                        task.traceId, task.id).firstResult();
+                if (taskNode != null) {
+                    traceService.completeNode(taskNode.id, statusText);
+                }
+
+                // Workflow runs own their trace lifecycle: WorkflowExecutionService
+                // completes the trace when the run reaches a terminal state.
+                if (task.workflowRunId == null) {
+                    traceService.completeTrace(task.traceId,
+                            result.success() ? "completed" : "failed");
+                }
+            } catch (Exception e) {
+                LOG.warnf(e, "Failed to complete trace for task %d", task.id);
+            }
+        }
+```
+
+> `statusText` / `result` are the existing local variables in that method — keep whatever names the
+> current code uses; only the `if (task.workflowRunId == null)` guard around `completeTrace` is new.
+
+- [ ] **Step 4: Developer checkpoint — verify it passes**
+
+Ask the developer to build and run `runTraceStaysOpenUntilRunCompletes`. Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/io/apitomy/axiom/app/TaskExecutionService.java \
+        app/src/test/java/io/apitomy/axiom/app/WorkflowRunsResourceTest.java
+git commit -m "fix: defer workflow trace completion to the run lifecycle"
+```
+
+---
+
+### Task 8: Enrich the `workflow-updated` SSE event
+
+**Files:**
+- Modify: `core/src/main/java/io/apitomy/axiom/core/events/SseEvent.java`
+- Modify: `app/src/main/java/io/apitomy/axiom/app/WorkflowExecutionService.java`
+
+**Interfaces:**
+- Produces: `SseEvent.workflowUpdated(long projectId, Long runId, String status)` emitting
+  `{"projectId":…,"runId":…,"status":"…"}`. Existing `projectId`-only consumers keep working.
+
+- [ ] **Step 1: Replace `workflowUpdated` with the enriched overload**
+
+In `SseEvent.java`, replace the current `workflowUpdated(long projectId)` (lines 170-173) with:
+
+```java
+    /**
+     * Fires when a workflow run changes state.
+     *
+     * @param projectId the project the run belongs to
+     * @param runId the workflow run that changed (nullable)
+     * @param status the run status (nullable)
+     */
+    public static SseEvent workflowUpdated(long projectId, Long runId, String status) {
+        StringBuilder json = new StringBuilder("{\"projectId\":").append(projectId);
+        if (runId != null) {
+            json.append(",\"runId\":").append(runId);
+        }
+        if (status != null) {
+            json.append(",\"status\":\"").append(escapeJson(status)).append("\"");
+        }
+        json.append("}");
+        return new SseEvent("workflow-updated", json.toString());
+    }
+```
+
+- [ ] **Step 2: Update all firing sites in `WorkflowExecutionService`**
+
+Replace each `sseEvents.fire(SseEvent.workflowUpdated(entity.projectId))` /
+`...workflowUpdated(projectId))` call with the enriched form. In `onTaskCompleted` (line ~202):
+
+```java
+        sseEvents.fire(SseEvent.workflowUpdated(
+                entity.projectId, entity.id, entity.status));
+```
+
+In `cancelWorkflow` (line ~245):
+
+```java
+        sseEvents.fire(SseEvent.workflowUpdated(
+                entity.projectId, entity.id, entity.status));
+```
+
+Also update the firing site in `triggerWorkflow` (search for `workflowUpdated` there) to pass
+`entity.id` and `entity.status`. Sweep the repo for any other `workflowUpdated(` callers and update
+them.
+
+- [ ] **Step 3: Developer checkpoint — compile + existing tests**
+
+Ask the developer to build and run `WorkflowInstanceResourceTest` + `WorkflowRunsResourceTest`. Expected:
+compile clean; tests pass (the WorkflowTab consumer filters on `data.projectId`, still present).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/src/main/java/io/apitomy/axiom/core/events/SseEvent.java \
+        app/src/main/java/io/apitomy/axiom/app/WorkflowExecutionService.java
+git commit -m "feat: include runId and status in workflow-updated SSE events"
+```
+
+---
+
+## Phase 3 — API Surface (contract-first)
+
+> All openapi.json edits use the **apicurio-data-models MCP tools**. After each openapi task, the
+> developer runs `./build.sh` to regenerate beans/interfaces before impl code referencing them compiles.
+
+### Task 9: Enrich existing schemas (WorkflowInstance, HistoryEntry, Task)
+
+**Files:**
+- Modify: `common/api/src/main/resources/openapi.json`
+
+**Interfaces:**
+- Produces beans: `WorkflowInstance` gains `runId` (int64) and `traceId` (uuid); `HistoryEntry` gains
+  `taskId` (int64) and `taskStatus` (string); `Task` gains `workflowRunId` (int64) and `nodeId` (string).
+
+- [ ] **Step 1: Load the document**
+
+Use apicurio `document_load` on `common/api/src/main/resources/openapi.json`.
+
+- [ ] **Step 2: Add properties to `WorkflowInstance`**
+
+Using `document_add_schema_property` (or `document_set_node`), add to `WorkflowInstance`:
+
+```json
+"runId":   { "format": "int64", "type": "integer" },
+"traceId": { "format": "uuid", "type": "string" }
+```
+
+- [ ] **Step 3: Add properties to `HistoryEntry`**
+
+```json
+"taskId":     { "format": "int64", "type": "integer" },
+"taskStatus": { "type": "string" }
+```
+
+- [ ] **Step 4: Add properties to `Task`**
+
+```json
+"workflowRunId": { "format": "int64", "type": "integer" },
+"nodeId":        { "type": "string" }
+```
+
+- [ ] **Step 5: Save**
+
+Use apicurio `document_save`. Developer checkpoint: run `./build.sh` to regenerate beans.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add common/api/src/main/resources/openapi.json
+git commit -m "feat(api): add run/trace/node fields to workflow beans"
+```
+
+---
+
+### Task 10: Add WorkflowRun schemas, tag, and `/workflow-runs` paths
+
+**Files:**
+- Modify: `common/api/src/main/resources/openapi.json`
+
+**Interfaces:**
+- Produces schemas `WorkflowRunSummary` and `WorkflowRunSearchResults`; tag `WorkflowRuns`; paths
+  `GET /workflow-runs` (operationId `listWorkflowRuns`) and `GET /workflow-runs/{runId}` (operationId
+  `getWorkflowRun`, returns `WorkflowInstance`). Beans: `WorkflowRunSummary`,
+  `WorkflowRunSearchResults`, generated interface `WorkflowRunsResource`.
+
+- [ ] **Step 1: Add schema `WorkflowRunSummary`**
+
+```json
+"WorkflowRunSummary": {
+  "type": "object",
+  "properties": {
+    "runId":             { "format": "int64", "type": "integer" },
+    "projectId":         { "format": "int64", "type": "integer" },
+    "projectName":       { "type": "string" },
+    "definitionId":      { "format": "int64", "type": "integer" },
+    "definitionName":    { "type": "string" },
+    "definitionVersion": { "format": "int32", "type": "integer" },
+    "status":            { "type": "string" },
+    "currentNodeName":   { "type": "string" },
+    "traceId":           { "format": "uuid", "type": "string" },
+    "startedOn":         { "format": "date-time", "type": "string" },
+    "completedOn":       { "format": "date-time", "type": "string" }
+  }
+}
+```
+
+- [ ] **Step 2: Add schema `WorkflowRunSearchResults`** (mirrors `ScheduledJobRunSearchResults`)
+
+```json
+"WorkflowRunSearchResults": {
+  "type": "object",
+  "properties": {
+    "items":      { "type": "array", "items": { "$ref": "#/components/schemas/WorkflowRunSummary" } },
+    "totalCount": { "format": "int64", "type": "integer" },
+    "page":       { "type": "integer" },
+    "limit":      { "type": "integer" }
+  }
+}
+```
+
+- [ ] **Step 3: Add tag `WorkflowRuns`**
+
+Using `document_add_tag`: name `WorkflowRuns`, description `Workflow run history and execution
+observability`.
+
+- [ ] **Step 4: Add path `/workflow-runs`**
+
+`document_add_path` `/workflow-runs`, then add a GET operation (`document_add_operation`) with:
+
+```json
+{
+  "tags": ["WorkflowRuns"],
+  "summary": "List workflow runs across all projects",
+  "operationId": "listWorkflowRuns",
+  "parameters": [
+    { "name": "projectId", "in": "query", "schema": { "format": "int64", "type": "integer" } },
+    { "name": "status", "in": "query", "description": "Filter by status (comma-separated)", "schema": { "type": "string" } },
+    { "name": "page", "in": "query", "schema": { "type": "integer" } },
+    { "name": "limit", "in": "query", "schema": { "type": "integer" } }
+  ],
+  "responses": {
+    "200": {
+      "description": "Paginated list of workflow runs",
+      "content": { "application/json": { "schema": { "$ref": "#/components/schemas/WorkflowRunSearchResults" } } }
+    }
+  }
+}
+```
+
+- [ ] **Step 5: Add path `/workflow-runs/{runId}`**
+
+GET operation:
+
+```json
+{
+  "tags": ["WorkflowRuns"],
+  "summary": "Get a single workflow run by ID",
+  "operationId": "getWorkflowRun",
+  "responses": {
+    "200": {
+      "description": "The workflow run",
+      "content": { "application/json": { "schema": { "$ref": "#/components/schemas/WorkflowInstance" } } }
+    },
+    "404": { "$ref": "#/components/responses/NotFound" }
+  }
+}
+```
+
+Add the path-level `runId` parameter:
+
+```json
+{ "name": "runId", "in": "path", "description": "Workflow run ID", "required": true,
+  "schema": { "format": "int64", "type": "integer" } }
+```
+
+- [ ] **Step 6: Save + developer checkpoint**
+
+`document_save`; ask developer to run `./build.sh`. Expected: generated `WorkflowRunsResource` interface
+and `WorkflowRunSummary` / `WorkflowRunSearchResults` beans exist.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add common/api/src/main/resources/openapi.json
+git commit -m "feat(api): add /workflow-runs endpoints and run-summary schemas"
+```
+
+---
+
+### Task 11: Add `/workflow-definitions/{workflowDefinitionId}/runs`
+
+**Files:**
+- Modify: `common/api/src/main/resources/openapi.json`
+
+**Interfaces:**
+- Produces: GET `/workflow-definitions/{workflowDefinitionId}/runs` (operationId
+  `listWorkflowDefinitionRuns`) added to the existing `WorkflowResource` interface, returning
+  `WorkflowRunSearchResults`.
+
+- [ ] **Step 1: Add the path + operation**
+
+`document_add_path` `/workflow-definitions/{workflowDefinitionId}/runs`, GET operation:
+
+```json
+{
+  "tags": ["WorkflowDefinitions"],
+  "summary": "List runs for a specific workflow definition (all versions)",
+  "operationId": "listWorkflowDefinitionRuns",
+  "parameters": [
+    { "name": "status", "in": "query", "description": "Filter by status (comma-separated)", "schema": { "type": "string" } },
+    { "name": "page", "in": "query", "schema": { "type": "integer" } },
+    { "name": "limit", "in": "query", "schema": { "type": "integer" } }
+  ],
+  "responses": {
+    "200": {
+      "description": "Paginated list of runs for the definition",
+      "content": { "application/json": { "schema": { "$ref": "#/components/schemas/WorkflowRunSearchResults" } } }
+    }
+  }
+}
+```
+
+Add the path-level parameter referencing the existing `WorkflowDefinitionId`:
+
+```json
+{ "$ref": "#/components/parameters/WorkflowDefinitionId" }
+```
+
+- [ ] **Step 2: Save + developer checkpoint**
+
+`document_save`; developer runs `./build.sh`. Expected: `WorkflowResource` interface gains
+`listWorkflowDefinitionRuns`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add common/api/src/main/resources/openapi.json
+git commit -m "feat(api): add per-definition workflow runs endpoint"
+```
+
+---
+
+### Task 12: Enrich `toWorkflowInstanceBean` — latest run + history taskId/taskStatus
+
+**Files:**
+- Modify: `app/src/main/java/io/apitomy/axiom/app/rest/ProjectsResourceImpl.java`
+- Test: `app/src/test/java/io/apitomy/axiom/app/WorkflowRunsResourceTest.java`
+
+**Interfaces:**
+- Consumes: generated beans `WorkflowInstance.setRunId/setTraceId`, `HistoryEntry.setTaskId/setTaskStatus`;
+  `WorkflowRunEntity`, `TaskEntity.workflowRunId/nodeId`.
+- Produces: `getProjectWorkflowInstance` returns the **latest** run for the project; the bean carries
+  `runId`, `traceId`; each history entry carries `taskId`/`taskStatus` (joined on `node_id`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `WorkflowRunsResourceTest`:
+
+```java
+    @Test
+    void projectWorkflowReturnsLatestRunWithRunIdAndTrace() {
+        int projectId = createProject("WF Latest Run Project");
+        int definitionId = createAndPublishActionWorkflow("Latest Run WF");
+
+        int firstRunId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"workflowDefinitionId\": %d}".formatted(definitionId))
+                .when().post(PROJECTS_PATH + "/" + projectId + "/workflow")
+                .then().statusCode(200).extract().path("runId");
+
+        given()
+                .when()
+                    .get(PROJECTS_PATH + "/" + projectId + "/workflow")
+                .then()
+                    .statusCode(200)
+                    .body("runId", equalTo(firstRunId))
+                    .body("traceId", notNullValue());
+    }
+```
+
+- [ ] **Step 2: Developer checkpoint — verify it fails**
+
+Ask developer to run `projectWorkflowReturnsLatestRunWithRunIdAndTrace`. Expected: FAIL — `runId` null.
+
+- [ ] **Step 3: Return the latest run in `getProjectWorkflowInstance`**
+
+Replace the `find("projectId", projectId).firstResult()` lookup (line ~527) with the latest-by-start:
+
+```java
+        WorkflowRunEntity entity = WorkflowRunEntity
+                .find("projectId", io.quarkus.panache.common.Sort.descending("startedOn"),
+                        projectId)
+                .firstResult();
+```
+
+- [ ] **Step 4: Set `runId` and `traceId` in `toWorkflowInstanceBean`**
+
+In `toWorkflowInstanceBean`, after `bean.setId(entity.id);` add:
+
+```java
+        bean.setRunId(entity.id);
+        if (entity.traceId != null) {
+            bean.setTraceId(entity.traceId);
+        }
+```
+
+- [ ] **Step 5: Populate history `taskId`/`taskStatus` by joining tasks on `node_id`**
+
+The bean's history is built in `toWorkflowInstanceBean` from the flow-model history (lines ~595-596 map
+`flowInstance.history()` via `toHistoryEntryBean`). Before mapping, build a `nodeId → TaskEntity` map for
+this run and thread it into the mapping. Replace the history mapping with:
+
+```java
+            List<TaskEntity> runTasks = TaskEntity
+                    .<TaskEntity>find("workflowRunId", entity.id).list();
+            Map<String, TaskEntity> tasksByNode = runTasks.stream()
+                    .filter(t -> t.nodeId != null)
+                    .collect(java.util.stream.Collectors.toMap(
+                            t -> t.nodeId, t -> t, (a, b) -> b));
+            bean.setHistory(flowInstance.history().stream()
+                    .map(h -> toHistoryEntryBean(h, tasksByNode))
+                    .toList());
+```
+
+Update `toHistoryEntryBean` to accept the map and set the fields:
+
+```java
+    private io.apitomy.axiom.api.beans.HistoryEntry toHistoryEntryBean(
+            io.apitomy.flow.model.HistoryEntry entry,
+            Map<String, TaskEntity> tasksByNode) {
+        io.apitomy.axiom.api.beans.HistoryEntry bean =
+                new io.apitomy.axiom.api.beans.HistoryEntry();
+        bean.setNodeId(entry.nodeId());
+        bean.setNodeName(entry.nodeName());
+        if (entry.enteredOn() != null) {
+            bean.setEnteredOn(Date.from(entry.enteredOn()));
+        }
+        if (entry.completedOn() != null) {
+            bean.setCompletedOn(Date.from(entry.completedOn()));
+        }
+        if (entry.output() != null && !entry.output().isEmpty()) {
+            bean.setOutput(objectMapper.convertValue(
+                    entry.output(),
+                    io.apitomy.axiom.api.beans.Output.class));
+        }
+        TaskEntity task = entry.nodeId() != null
+                ? tasksByNode.get(entry.nodeId()) : null;
+        if (task != null) {
+            bean.setTaskId(task.id);
+            bean.setTaskStatus(task.status);
+        }
+        return bean;
+    }
+```
+
+Add `import java.util.Map;` if not present.
+
+- [ ] **Step 6: Also map task `workflowRunId`/`nodeId` in the tasks-list mapping**
+
+Find where `ProjectsResourceImpl` maps `TaskEntity` → the `Task` bean (the tasks-list endpoint). Add:
+
+```java
+        bean.setWorkflowRunId(entity.workflowRunId);
+        bean.setNodeId(entity.nodeId);
+```
+
+(This satisfies Task 5's `nodeTaskCarriesRunNodeAndTrace` assertions.)
+
+- [ ] **Step 7: Developer checkpoint — verify it passes**
+
+Ask developer to build and run `WorkflowRunsResourceTest` (all tests, incl. Task 4/5 assertions now
+fully wired) + `WorkflowInstanceResourceTest`. Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/src/main/java/io/apitomy/axiom/app/rest/ProjectsResourceImpl.java \
+        app/src/test/java/io/apitomy/axiom/app/WorkflowRunsResourceTest.java
+git commit -m "feat(api): project workflow returns latest run with runId, trace, and task links"
+```
+
+---
+
+### Task 13: Implement `WorkflowRunsResourceImpl` (list + get-by-id)
+
+**Files:**
+- Create: `app/src/main/java/io/apitomy/axiom/app/rest/WorkflowRunsResourceImpl.java`
+- Test: `app/src/test/java/io/apitomy/axiom/app/WorkflowRunsResourceTest.java`
+
+**Interfaces:**
+- Consumes: generated `WorkflowRunsResource` interface; beans `WorkflowRunSummary`,
+  `WorkflowRunSearchResults`, `WorkflowInstance`. Reuses `ProjectsResourceImpl`'s bean-building? No —
+  keep this resource self-contained; for get-by-id, build the same enriched `WorkflowInstance` shape via
+  a shared helper. To avoid duplication, extract the run→`WorkflowInstance` bean logic.
+- Produces: `listWorkflowRuns(projectId, status, page, limit)` and `getWorkflowRun(runId)`.
+
+- [ ] **Step 1: Extract a shared run→bean builder**
+
+To avoid duplicating `toWorkflowInstanceBean`, move it (and `toHistoryEntryBean`) into a new
+`@ApplicationScoped` CDI bean `WorkflowRunBeanMapper` in
+`app/src/main/java/io/apitomy/axiom/app/WorkflowRunBeanMapper.java`, injecting `ObjectMapper`. Give it a
+public method:
+
+```java
+    /** Builds the enriched WorkflowInstance bean for a run. */
+    public io.apitomy.axiom.api.beans.WorkflowInstance toBean(WorkflowRunEntity entity) { ... }
+```
+
+Move the body from `ProjectsResourceImpl.toWorkflowInstanceBean` (and the two-arg `toHistoryEntryBean`)
+into this class verbatim, then have `ProjectsResourceImpl` inject `WorkflowRunBeanMapper` and delegate:
+
+```java
+    @Inject
+    WorkflowRunBeanMapper runBeanMapper;
+
+    private io.apitomy.axiom.api.beans.WorkflowInstance toWorkflowInstanceBean(
+            WorkflowRunEntity entity) {
+        return runBeanMapper.toBean(entity);
+    }
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `WorkflowRunsResourceTest`:
+
+```java
+    @Test
+    void listAndGetWorkflowRuns() {
+        int projectId = createProject("WF Runs List Project");
+        int definitionId = createAndPublishActionWorkflow("Runs List WF");
+
+        int runId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"workflowDefinitionId\": %d}".formatted(definitionId))
+                .when().post(PROJECTS_PATH + "/" + projectId + "/workflow")
+                .then().statusCode(200).extract().path("runId");
+
+        given()
+                .when().get("/api/v1/workflow-runs?projectId=" + projectId)
+                .then()
+                    .statusCode(200)
+                    .body("totalCount", equalTo(1))
+                    .body("items[0].runId", equalTo(runId))
+                    .body("items[0].projectName", equalTo("WF Runs List Project"))
+                    .body("items[0].definitionName", equalTo("Runs List WF"));
+
+        given()
+                .when().get("/api/v1/workflow-runs/" + runId)
+                .then()
+                    .statusCode(200)
+                    .body("runId", equalTo(runId))
+                    .body("projectId", equalTo(projectId));
+
+        given()
+                .when().get("/api/v1/workflow-runs/999999")
+                .then().statusCode(404);
+    }
+```
+
+- [ ] **Step 3: Developer checkpoint — verify it fails**
+
+Ask developer to run `listAndGetWorkflowRuns`. Expected: FAIL/404 across the board (resource not
+implemented).
+
+- [ ] **Step 4: Implement the resource**
+
+Create `app/src/main/java/io/apitomy/axiom/app/rest/WorkflowRunsResourceImpl.java`:
+
+```java
+package io.apitomy.axiom.app.rest;
+
+import io.apitomy.axiom.api.WorkflowRunsResource;
+import io.apitomy.axiom.api.beans.WorkflowInstance;
+import io.apitomy.axiom.api.beans.WorkflowRunSearchResults;
+import io.apitomy.axiom.api.beans.WorkflowRunSummary;
+import io.apitomy.axiom.app.WorkflowRunBeanMapper;
+import io.apitomy.axiom.core.entities.ProjectEntity;
+import io.apitomy.axiom.core.entities.WorkflowDefinitionEntity;
+import io.apitomy.axiom.core.entities.WorkflowRunEntity;
+import io.quarkus.panache.common.Page;
+import io.quarkus.panache.common.Sort;
+import io.smallrye.common.annotation.RunOnVirtualThread;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.WebApplicationException;
+
+import java.math.BigInteger;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * REST resource exposing workflow run history and detail.
+ */
+@ApplicationScoped
+@RunOnVirtualThread
+public class WorkflowRunsResourceImpl implements WorkflowRunsResource {
+
+    @Inject
+    WorkflowRunBeanMapper runBeanMapper;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public WorkflowRunSearchResults listWorkflowRuns(BigInteger projectId,
+                                                     String status,
+                                                     BigInteger page,
+                                                     BigInteger limit) {
+        int pageNum = page != null ? Math.max(1, page.intValue()) : 1;
+        int pageSize = limit != null ? Math.max(1, limit.intValue()) : 20;
+
+        StringBuilder hql = new StringBuilder("1=1");
+        Map<String, Object> params = new HashMap<>();
+        if (projectId != null) {
+            hql.append(" and projectId = :projectId");
+            params.put("projectId", projectId.longValue());
+        }
+        if (status != null && !status.isBlank()) {
+            hql.append(" and status in :statuses");
+            params.put("statuses", List.of(status.split(",")));
+        }
+
+        long totalCount = WorkflowRunEntity.count(hql.toString(), params);
+        List<WorkflowRunEntity> runs = WorkflowRunEntity
+                .<WorkflowRunEntity>find(hql.toString(),
+                        Sort.descending("startedOn"), params)
+                .page(Page.of(pageNum - 1, pageSize))
+                .list();
+
+        Map<Long, String> projectNames = resolveProjectNames(runs);
+        Map<Long, String> definitionNames = resolveDefinitionNames(runs);
+
+        WorkflowRunSearchResults results = new WorkflowRunSearchResults();
+        results.setItems(runs.stream()
+                .map(r -> toSummary(r, projectNames, definitionNames))
+                .toList());
+        results.setTotalCount(totalCount);
+        results.setPage(pageNum);
+        results.setLimit(pageSize);
+        return results;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public WorkflowInstance getWorkflowRun(long runId) {
+        WorkflowRunEntity run = WorkflowRunEntity.findById(runId);
+        if (run == null) {
+            throw new WebApplicationException("Workflow run not found: " + runId, 404);
+        }
+        return runBeanMapper.toBean(run);
+    }
+
+    private Map<Long, String> resolveProjectNames(List<WorkflowRunEntity> runs) {
+        Set<Long> ids = runs.stream().map(r -> r.projectId)
+                .collect(Collectors.toSet());
+        if (ids.isEmpty()) return Map.of();
+        return ProjectEntity.<ProjectEntity>find("id in :ids", Map.of("ids", ids))
+                .list().stream()
+                .collect(Collectors.toMap(p -> p.id, p -> p.name));
+    }
+
+    private Map<Long, String> resolveDefinitionNames(List<WorkflowRunEntity> runs) {
+        Set<Long> ids = runs.stream().map(r -> r.definitionId)
+                .collect(Collectors.toSet());
+        if (ids.isEmpty()) return Map.of();
+        return WorkflowDefinitionEntity
+                .<WorkflowDefinitionEntity>find("id in :ids", Map.of("ids", ids))
+                .list().stream()
+                .collect(Collectors.toMap(d -> d.id, d -> d.name));
+    }
+
+    private WorkflowRunSummary toSummary(WorkflowRunEntity run,
+                                         Map<Long, String> projectNames,
+                                         Map<Long, String> definitionNames) {
+        WorkflowRunSummary summary = new WorkflowRunSummary();
+        summary.setRunId(run.id);
+        summary.setProjectId(run.projectId);
+        summary.setProjectName(projectNames.getOrDefault(run.projectId, "Unknown"));
+        summary.setDefinitionId(run.definitionId);
+        summary.setDefinitionName(
+                definitionNames.getOrDefault(run.definitionId, "Unknown"));
+        summary.setDefinitionVersion(run.definitionVersion);
+        summary.setStatus(run.status);
+        if (run.traceId != null) {
+            summary.setTraceId(run.traceId);
+        }
+        summary.setStartedOn(Date.from(run.startedOn));
+        if (run.completedOn != null) {
+            summary.setCompletedOn(Date.from(run.completedOn));
+        }
+        // currentNodeName is resolved on the detail bean; list omits it to
+        // avoid per-row content loads. (Populate later if the UI needs it.)
+        return summary;
+    }
+}
+```
+
+> The summary intentionally leaves `currentNodeName` unset in the list to avoid an N+1 content read per
+> row; the detail bean (`getWorkflowRun`) carries `currentNodeName` via the mapper. If the list UI needs
+> it, add a batch resolve in a follow-up — noted, not silently dropped.
+
+- [ ] **Step 5: Developer checkpoint — verify it passes**
+
+Ask developer to build and run `listAndGetWorkflowRuns`. Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/io/apitomy/axiom/app/WorkflowRunBeanMapper.java \
+        app/src/main/java/io/apitomy/axiom/app/rest/WorkflowRunsResourceImpl.java \
+        app/src/main/java/io/apitomy/axiom/app/rest/ProjectsResourceImpl.java \
+        app/src/test/java/io/apitomy/axiom/app/WorkflowRunsResourceTest.java
+git commit -m "feat(api): implement /workflow-runs list and detail endpoints"
+```
+
+---
+
+### Task 14: Implement `listWorkflowDefinitionRuns`
+
+**Files:**
+- Modify: `app/src/main/java/io/apitomy/axiom/app/rest/WorkflowDefinitionsResourceImpl.java`
+- Test: `app/src/test/java/io/apitomy/axiom/app/WorkflowRunsResourceTest.java`
+
+**Interfaces:**
+- Consumes: generated `WorkflowResource.listWorkflowDefinitionRuns(long, String, BigInteger,
+  BigInteger)`; `WorkflowRunEntity`; the same summary shape as Task 13.
+- Produces: per-definition paginated runs.
+
+To share the summary mapping, extract `toSummary` + `resolveProjectNames`/`resolveDefinitionNames` into
+`WorkflowRunBeanMapper` as public methods and reuse from both resources.
+
+- [ ] **Step 1: Move summary helpers into `WorkflowRunBeanMapper`**
+
+Add to `WorkflowRunBeanMapper` public methods `toSummary(WorkflowRunEntity, Map, Map)`,
+`resolveProjectNames(List)`, `resolveDefinitionNames(List)` (move bodies from
+`WorkflowRunsResourceImpl`, make them public). Update `WorkflowRunsResourceImpl` to call
+`runBeanMapper.toSummary(...)` etc.
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `WorkflowRunsResourceTest`:
+
+```java
+    @Test
+    void listRunsForDefinition() {
+        int projectId = createProject("WF DefRuns Project");
+        int definitionId = createAndPublishActionWorkflow("DefRuns WF");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"workflowDefinitionId\": %d}".formatted(definitionId))
+                .when().post(PROJECTS_PATH + "/" + projectId + "/workflow")
+                .then().statusCode(200);
+
+        given()
+                .when().get(WORKFLOWS_PATH + "/" + definitionId + "/runs")
+                .then()
+                    .statusCode(200)
+                    .body("totalCount", equalTo(1))
+                    .body("items[0].definitionId", equalTo(definitionId));
+    }
+```
+
+- [ ] **Step 3: Developer checkpoint — verify it fails**
+
+Ask developer to run `listRunsForDefinition`. Expected: FAIL (method returns nothing / 500 until
+implemented).
+
+- [ ] **Step 4: Implement the method**
+
+Add to `WorkflowDefinitionsResourceImpl` (inject `WorkflowRunBeanMapper runBeanMapper;`):
+
+```java
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public WorkflowRunSearchResults listWorkflowDefinitionRuns(long workflowDefinitionId,
+                                                               String status,
+                                                               BigInteger page,
+                                                               BigInteger limit) {
+        findOrThrow(workflowDefinitionId);
+
+        int pageNum = page != null ? Math.max(1, page.intValue()) : 1;
+        int pageSize = limit != null ? Math.max(1, limit.intValue()) : 20;
+
+        StringBuilder hql = new StringBuilder("definitionId = :definitionId");
+        Map<String, Object> params = new HashMap<>();
+        params.put("definitionId", workflowDefinitionId);
+        if (status != null && !status.isBlank()) {
+            hql.append(" and status in :statuses");
+            params.put("statuses", List.of(status.split(",")));
+        }
+
+        long totalCount = WorkflowRunEntity.count(hql.toString(), params);
+        List<WorkflowRunEntity> runs = WorkflowRunEntity
+                .<WorkflowRunEntity>find(hql.toString(),
+                        Sort.descending("startedOn"), params)
+                .page(Page.of(pageNum - 1, pageSize))
+                .list();
+
+        Map<Long, String> projectNames = runBeanMapper.resolveProjectNames(runs);
+        Map<Long, String> definitionNames = runBeanMapper.resolveDefinitionNames(runs);
+
+        WorkflowRunSearchResults results = new WorkflowRunSearchResults();
+        results.setItems(runs.stream()
+                .map(r -> runBeanMapper.toSummary(r, projectNames, definitionNames))
+                .toList());
+        results.setTotalCount(totalCount);
+        results.setPage(pageNum);
+        results.setLimit(pageSize);
+        return results;
+    }
+```
+
+Add imports: `io.apitomy.axiom.api.beans.WorkflowRunSearchResults`,
+`io.apitomy.axiom.core.entities.WorkflowRunEntity`, `io.apitomy.axiom.app.WorkflowRunBeanMapper`,
+`io.quarkus.panache.common.Page`, `io.quarkus.panache.common.Sort`, `java.math.BigInteger`,
+`java.util.HashMap`, `java.util.List`, `java.util.Map`.
+
+- [ ] **Step 5: Developer checkpoint — verify it passes**
+
+Ask developer to build and run `listRunsForDefinition`. Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/io/apitomy/axiom/app/rest/WorkflowDefinitionsResourceImpl.java \
+        app/src/main/java/io/apitomy/axiom/app/WorkflowRunBeanMapper.java \
+        app/src/main/java/io/apitomy/axiom/app/rest/WorkflowRunsResourceImpl.java \
+        app/src/test/java/io/apitomy/axiom/app/WorkflowRunsResourceTest.java
+git commit -m "feat(api): implement per-definition workflow runs listing"
+```
+
+---
+
+## Phase 4 — UI
+
+> Frontend build/tests are also developer-run. UI tasks end with a "developer verifies in the browser"
+> checkpoint rather than an auto-run.
+
+### Task 15: api.ts — types + fetch functions; enrich existing types
+
+**Files:**
+- Modify: `ui/src/config/api.ts`
+
+**Interfaces:**
+- Produces: `WorkflowRunSummary` interface; `fetchWorkflowRuns(...)`, `getWorkflowRun(runId)`,
+  `fetchWorkflowDefinitionRuns(...)`; enriched `WorkflowInstanceInfo` (`runId`, `traceId`),
+  `HistoryEntryInfo` (`taskId`, `taskStatus`), `Task` (`workflowRunId`, `nodeId`). Reuses the existing
+  `SearchResults<T>` wrapper.
+
+- [ ] **Step 1: Enrich existing interfaces**
+
+In `WorkflowInstanceInfo` add:
+
+```ts
+    runId?: number;
+    traceId?: string;
+```
+
+In `HistoryEntryInfo` add:
+
+```ts
+    taskId?: number;
+    taskStatus?: string;
+```
+
+In `Task` add:
+
+```ts
+    workflowRunId?: number;
+    nodeId?: string;
+```
+
+- [ ] **Step 2: Add the summary interface + fetch functions**
+
+```ts
+export interface WorkflowRunSummary {
+    runId: number;
+    projectId: number;
+    projectName?: string;
+    definitionId: number;
+    definitionName?: string;
+    definitionVersion: number;
+    status: string;
+    currentNodeName?: string;
+    traceId?: string;
+    startedOn: string;
+    completedOn?: string;
+}
+
+export async function fetchWorkflowRuns(
+    page = 1, limit = 20, projectId?: number, status?: string
+): Promise<SearchResults<WorkflowRunSummary>> {
+    const params = new URLSearchParams();
+    params.set("page", String(page));
+    params.set("limit", String(limit));
+    if (projectId != null) params.set("projectId", String(projectId));
+    if (status) params.set("status", status);
+    const response = await fetch(`${API}/workflow-runs?${params}`);
+    if (!response.ok) throw new Error(`Failed to fetch workflow runs: ${response.status}`);
+    return response.json();
+}
+
+export async function getWorkflowRun(runId: number): Promise<WorkflowInstanceInfo> {
+    const response = await fetch(`${API}/workflow-runs/${runId}`);
+    if (!response.ok) throw new Error(`Failed to fetch workflow run: ${response.status}`);
+    return response.json();
+}
+
+export async function fetchWorkflowDefinitionRuns(
+    definitionId: number, page = 1, limit = 20, status?: string
+): Promise<SearchResults<WorkflowRunSummary>> {
+    const params = new URLSearchParams();
+    params.set("page", String(page));
+    params.set("limit", String(limit));
+    if (status) params.set("status", status);
+    const response = await fetch(
+        `${API}/workflow-definitions/${definitionId}/runs?${params}`);
+    if (!response.ok) throw new Error(`Failed to fetch definition runs: ${response.status}`);
+    return response.json();
+}
+```
+
+- [ ] **Step 3: Developer checkpoint**
+
+Ask developer to run the UI typecheck/build (`npm run build` in `ui/`). Expected: compiles.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ui/src/config/api.ts
+git commit -m "feat(ui): add workflow-run API types and fetch functions"
+```
+
+---
+
+### Task 16: WorkflowRunsPage (list) + route + sidebar nav
+
+**Files:**
+- Create: `ui/src/pages/WorkflowRunsPage.tsx`
+- Modify: `ui/src/App.tsx`, `ui/src/components/AppSidebar.tsx`
+
+**Interfaces:**
+- Consumes: `fetchWorkflowRuns`, `WorkflowRunSummary`, `SearchResults`. SSE via `sseClient.subscribe`
+  on `"workflow-updated"`.
+- Produces: route `/logs/workflow-runs`; sidebar "Workflow Runs" item.
+
+- [ ] **Step 1: Create the page** (model on `ScheduledJobRunsPage`)
+
+Create `ui/src/pages/WorkflowRunsPage.tsx`:
+
+```tsx
+import { useState, useEffect, useCallback } from "react";
+import { Link } from "react-router-dom";
+import {
+    Button,
+    EmptyState,
+    EmptyStateBody,
+    Label,
+    PageSection,
+    Pagination,
+    Title,
+    Toolbar,
+    ToolbarContent,
+    ToolbarItem,
+} from "@patternfly/react-core";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+import SyncAltIcon from "@patternfly/react-icons/dist/esm/icons/sync-alt-icon";
+import { type WorkflowRunSummary, fetchWorkflowRuns } from "../config/api";
+import { sseClient, type AxiomSseEvent } from "../config/sse";
+
+const STATUS_COLORS: Record<string, "blue" | "green" | "orange" | "grey" | "red"> = {
+    running: "blue",
+    waiting: "orange",
+    completed: "green",
+    failed: "red",
+    cancelled: "grey",
+};
+
+function formatDuration(startedOn: string, completedOn?: string): string {
+    if (!completedOn) return "—";
+    const ms = new Date(completedOn).getTime() - new Date(startedOn).getTime();
+    if (ms < 1000) return `${ms}ms`;
+    if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+    const mins = Math.floor(ms / 60_000);
+    const secs = Math.round((ms % 60_000) / 1000);
+    return `${mins}m ${secs}s`;
+}
+
+export function WorkflowRunsPage() {
+    const [runs, setRuns] = useState<WorkflowRunSummary[]>([]);
+    const [totalCount, setTotalCount] = useState(0);
+    const [page, setPage] = useState(1);
+    const [perPage, setPerPage] = useState(20);
+    const [loading, setLoading] = useState(true);
+
+    const loadData = useCallback(() => {
+        setLoading(true);
+        fetchWorkflowRuns(page, perPage)
+            .then((results) => {
+                setRuns(results.items);
+                setTotalCount(results.totalCount);
+            })
+            .catch(console.error)
+            .finally(() => setLoading(false));
+    }, [page, perPage]);
+
+    useEffect(() => { loadData(); }, [loadData]);
+
+    useEffect(() => {
+        let timeout: ReturnType<typeof setTimeout>;
+        const unsubscribe = sseClient.subscribe((event: AxiomSseEvent) => {
+            if (event.type === "workflow-updated") {
+                clearTimeout(timeout);
+                timeout = setTimeout(loadData, 300);
+            }
+        });
+        return () => { clearTimeout(timeout); unsubscribe(); };
+    }, [loadData]);
+
+    return (
+        <PageSection>
+            <Title headingLevel="h1" size="lg" style={{ marginBottom: "16px" }}>
+                Workflow Runs
+            </Title>
+
+            <Toolbar>
+                <ToolbarContent>
+                    <ToolbarItem>
+                        <Button variant="control" aria-label="Refresh" onClick={loadData}>
+                            <SyncAltIcon />
+                        </Button>
+                    </ToolbarItem>
+                    <ToolbarItem variant="pagination" align={{ default: "alignEnd" }}>
+                        <Pagination
+                            itemCount={totalCount}
+                            page={page}
+                            perPage={perPage}
+                            onSetPage={(_e, p) => setPage(p)}
+                            onPerPageSelect={(_e, pp) => { setPerPage(pp); setPage(1); }}
+                            isCompact
+                        />
+                    </ToolbarItem>
+                </ToolbarContent>
+            </Toolbar>
+
+            {loading ? (
+                <EmptyState><EmptyStateBody>Loading workflow runs...</EmptyStateBody></EmptyState>
+            ) : runs.length === 0 ? (
+                <EmptyState><EmptyStateBody>No workflow runs recorded yet.</EmptyStateBody></EmptyState>
+            ) : (
+                <Table aria-label="Workflow Runs" variant="compact">
+                    <Thead>
+                        <Tr>
+                            <Th>Status</Th>
+                            <Th>Project</Th>
+                            <Th>Workflow</Th>
+                            <Th>Started</Th>
+                            <Th>Duration</Th>
+                            <Th>Actions</Th>
+                        </Tr>
+                    </Thead>
+                    <Tbody>
+                        {runs.map((run) => (
+                            <Tr key={run.runId}>
+                                <Td>
+                                    <Label isCompact color={STATUS_COLORS[run.status] || "grey"}>
+                                        {run.status}
+                                    </Label>
+                                </Td>
+                                <Td>
+                                    <Link to={`/projects/${run.projectId}`}>
+                                        {run.projectName || `Project #${run.projectId}`}
+                                    </Link>
+                                </Td>
+                                <Td>
+                                    {run.definitionName || `Definition #${run.definitionId}`}
+                                    {" v"}{run.definitionVersion}
+                                </Td>
+                                <Td style={{ whiteSpace: "nowrap" }}>
+                                    {new Date(run.startedOn).toLocaleString()}
+                                </Td>
+                                <Td style={{ whiteSpace: "nowrap" }}>
+                                    {formatDuration(run.startedOn, run.completedOn)}
+                                </Td>
+                                <Td>
+                                    <Link to={`/logs/workflow-runs/${run.runId}`}>
+                                        View details
+                                    </Link>
+                                </Td>
+                            </Tr>
+                        ))}
+                    </Tbody>
+                </Table>
+            )}
+        </PageSection>
+    );
+}
+```
+
+> Note: `sseClient.subscribe` receives events only if the shared SSE client parses `workflow-updated`
+> into `{type, data}`. If the shared client only handles named listeners (as WorkflowTab does via a raw
+> `EventSource`), fall back to a raw `EventSource("/api/v1/sse")` + `addEventListener("workflow-updated",
+> …)` exactly like `WorkflowTab.tsx` lines 57-77. Verify against `ui/src/config/sse.ts` during
+> implementation and pick whichever the client actually supports.
+
+- [ ] **Step 2: Register the route in `App.tsx`**
+
+Add the import near the other page imports:
+
+```tsx
+import { WorkflowRunsPage } from "./pages/WorkflowRunsPage";
+```
+
+Add after the `/logs/traces/:traceId` route (line ~143):
+
+```tsx
+<Route path="/logs/workflow-runs" element={<WorkflowRunsPage />} />
+```
+
+(The `:runId` detail route is added in Task 17.)
+
+- [ ] **Step 3: Add the sidebar nav item**
+
+In `AppSidebar.tsx`, inside the Logs `NavExpandable`, after the Traces `NavItem`:
+
+```tsx
+<NavItem isActive={location.pathname.startsWith("/logs/workflow-runs")}
+    onClick={() => navigate("/logs/workflow-runs")}>
+    Workflow Runs
+</NavItem>
+```
+
+- [ ] **Step 4: Developer checkpoint**
+
+Ask developer to run the UI and navigate to Logs → Workflow Runs; confirm the list renders and rows
+link out. Expected: runs list shows triggered runs.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src/pages/WorkflowRunsPage.tsx ui/src/App.tsx ui/src/components/AppSidebar.tsx
+git commit -m "feat(ui): add Logs > Workflow Runs list page"
+```
+
+---
+
+### Task 17: WorkflowRunDetailPage (tabs) + step timeline + route
+
+**Files:**
+- Create: `ui/src/pages/WorkflowRunDetailPage.tsx`, `ui/src/components/WorkflowStepTimeline.tsx`
+- Modify: `ui/src/App.tsx`
+
+**Interfaces:**
+- Consumes: `getWorkflowRun(runId)` → `WorkflowInstanceInfo` (with `history` carrying `taskId`,
+  `taskStatus`), `TraceGraph` (`traceId`, `refreshKey`), `WorkflowViewer` (`workflow`, `instance`,
+  `theme`), `ExecutionLogModal` (`projectId`, `taskId`). Tabs pattern from `ProjectDetailPage`.
+- Produces: route `/logs/workflow-runs/:runId` with tabs Overview / Diagram / Timeline / Execution Trace.
+
+- [ ] **Step 1: Create the step-timeline component**
+
+Create `ui/src/components/WorkflowStepTimeline.tsx`:
+
+```tsx
+import { Button, Label } from "@patternfly/react-core";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+import { Link } from "react-router-dom";
+import type { HistoryEntryInfo } from "../config/api";
+
+interface WorkflowStepTimelineProps {
+    projectId: number;
+    history: HistoryEntryInfo[];
+    traceId?: string;
+    onViewLog: (taskId: number) => void;
+}
+
+const TASK_STATUS_COLORS: Record<string, "blue" | "green" | "grey" | "red" | "orange"> = {
+    Pending: "grey",
+    InProgress: "blue",
+    AwaitingInput: "orange",
+    Completed: "green",
+    Failed: "red",
+    Cancelled: "grey",
+};
+
+function stepDuration(entry: HistoryEntryInfo): string {
+    if (!entry.completedOn) return "—";
+    const ms = new Date(entry.completedOn).getTime()
+        - new Date(entry.enteredOn).getTime();
+    if (ms < 1000) return `${ms}ms`;
+    if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+    const mins = Math.floor(ms / 60_000);
+    const secs = Math.round((ms % 60_000) / 1000);
+    return `${mins}m ${secs}s`;
+}
+
+export function WorkflowStepTimeline({
+    history, traceId, onViewLog,
+}: WorkflowStepTimelineProps) {
+    if (history.length === 0) {
+        return <p>No steps have executed yet.</p>;
+    }
+    return (
+        <Table aria-label="Step Timeline" variant="compact">
+            <Thead>
+                <Tr>
+                    <Th>Step</Th>
+                    <Th>Task Status</Th>
+                    <Th>Entered</Th>
+                    <Th>Completed</Th>
+                    <Th>Duration</Th>
+                    <Th>Actions</Th>
+                </Tr>
+            </Thead>
+            <Tbody>
+                {history.map((entry, idx) => (
+                    <Tr key={`${entry.nodeId}-${idx}`}>
+                        <Td>{entry.nodeName || entry.nodeId}</Td>
+                        <Td>
+                            {entry.taskStatus && (
+                                <Label isCompact
+                                    color={TASK_STATUS_COLORS[entry.taskStatus] || "grey"}>
+                                    {entry.taskStatus}
+                                </Label>
+                            )}
+                        </Td>
+                        <Td style={{ whiteSpace: "nowrap" }}>
+                            {new Date(entry.enteredOn).toLocaleString()}
+                        </Td>
+                        <Td style={{ whiteSpace: "nowrap" }}>
+                            {entry.completedOn
+                                ? new Date(entry.completedOn).toLocaleString() : "—"}
+                        </Td>
+                        <Td style={{ whiteSpace: "nowrap" }}>{stepDuration(entry)}</Td>
+                        <Td>
+                            {entry.taskId != null && (
+                                <Button variant="link" isInline
+                                    onClick={() => onViewLog(entry.taskId!)}>
+                                    View Log
+                                </Button>
+                            )}
+                            {entry.taskId != null && traceId && " | "}
+                            {traceId && (
+                                <Link to={`/logs/traces/${traceId}`}>View Trace</Link>
+                            )}
+                        </Td>
+                    </Tr>
+                ))}
+            </Tbody>
+        </Table>
+    );
+}
+```
+
+- [ ] **Step 2: Create the detail page**
+
+Create `ui/src/pages/WorkflowRunDetailPage.tsx` (tabs pattern from `ProjectDetailPage`; `TraceGraph`
+embed from `TraceDetailPage`; `WorkflowViewer` + `viewerInstance` mapping from `WorkflowTab`):
+
+```tsx
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { useParams, Link } from "react-router-dom";
+import {
+    Breadcrumb, BreadcrumbItem, Button, Flex, FlexItem, Label,
+    PageSection, Tab, TabTitleText, Tabs, Title,
+} from "@patternfly/react-core";
+import SyncAltIcon from "@patternfly/react-icons/dist/esm/icons/sync-alt-icon";
+import { WorkflowViewer } from "@apitomy/flow-ui";
+import type { Workflow, WorkflowInstance as FlowInstance } from "@apitomy/flow-ui";
+import { TraceGraph } from "../components/TraceGraph";
+import { WorkflowStepTimeline } from "../components/WorkflowStepTimeline";
+import { ExecutionLogModal } from "../components/ExecutionLogModal";
+import { getWorkflowRun, type WorkflowInstanceInfo } from "../config/api";
+import { sseClient, type AxiomSseEvent } from "../config/sse";
+import { useEffectiveTheme } from "../hooks/useEffectiveTheme";
+
+const STATUS_COLORS: Record<string, "blue" | "green" | "orange" | "grey" | "red"> = {
+    running: "blue", waiting: "orange", completed: "green",
+    failed: "red", cancelled: "grey",
+};
+
+export function WorkflowRunDetailPage() {
+    const { runId } = useParams<{ runId: string }>();
+    const numericRunId = Number(runId);
+    const [run, setRun] = useState<WorkflowInstanceInfo | null>(null);
+    const [activeTab, setActiveTab] = useState(0);
+    const [refreshKey, setRefreshKey] = useState(0);
+    const [isLogOpen, setIsLogOpen] = useState(false);
+    const [logTaskId, setLogTaskId] = useState<number | null>(null);
+    const effectiveTheme = useEffectiveTheme();
+
+    const load = useCallback(() => {
+        getWorkflowRun(numericRunId).then(setRun).catch(console.error);
+    }, [numericRunId]);
+
+    useEffect(() => { load(); }, [load]);
+
+    useEffect(() => {
+        let timeout: ReturnType<typeof setTimeout>;
+        const unsubscribe = sseClient.subscribe((event: AxiomSseEvent) => {
+            if (event.type === "workflow-updated"
+                    && (event.data as { runId?: number }).runId === numericRunId) {
+                clearTimeout(timeout);
+                timeout = setTimeout(() => { load(); setRefreshKey((k) => k + 1); }, 300);
+            }
+        });
+        return () => { clearTimeout(timeout); unsubscribe(); };
+    }, [numericRunId, load]);
+
+    const workflowContent = useMemo(
+        () => (run?.workflowContent as Workflow | undefined), [run]);
+    const viewerInstance = useMemo<FlowInstance | undefined>(() => {
+        if (!run) return undefined;
+        return {
+            currentNodeId: run.currentNodeId ?? "",
+            status: run.status,
+            history: (run.history ?? []).map((h) => ({
+                nodeId: h.nodeId, nodeName: h.nodeName,
+                edgeId: "", edgeCondition: "",
+                enteredOn: h.enteredOn, completedOn: h.completedOn ?? "",
+                output: h.output ?? {},
+            })),
+            createdOn: run.startedOn,
+            updatedOn: run.completedOn ?? run.startedOn,
+        } as FlowInstance;
+    }, [run]);
+
+    if (!run) {
+        return <PageSection><p>Loading workflow run...</p></PageSection>;
+    }
+
+    const openLog = (taskId: number) => { setLogTaskId(taskId); setIsLogOpen(true); };
+
+    return (
+        <PageSection>
+            <Breadcrumb style={{ marginBottom: "12px" }}>
+                <BreadcrumbItem to="#" component={() => (
+                    <Link to="/logs/workflow-runs">Workflow Runs</Link>)} />
+                <BreadcrumbItem isActive>Run #{run.runId}</BreadcrumbItem>
+            </Breadcrumb>
+
+            <Flex justifyContent={{ default: "justifyContentSpaceBetween" }}
+                alignItems={{ default: "alignItemsCenter" }}
+                style={{ marginBottom: "16px" }}>
+                <FlexItem>
+                    <Title headingLevel="h1" size="lg">
+                        {run.definitionName} v{run.definitionVersion}{" "}
+                        <Label color={STATUS_COLORS[run.status] || "grey"}>
+                            {run.status}
+                        </Label>
+                    </Title>
+                </FlexItem>
+                <FlexItem>
+                    <Button variant="control" aria-label="Refresh"
+                        onClick={() => { load(); setRefreshKey((k) => k + 1); }}>
+                        <SyncAltIcon />
+                    </Button>
+                </FlexItem>
+            </Flex>
+
+            <Tabs activeKey={activeTab} onSelect={(_e, k) => setActiveTab(k as number)}>
+                <Tab eventKey={0} title={<TabTitleText>Overview</TabTitleText>} />
+                <Tab eventKey={1} title={<TabTitleText>Diagram</TabTitleText>} />
+                <Tab eventKey={2} title={<TabTitleText>Timeline</TabTitleText>} />
+                <Tab eventKey={3} title={<TabTitleText>Execution Trace</TabTitleText>} />
+            </Tabs>
+
+            <div style={{ paddingTop: "16px" }}>
+                {activeTab === 0 && (
+                    <dl>
+                        <dt><strong>Workflow</strong></dt>
+                        <dd>{run.definitionName} v{run.definitionVersion}</dd>
+                        <dt><strong>Status</strong></dt>
+                        <dd>{run.status}</dd>
+                        <dt><strong>Started</strong></dt>
+                        <dd>{new Date(run.startedOn).toLocaleString()}</dd>
+                        <dt><strong>Completed</strong></dt>
+                        <dd>{run.completedOn
+                            ? new Date(run.completedOn).toLocaleString() : "—"}</dd>
+                        {run.failureReason && (
+                            <>
+                                <dt><strong>Failure</strong></dt>
+                                <dd>{run.failureReason}</dd>
+                            </>
+                        )}
+                        {run.traceId && (
+                            <>
+                                <dt><strong>Trace</strong></dt>
+                                <dd>
+                                    <Link to={`/logs/traces/${run.traceId}`}>
+                                        View full execution trace →
+                                    </Link>
+                                </dd>
+                            </>
+                        )}
+                    </dl>
+                )}
+
+                {activeTab === 1 && workflowContent && viewerInstance && (
+                    <div style={{ height: "calc(100vh - 320px)", minHeight: "500px" }}>
+                        <WorkflowViewer
+                            workflow={workflowContent}
+                            instance={viewerInstance}
+                            theme={effectiveTheme === "dark" ? "dark" : "light"}
+                        />
+                    </div>
+                )}
+
+                {activeTab === 2 && (
+                    <WorkflowStepTimeline
+                        projectId={run.projectId}
+                        history={run.history ?? []}
+                        traceId={run.traceId}
+                        onViewLog={openLog}
+                    />
+                )}
+
+                {activeTab === 3 && run.traceId && (
+                    <div style={{ height: "calc(100vh - 320px)", minHeight: "500px" }}>
+                        <TraceGraph traceId={run.traceId} refreshKey={refreshKey} />
+                    </div>
+                )}
+                {activeTab === 3 && !run.traceId && (
+                    <p>No execution trace is available for this run.</p>
+                )}
+            </div>
+
+            <ExecutionLogModal
+                isOpen={isLogOpen}
+                projectId={run.projectId}
+                taskId={logTaskId}
+                onClose={() => setIsLogOpen(false)}
+            />
+        </PageSection>
+    );
+}
+```
+
+> Verify the exact import path for the theme hook (`useEffectiveTheme`) — `WorkflowTab`/`TraceGraph` use
+> it; copy their import. Verify `ExecutionLogModal` accepts `projectId` + `taskId` (it does, per the
+> multi-source modal) and renders the task log. Verify `Breadcrumb`'s link rendering against an existing
+> page (`TraceDetailPage`) and match its exact idiom.
+
+- [ ] **Step 3: Register the route in `App.tsx`**
+
+```tsx
+import { WorkflowRunDetailPage } from "./pages/WorkflowRunDetailPage";
+```
+
+```tsx
+<Route path="/logs/workflow-runs/:runId" element={<WorkflowRunDetailPage />} />
+```
+
+- [ ] **Step 4: Developer checkpoint**
+
+Ask developer to run the UI, open a run from the list, and exercise all four tabs (Overview, Diagram,
+Timeline with View Log/View Trace, Execution Trace). Expected: tabs render; log modal opens; trace graph
+renders.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src/pages/WorkflowRunDetailPage.tsx \
+        ui/src/components/WorkflowStepTimeline.tsx ui/src/App.tsx
+git commit -m "feat(ui): add tabbed workflow run detail page with step timeline"
+```
+
+---
+
+### Task 18: WorkflowTab — "View run details →" link
+
+**Files:**
+- Modify: `ui/src/components/WorkflowTab.tsx`
+
+**Interfaces:**
+- Consumes: `instance.id` (the run id) from `WorkflowInstanceInfo`. No timeline is added here (spec:
+  project page stays lightweight).
+
+- [ ] **Step 1: Add the link in the header Flex**
+
+In the loaded-instance header `Flex` (the block with the definition name + status labels + Cancel
+button), add a `FlexItem` with a link to the run detail page. Place it next to the Cancel button:
+
+```tsx
+<FlexItem>
+    <Link to={`/logs/workflow-runs/${instance.id}`}>
+        View run details →
+    </Link>
+</FlexItem>
+```
+
+Add `import { Link } from "react-router-dom";` if not already imported.
+
+- [ ] **Step 2: Developer checkpoint**
+
+Ask developer to open a project's Workflow tab and confirm the "View run details →" link navigates to
+the run detail page. Expected: link present and working; no timeline added on the project page.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ui/src/components/WorkflowTab.tsx
+git commit -m "feat(ui): link project Workflow tab to the run detail page"
+```
+
+---
+
+### Task 19: File Apitomy Flow enhancement issues
+
+Not a code task — a required side-deliverable from the spec. File GitHub issues on `Apitomy/apitomy-flow`
+for the enhancements the diagram drill-down depends on. Do this once the UI work confirms the exact gaps.
+
+**Interfaces:**
+- Produces: GitHub issues; note their URLs in the PR description.
+
+- [ ] **Step 1: Confirm the flow-ui gap**
+
+Inspect `@apitomy/flow-ui` `WorkflowViewer` types (node_modules or the flow repo) to confirm it exposes
+no node-click / node-action callback. If it truly lacks one, that's issue #1.
+
+- [ ] **Step 2: File the node-click callback issue**
+
+Using `mcp__axiom-tools__fetch-github-repo-labels` to pick appropriate `type/`/`area/` labels, open an
+issue titled e.g. *"WorkflowViewer: expose an onNodeClick callback for host-driven node actions"*,
+describing the Axiom need (node→execution-log drill-down on the run detail Diagram tab), the current
+props (`workflow`, `instance`, `theme`), and the desired API (`onNodeClick(nodeId: string)` or pluggable
+node actions). Use the `fetch-github-issue`/labels tools; do not include Claude attribution.
+
+- [ ] **Step 3: File the history edge-metadata issue**
+
+Open a second issue: *"WorkflowInstance history should retain edgeId / edgeCondition for viewer edge
+highlighting"* — Axiom currently maps `edgeId: ""`, `edgeCondition: ""` because the model/engine history
+drops them. Describe the need for edge highlighting on the diagram.
+
+- [ ] **Step 4: Record issue URLs**
+
+Note both issue URLs in the eventual PR description and, if useful, as a code comment near the
+`viewerInstance` mapping in `WorkflowRunDetailPage.tsx`.
+
+---
+
+## Self-Review
+
+**Spec coverage check** (each spec section → task):
+
+- Data model (rename, drop unique, `trace_id`, `task.node_id`, `workflow_run_id`, index, business rule) →
+  Tasks 1-3 (schema/entities) + Task 4 (active-run guard).
+- Backend trigger trace root → Task 4. Node task wiring (`workflowRunId`/`nodeId`/`traceId` + task node)
+  → Task 5. Terminal `completeTrace` + `completedOn` → Task 6. Best-effort/additive tracing → Tasks 4-6
+  (try/catch around all `TraceService` calls). The premature-completion hazard → Task 7. SSE enrichment
+  → Task 8.
+- API #1 (enriched `/projects/{id}/workflow`, latest run, history `taskId`/`taskStatus`) → Tasks 9 + 12.
+  API #2 (`/workflow-runs` list + `{runId}`) → Tasks 10 + 13. API #4 (`/workflow-definitions/{id}/runs`)
+  → Tasks 11 + 14. API #5 (`Task` bean `workflowRunId`/`nodeId`) → Task 9 (+ mapping in Task 12).
+  `WorkflowRunSummary` schema → Task 10. Reuse of `/tasks/{id}/log` and `/traces/{id}` → Tasks 17
+  (`ExecutionLogModal`, `TraceGraph`).
+- UI project page link, no timeline → Task 18. Logs → Workflow Runs list → Task 16. Run detail with
+  Overview/Diagram/Timeline/Execution Trace tabs → Task 17. Flow enhancement issues → Task 19.
+  Deferred per-definition UI → correctly not built (endpoint only, Tasks 11/14).
+- Testing (run history, active-run 409, trace wiring, REST list/detail/definition-runs, enriched project
+  workflow) → Tasks 4, 5, 7, 12, 13, 14. Manual build/test execution → Global Constraints.
+
+**Type consistency check:** `WorkflowRunEntity`, `workflowRunId`, `nodeId`, `traceId` used consistently
+across Tasks 2-14. Bean field names (`runId`, `traceId`, `taskId`, `taskStatus`, `workflowRunId`,
+`nodeId`, `WorkflowRunSummary.*`) match between openapi (Tasks 9-11), Java impls (Tasks 12-14), and
+api.ts (Task 15). `WorkflowRunBeanMapper.toBean/toSummary/resolveProjectNames/resolveDefinitionNames`
+are defined in Task 13, made public and reused in Task 14. `fetchWorkflowRuns`/`getWorkflowRun`/
+`fetchWorkflowDefinitionRuns` defined in Task 15, consumed in Tasks 16-17.
+
+**Placeholder scan:** No TBD/TODO. Each code step carries concrete code. Two flagged verification points
+(SSE client subscribe vs raw EventSource; theme-hook import path) are explicit "verify against the actual
+file" instructions with a concrete fallback, not placeholders.
+
+**Known cross-task dependency:** Task 4's `traceId` test assertion depends on Tasks 9 & 12 (bean field +
+mapping). The plan notes this and offers a staged assertion so tasks stay independently runnable.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to
+`docs/superpowers/plans/2026-08-27-workflow-execution-observability.md`.

--- a/docs/superpowers/specs/2026-08-27-workflow-execution-observability-design.md
+++ b/docs/superpowers/specs/2026-08-27-workflow-execution-observability-design.md
@@ -1,0 +1,201 @@
+# Workflow Execution Observability — Design
+
+- **Date:** 2026-08-27
+- **Status:** Approved (pending implementation plan)
+- **Branch:** `feat/workflow-execution-observability`
+
+## Problem
+
+Users cannot effectively determine what happened during a workflow execution — neither while it is
+running nor after it completes. The current state:
+
+- A workflow run persists as a single `WorkflowInstanceEntity` per project (unique `project_id`), so
+  re-triggering overwrites the previous run. There is no run history.
+- The execution `history` (per-node timestamps + output) lives only inside an opaque serialized
+  `instance_state` blob.
+- Workflow action nodes run as `TaskEntity` rows with a rich `executionLog`, but tasks store **no**
+  `nodeId`, and there is no UI path from a workflow node to the task's log. The log the user actually
+  needs is unreachable from the workflow view.
+- The tracing subsystem (`TraceEntity` / `TraceNodeEntity` / `TraceService`) — which already builds a
+  tree of task and MCP-tool-call activity — is completely disconnected from workflows. Workflow-spawned
+  tasks are created without a `traceId`, so they never join a trace tree.
+- The UI shows only a status badge, the current node, and a diagram; there is no step timeline, no
+  node→log drill-down, and no view of past runs.
+
+## Goal
+
+Let a user review a workflow execution — live and after completion — including which node is running,
+which nodes already ran and their outcomes, and the full per-node execution log and tool activity.
+Provide run history via a new **Logs → Workflow Runs** area, while keeping the project details page a
+lightweight current-run glance.
+
+## Approach
+
+**Hybrid (approach C):** a run-history table is the source of truth for workflow-run identity/status,
+wired into the existing tracing subsystem so the deep agent-activity drill-down comes for free.
+
+- Run-history persistence owns workflow identity, status, current node, and history.
+- Each run gets a trace root; workflow-spawned tasks receive a `traceId` and a task trace node, so
+  MCP tool calls nest under the node automatically — reusing existing task/tool instrumentation.
+- Precise **node → task → execution-log** linkage via a new `task.node_id`.
+
+Rejected alternatives: (A) dedicated workflow-run persistence with no tracing — loses the deep
+tool-call view; (B) trace-centric where a run *is* a trace — traces do not naturally hold
+workflow-specific identity/lifecycle.
+
+## Data Model
+
+New Flyway migration `V54` (repurposing the day-old `V53` schema):
+
+- Rename `workflow_instance` → **`workflow_run`**; entity `WorkflowInstanceEntity` →
+  **`WorkflowRunEntity`**. This also resolves the name collision between the engine's
+  `WorkflowInstance`, the API bean `WorkflowInstance`, and the entity.
+- **Drop `UNIQUE(project_id)`** — many runs per project.
+- Add **`trace_id UUID`** (nullable) — links a run to its execution trace.
+- Keep `instance_state`, `status`, `current_node_id`, `failure_reason`, `started_on`, `completed_on`,
+  `definition_id`, `definition_version`.
+- Rename `task.workflow_instance_id` → **`task.workflow_run_id`**; add **`task.node_id VARCHAR(255)`**.
+- Rename the sequence; add index **`(project_id, started_on DESC)`** for latest-run and per-project
+  filtering.
+
+**Business rule:** at most one *active* (non-terminal) run per project; terminal runs accumulate as
+history. Enforced in `triggerWorkflow`.
+
+**"Current run" for the project page** = the most recent run for the project by `started_on`. No
+separate pointer column.
+
+## Backend: Run Lifecycle & Trace Wiring
+
+All changes centered in `WorkflowExecutionService`.
+
+**On trigger (`triggerWorkflow`):**
+- Reject with **409** if an active run already exists for the project.
+- Insert a new `WorkflowRunEntity`.
+- Call `TraceService.createTrace(traceType="workflow", summary=<definition name>, projectId,
+  rootNodeType="workflow", rootNodeSummary=<definition name>, rootEntityType="workflow-run",
+  rootEntityId=run.id)` and store `run.traceId`.
+
+**On node task creation (`createTaskForCurrentNode`):**
+- Set `task.workflowRunId = run.id`, `task.nodeId = instance.currentNodeId()`,
+  `task.traceId = run.traceId`.
+- Create a **`task` trace node** under the run's root node (mirroring how `PipelineOrchestrator` sets
+  up event-pipeline task nodes), summarized with the node name + action type.
+- `TaskExecutionService` already looks up the task trace node by `traceId`/`entityId`, injects
+  `AXIOM_TRACE_ID` / `AXIOM_PARENT_NODE_ID`, and completes it — so MCP tool calls nest automatically
+  with no new instrumentation.
+
+**On run terminal (`onTaskCompleted` / `cancelWorkflow`):**
+- Set `run.completedOn` and call `TraceService.completeTrace(run.traceId, status)`.
+- Cancellation additionally marks the active task failed (existing behavior).
+
+**Trace is best-effort/additive:** `TraceService` runs in `requiringNew()`. If trace creation fails,
+the run proceeds with `trace_id = null`; node→log drill-down still works via `taskId`.
+
+**SSE:** extend `workflow-updated` from `{projectId}` to `{projectId, runId, status}` (additive;
+existing `WorkflowTab` filter-by-`projectId` keeps working). `trace-updated` already fires from
+`TraceService`.
+
+**Known limitation (upstream):** run *status* is derived from the engine instance, so until
+[apitomy-flow#38](https://github.com/Apitomy/apitomy-flow/issues/38) is fixed and a new Flow released,
+a failed node yields a "completed" run badge. The failed task and its trace node are recorded
+truthfully regardless, so drill-down is honest even before the fix. We will inherit the corrected run
+status from the new Flow release rather than duplicate engine logic in Axiom.
+
+## API Surface (contract-first)
+
+All operations are added to `openapi.json` first, then implemented against the generated interfaces.
+
+1. **`GET /projects/{projectId}/workflow`** (kept) — now returns the *latest* run. The
+   `WorkflowInstance` bean gains **`runId`** and **`traceId`**; each `HistoryEntry` gains **`taskId`**
+   and **`taskStatus`** (populated by joining the run's tasks on `node_id`).
+2. **`GET /workflow-runs`** (new, tag `WorkflowRuns`) — global paginated list, mirroring
+   `/scheduled-jobs/runs`. Query params: `projectId?`, `status?`, `page`, `pageSize`. Returns
+   `WorkflowRunSummary[]` + total.
+3. **`GET /workflow-runs/{runId}`** (new) — full run detail; same enriched shape as #1.
+4. **`GET /workflow-definitions/{workflowDefinitionId}/runs`** (new) — paginated runs for a specific
+   definition across all versions. Query params: `status?`, `page`, `pageSize`. Same
+   `WorkflowRunSummary[]` + total.
+5. **`Task` bean** gains **`workflowRunId`** and **`nodeId`**.
+
+**`WorkflowRunSummary`** schema: `{ runId, projectId, projectName, definitionName, definitionVersion,
+status, currentNodeName, startedOn, completedOn, traceId }`.
+
+**Reuse, not rebuild:** per-node execution logs stay on the existing
+`GET /projects/{projectId}/tasks/{taskId}/log`; the deep tool-call tree stays on
+`GET /traces/{traceId}`. The new endpoints expose run identity + the node→task→trace linkage that ties
+them together.
+
+**Impls:** enrich `toWorkflowInstanceBean` in `ProjectsResourceImpl`; add a new
+`WorkflowRunsResourceImpl` for #2/#3; add #4 to the existing `WorkflowDefinitionsResourceImpl`, reusing
+a shared run-summary query/mapper.
+
+## UI
+
+### Apitomy Flow dependency
+
+The node→log drill-down on the diagram likely requires enhancements to `@apitomy/flow-ui` (the
+`WorkflowViewer` renders its own node-detail panel with no host callback; we need something like an
+`onNodeClick(nodeId)` callback or pluggable node actions). There may also be a flow-engine/model item:
+history currently drops `edgeId` / `edgeCondition`, which the viewer needs for edge highlighting.
+
+**Deliverable:** during implementation, identify each required Apitomy Flow enhancement and file it as
+a GitHub issue on `Apitomy/apitomy-flow`.
+
+**Resilience:** the step-timeline is our own component, so it can offer node→log drill-down independent
+of flow-ui. If the flow-ui callback is not yet available, users still get drill-down via the Timeline
+tab while the diagram drill-down waits on a Flow release.
+
+### Project details page (`WorkflowTab`)
+
+Kept lightweight — current-run diagram, status badge, current node, cancel button, and **no timeline**.
+Add a prominent **"View run details →"** link to `/logs/workflow-runs/{runId}` for the current run.
+Rich review lives on the run detail page.
+
+### New Logs → Workflow Runs pages
+
+Registered in `AppSidebar` under **Logs** (route `/logs/workflow-runs`), following the Job Runs /
+Traces templates.
+
+- **`WorkflowRunsPage`** (list): table from `GET /workflow-runs` — project, definition + version,
+  status badge, current node, started/completed, duration. Filters for project + status; row click →
+  detail. Live via `workflow-updated` SSE (now carrying `runId` / `status`).
+- **`WorkflowRunDetailPage`** (`/logs/workflow-runs/:runId`), sourced from `GET /workflow-runs/{runId}`,
+  with PatternFly tabs (same pattern as `ProjectDetailPage`):
+  - **Overview** (default) — run metadata: definition + version, status, started/completed, duration,
+    trigger input/context summary, failure reason, aggregate cost/tokens across the run's tasks, and a
+    "View full execution trace →" link to `/logs/traces/{traceId}`.
+  - **Diagram** — the `WorkflowViewer` with node→log drill-down (pending the flow-ui enhancement).
+  - **Timeline** — full ordered step timeline (node name, status, timestamps, duration, View-log /
+    View-trace per step). Our own component; drill-down here is not blocked on flow-ui.
+  - **Execution Trace** — the full trace tree (run → node → task → MCP tool calls) embedded inline,
+    reusing the Traces detail view.
+
+**Reuse:** `ExecutionLogModal` and `WorkflowViewer` are reused as-is; the step-timeline is the one
+genuinely new shared component.
+
+**Deferred:** a per-definition runs UI. The `/workflow-definitions/{id}/runs` endpoint ships, but no
+page is built in this pass.
+
+## Testing
+
+JUnit 5 / `@QuarkusTest`, matching the existing `WorkflowInstanceResourceTest`:
+
+- Run history: multiple runs persist; "latest run for project" query; active-run **409** guard.
+- Trace wiring: trigger creates a trace root; `createTaskForCurrentNode` sets `node_id` /
+  `workflow_run_id` / `trace_id` and a task trace node under the root; terminal run calls
+  `completeTrace` and sets `completedOn`.
+- REST: `/workflow-runs` (filters + pagination), `/workflow-runs/{id}`,
+  `/workflow-definitions/{id}/runs`, and enriched `/projects/{id}/workflow` (history entries carry
+  `taskId`).
+- Update existing workflow tests for the rename.
+- Frontend: follow existing UI test conventions (if present) for the two new pages, the SSE handler,
+  and node-click → log modal.
+
+Compilation, bean regeneration, and test runs are handled manually by the developer.
+
+## Out of Scope
+
+- Fixing the run-status-on-node-failure defect (upstream [apitomy-flow#38](https://github.com/Apitomy/apitomy-flow/issues/38)).
+- A per-definition runs UI page.
+- Per-node retry semantics (multiple tasks per node) — the model is forward-compatible but retries are
+  not built here.

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9,7 +9,7 @@
             "version": "3",
             "dependencies": {
                 "@apitomy/common-ui-components": "4.1.2",
-                "@apitomy/flow-ui": "1.0.1",
+                "@apitomy/flow-ui": "1.0.2",
                 "@patternfly/react-charts": "8.6.1",
                 "@patternfly/react-code-editor": "6.6.1",
                 "@patternfly/react-core": "6.6.1",
@@ -86,9 +86,9 @@
             }
         },
         "node_modules/@apitomy/flow-ui": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@apitomy/flow-ui/-/flow-ui-1.0.1.tgz",
-            "integrity": "sha512-Vr72XeQlQp1ymuqtFKshDVEA0laFlIAbJYTrgxDA2pJmoBkfOiyiEQ9FFDnyMM7L3+HfbJWKLEs3y6kGtoXL5g==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@apitomy/flow-ui/-/flow-ui-1.0.2.tgz",
+            "integrity": "sha512-euuts2sxwLoSfIgB5RTWQRwi9IcmykpbDgfqhlOTAaaqbOcN1iS+zMIx5FzQgRTDSzCGy2qJMhaNhRpvljIl2w==",
             "license": "Apache-2.0",
             "peerDependencies": {
                 "@patternfly/patternfly": "^6.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,7 @@
     },
     "dependencies": {
         "@apitomy/common-ui-components": "4.1.2",
-        "@apitomy/flow-ui": "1.0.1",
+        "@apitomy/flow-ui": "1.0.2",
         "@patternfly/react-charts": "8.6.1",
         "echarts": "5.6.0",
         "victory-area": "37.3.6",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -50,6 +50,7 @@ import { ScheduledJobRunsPage } from "./pages/ScheduledJobRunsPage";
 import { WorkflowDefinitionsPage } from "./pages/WorkflowDefinitionsPage";
 import { WorkflowDefinitionDetailPage } from "./pages/WorkflowDefinitionDetailPage";
 import { WorkflowRunsPage } from "./pages/WorkflowRunsPage";
+import { WorkflowRunDetailPage } from "./pages/WorkflowRunDetailPage";
 import { type StartupCheck, fetchSystemHealth, fetchSystemConfig } from "./config/api";
 import { sseClient } from "./config/sse";
 
@@ -143,6 +144,7 @@ export function App() {
                         <Route path="/logs/traces" element={<TracesPage />} />
                         <Route path="/logs/traces/:traceId" element={<TraceDetailPage />} />
                         <Route path="/logs/workflow-runs" element={<WorkflowRunsPage />} />
+                        <Route path="/logs/workflow-runs/:runId" element={<WorkflowRunDetailPage />} />
                         <Route path="/reports" element={<ReportsPage />} />
                         <Route path="/reports/:reportId" element={<ReportDetailPage />} />
                         <Route path="/report-definitions" element={<ReportDefinitionsPage />} />

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -49,6 +49,7 @@ import { ScheduledJobDetailPage } from "./pages/ScheduledJobDetailPage";
 import { ScheduledJobRunsPage } from "./pages/ScheduledJobRunsPage";
 import { WorkflowDefinitionsPage } from "./pages/WorkflowDefinitionsPage";
 import { WorkflowDefinitionDetailPage } from "./pages/WorkflowDefinitionDetailPage";
+import { WorkflowRunsPage } from "./pages/WorkflowRunsPage";
 import { type StartupCheck, fetchSystemHealth, fetchSystemConfig } from "./config/api";
 import { sseClient } from "./config/sse";
 
@@ -141,6 +142,7 @@ export function App() {
                         <Route path="/logs/job-runs" element={<ScheduledJobRunsPage />} />
                         <Route path="/logs/traces" element={<TracesPage />} />
                         <Route path="/logs/traces/:traceId" element={<TraceDetailPage />} />
+                        <Route path="/logs/workflow-runs" element={<WorkflowRunsPage />} />
                         <Route path="/reports" element={<ReportsPage />} />
                         <Route path="/reports/:reportId" element={<ReportDetailPage />} />
                         <Route path="/report-definitions" element={<ReportDefinitionsPage />} />

--- a/ui/src/components/AppSidebar.tsx
+++ b/ui/src/components/AppSidebar.tsx
@@ -81,6 +81,9 @@ export function AppSidebar() {
                             <NavItem isActive={location.pathname.startsWith("/logs/traces")} onClick={() => navigate("/logs/traces")}>
                                 Traces
                             </NavItem>
+                            <NavItem isActive={location.pathname.startsWith("/logs/workflow-runs")} onClick={() => navigate("/logs/workflow-runs")}>
+                                Workflow Runs
+                            </NavItem>
                         </NavExpandable>
                         <NavExpandable title="Metrics"
                             isActive={location.pathname.startsWith("/metrics")}

--- a/ui/src/components/WorkflowStepTimeline.tsx
+++ b/ui/src/components/WorkflowStepTimeline.tsx
@@ -4,7 +4,6 @@ import { Link } from "react-router-dom";
 import type { HistoryEntryInfo } from "../config/api";
 
 interface WorkflowStepTimelineProps {
-    projectId: number;
     history: HistoryEntryInfo[];
     traceId?: string;
     onViewLog: (taskId: number) => void;

--- a/ui/src/components/WorkflowStepTimeline.tsx
+++ b/ui/src/components/WorkflowStepTimeline.tsx
@@ -1,0 +1,88 @@
+import { Button, Label } from "@patternfly/react-core";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+import { Link } from "react-router-dom";
+import type { HistoryEntryInfo } from "../config/api";
+
+interface WorkflowStepTimelineProps {
+    projectId: number;
+    history: HistoryEntryInfo[];
+    traceId?: string;
+    onViewLog: (taskId: number) => void;
+}
+
+const TASK_STATUS_COLORS: Record<string, "blue" | "green" | "grey" | "red" | "orange"> = {
+    Pending: "grey",
+    InProgress: "blue",
+    AwaitingInput: "orange",
+    Completed: "green",
+    Failed: "red",
+    Cancelled: "grey",
+};
+
+function stepDuration(entry: HistoryEntryInfo): string {
+    if (!entry.completedOn) return "—";
+    const ms = new Date(entry.completedOn).getTime()
+        - new Date(entry.enteredOn).getTime();
+    if (ms < 1000) return `${ms}ms`;
+    if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+    const mins = Math.floor(ms / 60_000);
+    const secs = Math.round((ms % 60_000) / 1000);
+    return `${mins}m ${secs}s`;
+}
+
+export function WorkflowStepTimeline({
+    history, traceId, onViewLog,
+}: WorkflowStepTimelineProps) {
+    if (history.length === 0) {
+        return <p>No steps have executed yet.</p>;
+    }
+    return (
+        <Table aria-label="Step Timeline" variant="compact">
+            <Thead>
+                <Tr>
+                    <Th>Step</Th>
+                    <Th>Task Status</Th>
+                    <Th>Entered</Th>
+                    <Th>Completed</Th>
+                    <Th>Duration</Th>
+                    <Th>Actions</Th>
+                </Tr>
+            </Thead>
+            <Tbody>
+                {history.map((entry, idx) => (
+                    <Tr key={`${entry.nodeId}-${idx}`}>
+                        <Td>{entry.nodeName || entry.nodeId}</Td>
+                        <Td>
+                            {entry.taskStatus && (
+                                <Label isCompact
+                                    color={TASK_STATUS_COLORS[entry.taskStatus] || "grey"}>
+                                    {entry.taskStatus}
+                                </Label>
+                            )}
+                        </Td>
+                        <Td style={{ whiteSpace: "nowrap" }}>
+                            {new Date(entry.enteredOn).toLocaleString()}
+                        </Td>
+                        <Td style={{ whiteSpace: "nowrap" }}>
+                            {entry.completedOn
+                                ? new Date(entry.completedOn).toLocaleString() : "—"}
+                        </Td>
+                        <Td style={{ whiteSpace: "nowrap" }}>{stepDuration(entry)}</Td>
+                        <Td>
+                            {entry.taskId != null && (
+                                <Button variant="link" isInline
+                                    onClick={() => onViewLog(entry.taskId!)}>
+                                    View Log
+                                </Button>
+                            )}
+                            {entry.taskId != null && traceId && " | "}
+                            {traceId && (
+                                <Link to={`/logs/traces/${traceId}`}>View Trace</Link>
+                            )}
+                        </Td>
+                    </Tr>
+                ))}
+            </Tbody>
+        </Table>
+    );
+}

--- a/ui/src/components/WorkflowTab.tsx
+++ b/ui/src/components/WorkflowTab.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import {
     Alert,
     Button, EmptyState, EmptyStateBody,
@@ -8,9 +8,12 @@ import {
     FormSelect, FormSelectOption,
 } from "@patternfly/react-core";
 import { WorkflowViewer } from "@apitomy/flow-ui";
-import type { Workflow, WorkflowInstance } from "@apitomy/flow-ui";
+import type {
+    Workflow, WorkflowInstance, WorkflowViewerNodeMenuItem,
+} from "@apitomy/flow-ui";
 import { useEffectiveTheme } from "../hooks/useTheme";
 import { ConfirmDeleteModal } from "./ConfirmDeleteModal";
+import { ExecutionLogModal } from "./ExecutionLogModal";
 import {
     type WorkflowDefinition, type WorkflowInstanceInfo,
     fetchWorkflowDefinitions, triggerWorkflow,
@@ -27,11 +30,14 @@ export function WorkflowTab({
     projectId, hasWorkflowInstance, onRefresh,
 }: WorkflowTabProps) {
     const effectiveTheme = useEffectiveTheme();
+    const navigate = useNavigate();
     const [instance, setInstance] =
         useState<WorkflowInstanceInfo | null>(null);
     const [loading, setLoading] = useState(true);
     const [isTriggerOpen, setIsTriggerOpen] = useState(false);
     const [isCancelOpen, setIsCancelOpen] = useState(false);
+    const [isLogOpen, setIsLogOpen] = useState(false);
+    const [logTaskId, setLogTaskId] = useState<number | null>(null);
     const [definitions, setDefinitions] =
         useState<WorkflowDefinition[]>([]);
     const [selectedDefId, setSelectedDefId] = useState("");
@@ -148,6 +154,34 @@ export function WorkflowTab({
             updatedOn: instance.completedOn || instance.startedOn,
         } as WorkflowInstance;
     }, [instance]);
+
+    // Host-contributed right-click actions for a viewer node: open that node's
+    // task execution log, and jump to the full run detail page.
+    const nodeMenuItems = useCallback(
+        (nodeId: string): WorkflowViewerNodeMenuItem[] => {
+            if (!instance) return [];
+            const items: WorkflowViewerNodeMenuItem[] = [];
+            const entry = (instance.history || []).find(
+                (h) => h.nodeId === nodeId);
+            if (entry?.taskId != null) {
+                const taskId = entry.taskId;
+                items.push({
+                    id: "open-log",
+                    label: "Open execution log",
+                    onSelect: () => {
+                        setLogTaskId(taskId);
+                        setIsLogOpen(true);
+                    },
+                });
+            }
+            items.push({
+                id: "view-run",
+                label: "View run details",
+                onSelect: () => navigate(
+                    `/logs/workflow-runs/${instance.id}`),
+            });
+            return items;
+        }, [instance, navigate]);
 
     if (loading) {
         return <EmptyState><EmptyStateBody>
@@ -310,6 +344,7 @@ export function WorkflowTab({
                         instance={viewerInstance}
                         theme={effectiveTheme === "dark"
                             ? "dark" : "light"}
+                        nodeContextMenuItems={nodeMenuItems}
                     />
                 </div>
             )}
@@ -323,6 +358,13 @@ export function WorkflowTab({
                 Are you sure you want to cancel this workflow?
                 Any in-progress tasks will be stopped.
             </ConfirmDeleteModal>
+
+            <ExecutionLogModal
+                isOpen={isLogOpen}
+                projectId={projectId}
+                taskId={logTaskId}
+                onClose={() => setIsLogOpen(false)}
+            />
         </div>
     );
 }

--- a/ui/src/components/WorkflowTab.tsx
+++ b/ui/src/components/WorkflowTab.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
+import { Link } from "react-router-dom";
 import {
     Alert,
     Button, EmptyState, EmptyStateBody,
@@ -281,6 +282,11 @@ export function WorkflowTab({
                         </Button>
                     </FlexItem>
                 )}
+                <FlexItem>
+                    <Link to={`/logs/workflow-runs/${instance.id}`}>
+                        View run details →
+                    </Link>
+                </FlexItem>
             </Flex>
 
             {instance.failureReason && (

--- a/ui/src/components/WorkflowTab.tsx
+++ b/ui/src/components/WorkflowTab.tsx
@@ -137,8 +137,8 @@ export function WorkflowTab({
             history: (instance.history || []).map((h) => ({
                 nodeId: h.nodeId,
                 nodeName: h.nodeName,
-                edgeId: "",
-                edgeCondition: "",
+                edgeId: h.edgeId ?? "",
+                edgeCondition: h.edgeCondition ?? "",
                 enteredOn: h.enteredOn,
                 completedOn: h.completedOn || "",
                 output: h.output || {},

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -2233,6 +2233,8 @@ export interface HistoryEntryInfo {
     output?: any;
     taskId?: number;
     taskStatus?: string;
+    edgeId?: string;
+    edgeCondition?: string;
 }
 
 export interface TriggerWorkflowRequest {

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -2125,7 +2125,7 @@ export async function fetchWorkflowDefinitions(
     params.set("page", String(page));
     params.set("limit", String(limit));
     if (filterName) params.set("filterName", filterName);
-    const response = await fetch(`${API}/workflow-definitions?${params}`);
+    const response = await fetch(`${API}/workflow/definitions?${params}`);
     if (!response.ok) throw new Error(`Failed to fetch workflow definitions: ${response.status}`);
     return response.json();
 }
@@ -2133,7 +2133,7 @@ export async function fetchWorkflowDefinitions(
 export async function createWorkflowDefinition(
     data: NewWorkflowDefinition
 ): Promise<WorkflowDefinition> {
-    const response = await fetch(`${API}/workflow-definitions`, {
+    const response = await fetch(`${API}/workflow/definitions`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(data),
@@ -2143,7 +2143,7 @@ export async function createWorkflowDefinition(
 }
 
 export async function getWorkflowDefinition(id: number): Promise<WorkflowDefinition> {
-    const response = await fetch(`${API}/workflow-definitions/${id}`);
+    const response = await fetch(`${API}/workflow/definitions/${id}`);
     if (!response.ok) throw new Error(`Failed to get workflow definition: ${response.status}`);
     return response.json();
 }
@@ -2151,7 +2151,7 @@ export async function getWorkflowDefinition(id: number): Promise<WorkflowDefinit
 export async function updateWorkflowDefinition(
     id: number, data: UpdateWorkflowDefinition
 ): Promise<WorkflowDefinition> {
-    const response = await fetch(`${API}/workflow-definitions/${id}`, {
+    const response = await fetch(`${API}/workflow/definitions/${id}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(data),
@@ -2163,7 +2163,7 @@ export async function updateWorkflowDefinition(
 export async function updateWorkflowDefinitionContent(
     id: number, content: any
 ): Promise<void> {
-    const response = await fetch(`${API}/workflow-definitions/${id}/content`, {
+    const response = await fetch(`${API}/workflow/definitions/${id}/content`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(content),
@@ -2174,7 +2174,7 @@ export async function updateWorkflowDefinitionContent(
 export async function publishWorkflowDefinition(
     id: number
 ): Promise<WorkflowDefinitionVersion> {
-    const response = await fetch(`${API}/workflow-definitions/${id}/publish`, {
+    const response = await fetch(`${API}/workflow/definitions/${id}/publish`, {
         method: "POST",
     });
     if (!response.ok) throw new Error(`Failed to publish workflow definition: ${response.status}`);
@@ -2182,7 +2182,7 @@ export async function publishWorkflowDefinition(
 }
 
 export async function deleteWorkflowDefinition(id: number): Promise<void> {
-    const response = await fetch(`${API}/workflow-definitions/${id}`, {
+    const response = await fetch(`${API}/workflow/definitions/${id}`, {
         method: "DELETE",
     });
     if (!response.ok) throw new Error(`Failed to delete workflow definition: ${response.status}`);
@@ -2191,7 +2191,7 @@ export async function deleteWorkflowDefinition(id: number): Promise<void> {
 export async function listWorkflowDefinitionVersions(
     id: number
 ): Promise<WorkflowDefinitionVersion[]> {
-    const response = await fetch(`${API}/workflow-definitions/${id}/versions`);
+    const response = await fetch(`${API}/workflow/definitions/${id}/versions`);
     if (!response.ok) throw new Error(`Failed to list versions: ${response.status}`);
     return response.json();
 }
@@ -2199,7 +2199,7 @@ export async function listWorkflowDefinitionVersions(
 export async function getWorkflowDefinitionVersion(
     id: number, version: number
 ): Promise<WorkflowDefinitionVersion> {
-    const response = await fetch(`${API}/workflow-definitions/${id}/versions/${version}`);
+    const response = await fetch(`${API}/workflow/definitions/${id}/versions/${version}`);
     if (!response.ok) throw new Error(`Failed to get version: ${response.status}`);
     return response.json();
 }

--- a/ui/src/config/api.ts
+++ b/ui/src/config/api.ts
@@ -116,6 +116,8 @@ export interface Task {
     completedOn?: string;
     sessionId?: string;
     traceId?: string;
+    workflowRunId?: number;
+    nodeId?: string;
 }
 
 export interface ThreadEntry {
@@ -2219,6 +2221,8 @@ export interface WorkflowInstanceInfo {
     history: HistoryEntryInfo[];
     startedOn: string;
     completedOn?: string;
+    runId?: number;
+    traceId?: string;
 }
 
 export interface HistoryEntryInfo {
@@ -2227,6 +2231,8 @@ export interface HistoryEntryInfo {
     enteredOn: string;
     completedOn?: string;
     output?: any;
+    taskId?: number;
+    taskStatus?: string;
 }
 
 export interface TriggerWorkflowRequest {
@@ -2284,4 +2290,50 @@ export async function cancelWorkflow(
         throw new Error(
             `Failed to cancel workflow: ${response.status}`);
     }
+}
+
+export interface WorkflowRunSummary {
+    runId: number;
+    projectId: number;
+    projectName?: string;
+    definitionId: number;
+    definitionName?: string;
+    definitionVersion: number;
+    status: string;
+    currentNodeName?: string;
+    traceId?: string;
+    startedOn: string;
+    completedOn?: string;
+}
+
+export async function fetchWorkflowRuns(
+    page = 1, limit = 20, projectId?: number, status?: string
+): Promise<SearchResults<WorkflowRunSummary>> {
+    const params = new URLSearchParams();
+    params.set("page", String(page));
+    params.set("limit", String(limit));
+    if (projectId != null) params.set("projectId", String(projectId));
+    if (status) params.set("status", status);
+    const response = await fetch(`${API}/workflow/runs?${params}`);
+    if (!response.ok) throw new Error(`Failed to fetch workflow runs: ${response.status}`);
+    return response.json();
+}
+
+export async function getWorkflowRun(runId: number): Promise<WorkflowInstanceInfo> {
+    const response = await fetch(`${API}/workflow/runs/${runId}`);
+    if (!response.ok) throw new Error(`Failed to fetch workflow run: ${response.status}`);
+    return response.json();
+}
+
+export async function fetchWorkflowDefinitionRuns(
+    definitionId: number, page = 1, limit = 20, status?: string
+): Promise<SearchResults<WorkflowRunSummary>> {
+    const params = new URLSearchParams();
+    params.set("page", String(page));
+    params.set("limit", String(limit));
+    if (status) params.set("status", status);
+    const response = await fetch(
+        `${API}/workflow/definitions/${definitionId}/runs?${params}`);
+    if (!response.ok) throw new Error(`Failed to fetch definition runs: ${response.status}`);
+    return response.json();
 }

--- a/ui/src/pages/WorkflowRunDetailPage.tsx
+++ b/ui/src/pages/WorkflowRunDetailPage.tsx
@@ -1,0 +1,176 @@
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { useParams, Link } from "react-router-dom";
+import {
+    Breadcrumb, BreadcrumbItem, Button, Flex, FlexItem, Label,
+    PageSection, Tab, TabTitleText, Tabs, Title,
+} from "@patternfly/react-core";
+import SyncAltIcon from "@patternfly/react-icons/dist/esm/icons/sync-alt-icon";
+import { WorkflowViewer } from "@apitomy/flow-ui";
+import type { Workflow, WorkflowInstance as FlowInstance } from "@apitomy/flow-ui";
+import { TraceGraph } from "../components/TraceGraph";
+import { WorkflowStepTimeline } from "../components/WorkflowStepTimeline";
+import { ExecutionLogModal } from "../components/ExecutionLogModal";
+import { getWorkflowRun, type WorkflowInstanceInfo } from "../config/api";
+import { sseClient, type AxiomSseEvent } from "../config/sse";
+import { useEffectiveTheme } from "../hooks/useTheme";
+
+const STATUS_COLORS: Record<string, "blue" | "green" | "orange" | "grey" | "red"> = {
+    running: "blue", waiting: "orange", completed: "green",
+    failed: "red", cancelled: "grey",
+};
+
+export function WorkflowRunDetailPage() {
+    const { runId } = useParams<{ runId: string }>();
+    const numericRunId = Number(runId);
+    const [run, setRun] = useState<WorkflowInstanceInfo | null>(null);
+    const [activeTab, setActiveTab] = useState(0);
+    const [refreshKey, setRefreshKey] = useState(0);
+    const [isLogOpen, setIsLogOpen] = useState(false);
+    const [logTaskId, setLogTaskId] = useState<number | null>(null);
+    const effectiveTheme = useEffectiveTheme();
+
+    const load = useCallback(() => {
+        getWorkflowRun(numericRunId).then(setRun).catch(console.error);
+    }, [numericRunId]);
+
+    useEffect(() => { load(); }, [load]);
+
+    useEffect(() => {
+        let timeout: ReturnType<typeof setTimeout>;
+        const unsubscribe = sseClient.subscribe((event: AxiomSseEvent) => {
+            if (event.type === "workflow-updated"
+                    && (event.data as { runId?: number }).runId === numericRunId) {
+                clearTimeout(timeout);
+                timeout = setTimeout(() => { load(); setRefreshKey((k) => k + 1); }, 300);
+            }
+        });
+        return () => { clearTimeout(timeout); unsubscribe(); };
+    }, [numericRunId, load]);
+
+    const workflowContent = useMemo(
+        () => (run?.workflowContent as Workflow | undefined), [run]);
+    const viewerInstance = useMemo<FlowInstance | undefined>(() => {
+        if (!run) return undefined;
+        return {
+            currentNodeId: run.currentNodeId ?? "",
+            status: run.status,
+            history: (run.history ?? []).map((h) => ({
+                nodeId: h.nodeId, nodeName: h.nodeName,
+                edgeId: "", edgeCondition: "",
+                enteredOn: h.enteredOn, completedOn: h.completedOn ?? "",
+                output: h.output ?? {},
+            })),
+            createdOn: run.startedOn,
+            updatedOn: run.completedOn ?? run.startedOn,
+        } as FlowInstance;
+    }, [run]);
+
+    if (!run) {
+        return <PageSection><p>Loading workflow run...</p></PageSection>;
+    }
+
+    const openLog = (taskId: number) => { setLogTaskId(taskId); setIsLogOpen(true); };
+
+    return (
+        <PageSection>
+            <Breadcrumb style={{ marginBottom: "12px" }}>
+                <BreadcrumbItem render={() => (
+                    <Link to="/logs/workflow-runs">Workflow Runs</Link>)} />
+                <BreadcrumbItem isActive>Run #{run.runId}</BreadcrumbItem>
+            </Breadcrumb>
+
+            <Flex justifyContent={{ default: "justifyContentSpaceBetween" }}
+                alignItems={{ default: "alignItemsCenter" }}
+                style={{ marginBottom: "16px" }}>
+                <FlexItem>
+                    <Title headingLevel="h1" size="lg">
+                        {run.definitionName} v{run.definitionVersion}{" "}
+                        <Label color={STATUS_COLORS[run.status] || "grey"}>
+                            {run.status}
+                        </Label>
+                    </Title>
+                </FlexItem>
+                <FlexItem>
+                    <Button variant="control" aria-label="Refresh"
+                        onClick={() => { load(); setRefreshKey((k) => k + 1); }}>
+                        <SyncAltIcon />
+                    </Button>
+                </FlexItem>
+            </Flex>
+
+            <Tabs activeKey={activeTab} onSelect={(_e, k) => setActiveTab(k as number)}>
+                <Tab eventKey={0} title={<TabTitleText>Overview</TabTitleText>} />
+                <Tab eventKey={1} title={<TabTitleText>Diagram</TabTitleText>} />
+                <Tab eventKey={2} title={<TabTitleText>Timeline</TabTitleText>} />
+                <Tab eventKey={3} title={<TabTitleText>Execution Trace</TabTitleText>} />
+            </Tabs>
+
+            <div style={{ paddingTop: "16px" }}>
+                {activeTab === 0 && (
+                    <dl>
+                        <dt><strong>Workflow</strong></dt>
+                        <dd>{run.definitionName} v{run.definitionVersion}</dd>
+                        <dt><strong>Status</strong></dt>
+                        <dd>{run.status}</dd>
+                        <dt><strong>Started</strong></dt>
+                        <dd>{new Date(run.startedOn).toLocaleString()}</dd>
+                        <dt><strong>Completed</strong></dt>
+                        <dd>{run.completedOn
+                            ? new Date(run.completedOn).toLocaleString() : "—"}</dd>
+                        {run.failureReason && (
+                            <>
+                                <dt><strong>Failure</strong></dt>
+                                <dd>{run.failureReason}</dd>
+                            </>
+                        )}
+                        {run.traceId && (
+                            <>
+                                <dt><strong>Trace</strong></dt>
+                                <dd>
+                                    <Link to={`/logs/traces/${run.traceId}`}>
+                                        View full execution trace →
+                                    </Link>
+                                </dd>
+                            </>
+                        )}
+                    </dl>
+                )}
+
+                {activeTab === 1 && workflowContent && viewerInstance && (
+                    <div style={{ height: "calc(100vh - 320px)", minHeight: "500px" }}>
+                        <WorkflowViewer
+                            workflow={workflowContent}
+                            instance={viewerInstance}
+                            theme={effectiveTheme === "dark" ? "dark" : "light"}
+                        />
+                    </div>
+                )}
+
+                {activeTab === 2 && (
+                    <WorkflowStepTimeline
+                        projectId={run.projectId}
+                        history={run.history ?? []}
+                        traceId={run.traceId}
+                        onViewLog={openLog}
+                    />
+                )}
+
+                {activeTab === 3 && run.traceId && (
+                    <div style={{ height: "calc(100vh - 320px)", minHeight: "500px" }}>
+                        <TraceGraph traceId={run.traceId} refreshKey={refreshKey} />
+                    </div>
+                )}
+                {activeTab === 3 && !run.traceId && (
+                    <p>No execution trace is available for this run.</p>
+                )}
+            </div>
+
+            <ExecutionLogModal
+                isOpen={isLogOpen}
+                projectId={run.projectId}
+                taskId={logTaskId}
+                onClose={() => setIsLogOpen(false)}
+            />
+        </PageSection>
+    );
+}

--- a/ui/src/pages/WorkflowRunDetailPage.tsx
+++ b/ui/src/pages/WorkflowRunDetailPage.tsx
@@ -6,7 +6,9 @@ import {
 } from "@patternfly/react-core";
 import SyncAltIcon from "@patternfly/react-icons/dist/esm/icons/sync-alt-icon";
 import { WorkflowViewer } from "@apitomy/flow-ui";
-import type { Workflow, WorkflowInstance as FlowInstance } from "@apitomy/flow-ui";
+import type {
+    Workflow, WorkflowInstance as FlowInstance, WorkflowViewerNodeMenuItem,
+} from "@apitomy/flow-ui";
 import { TraceGraph } from "../components/TraceGraph";
 import { WorkflowStepTimeline } from "../components/WorkflowStepTimeline";
 import { ExecutionLogModal } from "../components/ExecutionLogModal";
@@ -74,6 +76,29 @@ export function WorkflowRunDetailPage() {
     }
 
     const openLog = (taskId: number) => { setLogTaskId(taskId); setIsLogOpen(true); };
+
+    // Host-contributed right-click actions for a viewer node: open that node's
+    // task execution log, and jump to the run's execution trace tab.
+    const nodeMenuItems = (nodeId: string): WorkflowViewerNodeMenuItem[] => {
+        const items: WorkflowViewerNodeMenuItem[] = [];
+        const entry = (run.history ?? []).find((h) => h.nodeId === nodeId);
+        if (entry?.taskId != null) {
+            const taskId = entry.taskId;
+            items.push({
+                id: "open-log",
+                label: "Open execution log",
+                onSelect: () => openLog(taskId),
+            });
+        }
+        if (run.traceId) {
+            items.push({
+                id: "view-trace",
+                label: "View in execution trace",
+                onSelect: () => setActiveTab(3),
+            });
+        }
+        return items;
+    };
 
     return (
         <PageSection>
@@ -146,6 +171,7 @@ export function WorkflowRunDetailPage() {
                             workflow={workflowContent}
                             instance={viewerInstance}
                             theme={effectiveTheme === "dark" ? "dark" : "light"}
+                            nodeContextMenuItems={nodeMenuItems}
                         />
                     </div>
                 )}

--- a/ui/src/pages/WorkflowRunDetailPage.tsx
+++ b/ui/src/pages/WorkflowRunDetailPage.tsx
@@ -52,14 +52,18 @@ export function WorkflowRunDetailPage() {
     const viewerInstance = useMemo<FlowInstance | undefined>(() => {
         if (!run) return undefined;
         return {
+            id: String(run.id),
+            workflowId: String(run.definitionId),
             currentNodeId: run.currentNodeId ?? "",
-            status: run.status,
+            status: run.status as any,
+            context: run.context || {},
             history: (run.history ?? []).map((h) => ({
                 nodeId: h.nodeId, nodeName: h.nodeName,
                 edgeId: "", edgeCondition: "",
                 enteredOn: h.enteredOn, completedOn: h.completedOn ?? "",
                 output: h.output ?? {},
             })),
+            failureReason: run.failureReason,
             createdOn: run.startedOn,
             updatedOn: run.completedOn ?? run.startedOn,
         } as FlowInstance;
@@ -148,7 +152,6 @@ export function WorkflowRunDetailPage() {
 
                 {activeTab === 2 && (
                     <WorkflowStepTimeline
-                        projectId={run.projectId}
                         history={run.history ?? []}
                         traceId={run.traceId}
                         onViewLog={openLog}

--- a/ui/src/pages/WorkflowRunDetailPage.tsx
+++ b/ui/src/pages/WorkflowRunDetailPage.tsx
@@ -59,6 +59,8 @@ export function WorkflowRunDetailPage() {
             context: run.context || {},
             history: (run.history ?? []).map((h) => ({
                 nodeId: h.nodeId, nodeName: h.nodeName,
+                // edgeId/edgeCondition are empty because the engine history does not
+                // retain traversed edges yet — see Apitomy/apitomy-flow#41.
                 edgeId: "", edgeCondition: "",
                 enteredOn: h.enteredOn, completedOn: h.completedOn ?? "",
                 output: h.output ?? {},

--- a/ui/src/pages/WorkflowRunDetailPage.tsx
+++ b/ui/src/pages/WorkflowRunDetailPage.tsx
@@ -59,9 +59,7 @@ export function WorkflowRunDetailPage() {
             context: run.context || {},
             history: (run.history ?? []).map((h) => ({
                 nodeId: h.nodeId, nodeName: h.nodeName,
-                // edgeId/edgeCondition are empty because the engine history does not
-                // retain traversed edges yet — see Apitomy/apitomy-flow#41.
-                edgeId: "", edgeCondition: "",
+                edgeId: h.edgeId ?? "", edgeCondition: h.edgeCondition ?? "",
                 enteredOn: h.enteredOn, completedOn: h.completedOn ?? "",
                 output: h.output ?? {},
             })),

--- a/ui/src/pages/WorkflowRunsPage.tsx
+++ b/ui/src/pages/WorkflowRunsPage.tsx
@@ -1,0 +1,146 @@
+import { useState, useEffect, useCallback } from "react";
+import { Link } from "react-router-dom";
+import {
+    Button,
+    EmptyState,
+    EmptyStateBody,
+    Label,
+    PageSection,
+    Pagination,
+    Title,
+    Toolbar,
+    ToolbarContent,
+    ToolbarItem,
+} from "@patternfly/react-core";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+import SyncAltIcon from "@patternfly/react-icons/dist/esm/icons/sync-alt-icon";
+import { type WorkflowRunSummary, fetchWorkflowRuns } from "../config/api";
+import { sseClient, type AxiomSseEvent } from "../config/sse";
+
+const STATUS_COLORS: Record<string, "blue" | "green" | "orange" | "grey" | "red"> = {
+    running: "blue",
+    waiting: "orange",
+    completed: "green",
+    failed: "red",
+    cancelled: "grey",
+};
+
+function formatDuration(startedOn: string, completedOn?: string): string {
+    if (!completedOn) return "—";
+    const ms = new Date(completedOn).getTime() - new Date(startedOn).getTime();
+    if (ms < 1000) return `${ms}ms`;
+    if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+    const mins = Math.floor(ms / 60_000);
+    const secs = Math.round((ms % 60_000) / 1000);
+    return `${mins}m ${secs}s`;
+}
+
+export function WorkflowRunsPage() {
+    const [runs, setRuns] = useState<WorkflowRunSummary[]>([]);
+    const [totalCount, setTotalCount] = useState(0);
+    const [page, setPage] = useState(1);
+    const [perPage, setPerPage] = useState(20);
+    const [loading, setLoading] = useState(true);
+
+    const loadData = useCallback(() => {
+        setLoading(true);
+        fetchWorkflowRuns(page, perPage)
+            .then((results) => {
+                setRuns(results.items);
+                setTotalCount(results.totalCount);
+            })
+            .catch(console.error)
+            .finally(() => setLoading(false));
+    }, [page, perPage]);
+
+    useEffect(() => { loadData(); }, [loadData]);
+
+    useEffect(() => {
+        let timeout: ReturnType<typeof setTimeout>;
+        const unsubscribe = sseClient.subscribe((event: AxiomSseEvent) => {
+            if (event.type === "workflow-updated") {
+                clearTimeout(timeout);
+                timeout = setTimeout(loadData, 300);
+            }
+        });
+        return () => { clearTimeout(timeout); unsubscribe(); };
+    }, [loadData]);
+
+    return (
+        <PageSection>
+            <Title headingLevel="h1" size="lg" style={{ marginBottom: "16px" }}>
+                Workflow Runs
+            </Title>
+
+            <Toolbar>
+                <ToolbarContent>
+                    <ToolbarItem>
+                        <Button variant="control" aria-label="Refresh" onClick={loadData}>
+                            <SyncAltIcon />
+                        </Button>
+                    </ToolbarItem>
+                    <ToolbarItem variant="pagination" align={{ default: "alignEnd" }}>
+                        <Pagination
+                            itemCount={totalCount}
+                            page={page}
+                            perPage={perPage}
+                            onSetPage={(_e, p) => setPage(p)}
+                            onPerPageSelect={(_e, pp) => { setPerPage(pp); setPage(1); }}
+                            isCompact
+                        />
+                    </ToolbarItem>
+                </ToolbarContent>
+            </Toolbar>
+
+            {loading ? (
+                <EmptyState><EmptyStateBody>Loading workflow runs...</EmptyStateBody></EmptyState>
+            ) : runs.length === 0 ? (
+                <EmptyState><EmptyStateBody>No workflow runs recorded yet.</EmptyStateBody></EmptyState>
+            ) : (
+                <Table aria-label="Workflow Runs" variant="compact">
+                    <Thead>
+                        <Tr>
+                            <Th>Status</Th>
+                            <Th>Project</Th>
+                            <Th>Workflow</Th>
+                            <Th>Started</Th>
+                            <Th>Duration</Th>
+                            <Th>Actions</Th>
+                        </Tr>
+                    </Thead>
+                    <Tbody>
+                        {runs.map((run) => (
+                            <Tr key={run.runId}>
+                                <Td>
+                                    <Label isCompact color={STATUS_COLORS[run.status] || "grey"}>
+                                        {run.status}
+                                    </Label>
+                                </Td>
+                                <Td>
+                                    <Link to={`/projects/${run.projectId}`}>
+                                        {run.projectName || `Project #${run.projectId}`}
+                                    </Link>
+                                </Td>
+                                <Td>
+                                    {run.definitionName || `Definition #${run.definitionId}`}
+                                    {" v"}{run.definitionVersion}
+                                </Td>
+                                <Td style={{ whiteSpace: "nowrap" }}>
+                                    {new Date(run.startedOn).toLocaleString()}
+                                </Td>
+                                <Td style={{ whiteSpace: "nowrap" }}>
+                                    {formatDuration(run.startedOn, run.completedOn)}
+                                </Td>
+                                <Td>
+                                    <Link to={`/logs/workflow-runs/${run.runId}`}>
+                                        View details
+                                    </Link>
+                                </Td>
+                            </Tr>
+                        ))}
+                    </Tbody>
+                </Table>
+            )}
+        </PageSection>
+    );
+}


### PR DESCRIPTION
## Summary

Adds end-to-end observability for workflow executions — live and post-completion. Users can now see
which node is running, which nodes have run and their outcomes, per-node execution logs, and tool
activity. A `workflow_run` history table becomes the source of truth and is wired into the tracing
subsystem; run history is exposed through a new **Logs → Workflow Runs** area, while the project
details page stays a lightweight current-run glance.

## What's included

**Data model & backend**
- Flyway `V54`: migrate `workflow_instance` → `workflow_run` history table (drop `UNIQUE(project_id)`,
  add `trace_id`, `task.workflow_run_id`, `task.node_id`, `(project_id, started_on DESC)` index).
- Rename `WorkflowInstanceEntity` → `WorkflowRunEntity` and the task linkage fields; propagate
  everywhere.
- Per-run trace root on trigger; node tasks stamped with run/node/trace; trace completed on terminal
  run states. All tracing is best-effort (a tracing failure never breaks the run lifecycle).
- Stop `TaskExecutionService` from prematurely completing workflow traces.
- Enriched `workflow-updated` SSE event with `{projectId, runId, status}`.

**REST API (contract-first)**
- All workflow endpoints namespaced under `/workflow/*`: `/workflow/definitions*` and `/workflow/runs*`
  (renamed from `/workflow-definitions*` to resolve a codegen path-grouping collision).
- New: `GET /workflow/runs` (list, with project/status filters + pagination), `GET /workflow/runs/{runId}`
  (detail), `GET /workflow/definitions/{workflowDefinitionId}/runs` (per-definition list).
- Enriched project workflow endpoint returns the latest run with `runId`/`traceId` and history entries
  carrying `taskId`/`taskStatus`; `Task` bean gains `workflowRunId`/`nodeId`.
- `HistoryEntry` now carries `edgeId`/`edgeCondition` end-to-end so the diagram can highlight the actual
  path taken through the workflow (the flow engine already records these; Axiom now passes them through
  instead of hardcoding empty strings).
- Shared `WorkflowRunBeanMapper` (`toBean`/`search`) backing the run endpoints (batched name lookups,
  no N+1).

**UI**
- **Logs → Workflow Runs** list page (status labels, pagination, live SSE refresh, row links).
- Tabbed run-detail page: Overview / Diagram (WorkflowViewer) / Timeline / Execution Trace (TraceGraph),
  with an execution-log modal; SSE scoped to the run.
- "View run details →" link from the project Workflow tab (project page stays lightweight — no timeline).

## Testing

`./build.sh` — full suite green (373 tests). Coverage includes the run lifecycle, active-run 409 guard,
trace root/node wiring, "trace stays open until the run completes", REST list/detail/definition-runs,
the enriched project workflow response, and a regression test proving cancel targets the active run
rather than an arbitrary prior (terminal) run.

## Related enhancement issue (Apitomy Flow)

- Apitomy/apitomy-flow#40 — `WorkflowViewer`: expose an `onNodeClick` callback for host-driven node
  actions (needed for click-to-drill-down from the Diagram tab into a node's execution log/trace).

> Note: Apitomy/apitomy-flow#41 (retain `edgeId`/`edgeCondition`) turned out to be already implemented
> in the Flow engine and viewer — the real gap was host-side, now fixed here (see the `HistoryEntry`
> pass-through above).

## Known follow-ups (non-blocking)

- Add project/status filter controls to the Workflow Runs list page (the fetch API already accepts them).
- Enrich the run-detail Overview with duration, trigger-input/context summary, and aggregate
  cost/tokens across the run's tasks.
- Populate or drop the currently-unused `WorkflowRunSummary.currentNodeName` field (omitted on the list
  to avoid an N+1 content read).

## Note on the API change

Renaming `/workflow-definitions*` → `/workflow/definitions*` is a breaking URL change for that internal
API; all in-repo consumers (tests + UI) were updated in the same branch.
