### PR TITLE
Defer internal task event emission until after output-contract validation

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/TaskExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/TaskExecutionService.java
@@ -547,13 +547,19 @@ public class TaskExecutionService {
         // Update project status back to Idle if no more active tasks
         updateProjectStatusAfterTask(task.projectId);
 
-        // Emit internal event if configured
-        emitInternalEventIfNeeded(task);
-
-        // Advance workflow if this task is part of one
+        // Advance workflow if this task is part of one. This runs output-contract
+        // validation and may transition the task to Failed. It shares this
+        // transaction's persistence context, so any status change is reflected in
+        // the managed `task` entity below.
         if (task.workflowRunId != null) {
             workflowExecutionService.onTaskCompleted(task.id);
         }
+
+        // Emit internal event if configured. Deferred until after workflow
+        // output-contract validation so consumers never observe a "completed"
+        // task that the workflow layer immediately fails (the emitted event type
+        // reflects the final, post-validation task status).
+        emitInternalEventIfNeeded(task);
     }
 
     @Transactional


### PR DESCRIPTION
## Summary

Fixes #272.

`TaskExecutionService.onTaskCompleted` previously emitted the internal `task-completed` event (via `emitInternalEventIfNeeded`) **before** calling `workflowExecutionService.onTaskCompleted(task.id)`, which runs output-contract validation and may transition the task to `Failed`. As a result, downstream consumers of the internal event could observe a task as `completed` even when the workflow layer immediately failed it during validation.

## Change

Reorder the two calls in `TaskExecutionService.onTaskCompleted` so that the workflow advancement (and its output-contract validation) runs **before** `emitInternalEventIfNeeded(task)`.

Both `TaskExecutionService.onTaskCompleted` and `WorkflowExecutionService.onTaskCompleted` are `@Transactional` and run in the same thread/transaction (default `REQUIRED` propagation), so `TaskEntity.findById` returns the same managed entity instance. Any status flip to `Failed` performed by the workflow layer is therefore reflected in the `task` entity by the time the internal event is emitted — meaning the emitted event type (`task-completed` vs `task-failed`) now reflects the final, post-validation status.

Behavior for non-workflow tasks (`workflowRunId == null`) is unchanged: the internal event is still emitted exactly once.

## Files modified

- `app/src/main/java/io/apitomy/axiom/app/TaskExecutionService.java`