### PR TITLE
Action Type UI: editable field name with inline identifier validation

### DIFF
--- a/ui/src/components/ActionTypeFieldsTab.tsx
+++ b/ui/src/components/ActionTypeFieldsTab.tsx
@@ -7,8 +7,11 @@ import {
     Flex,
     FlexItem,
     FormGroup,
+    FormHelperText,
     FormSelect,
     FormSelectOption,
+    HelperText,
+    HelperTextItem,
     TextInput,
 } from "@patternfly/react-core";
 import PlusCircleIcon from "@patternfly/react-icons/dist/esm/icons/plus-circle-icon";
@@ -16,6 +19,29 @@ import TimesIcon from "@patternfly/react-icons/dist/esm/icons/times-icon";
 import type { ActionTypeField } from "../config/api";
 
 const FIELD_TYPES: ActionTypeField["type"][] = ["string", "number", "boolean", "object"];
+
+// Mirrors the server-side identifier rule (ActionTypeValidator.VALID_FIELD_NAME_PATTERN).
+const VALID_FIELD_NAME_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+/**
+ * Client-side validation of a field name mirroring the server rules: non-blank,
+ * a valid identifier, and unique within the list. Returns an error message, or
+ * null when the name is valid. `selfIndex` excludes a field from the uniqueness
+ * check so it can keep its own name while being edited.
+ */
+function validateFieldName(name: string, fields: ActionTypeField[], selfIndex: number): string | null {
+    const trimmed = name.trim();
+    if (!trimmed) {
+        return "Field name is required.";
+    }
+    if (!VALID_FIELD_NAME_PATTERN.test(trimmed)) {
+        return "Use letters, digits, and underscores; must not start with a digit.";
+    }
+    if (fields.some((f, i) => i !== selfIndex && f.name === trimmed)) {
+        return "Field name must be unique.";
+    }
+    return null;
+}
 
 /**
  * Editable list of typed fields (name/type/required/description). Reused by the
@@ -28,10 +54,12 @@ export function ActionTypeFieldsTab({ kind, fields, onChange }: {
 }) {
     const [newName, setNewName] = useState("");
 
+    // Only surface the "required" error once the user has started typing.
+    const newNameError = newName.trim() ? validateFieldName(newName, fields, -1) : null;
+
     const handleAdd = () => {
-        const trimmed = newName.trim();
-        if (!trimmed || fields.some((f) => f.name === trimmed)) return;
-        onChange([...fields, { name: trimmed, type: "string", required: false }]);
+        if (validateFieldName(newName, fields, -1)) return;
+        onChange([...fields, { name: newName.trim(), type: "string", required: false }]);
         setNewName("");
     };
 
@@ -55,15 +83,23 @@ export function ActionTypeFieldsTab({ kind, fields, onChange }: {
                 <FlexItem style={{ flex: 1 }}>
                     <FormGroup label="Name" fieldId={`${kind}-new-name`}>
                         <TextInput id={`${kind}-new-name`} value={newName}
+                            validated={newNameError ? "error" : "default"}
                             onChange={(_e, v) => setNewName(v)}
                             placeholder="e.g. repository"
                             onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); handleAdd(); } }}
                         />
+                        {newNameError && (
+                            <FormHelperText>
+                                <HelperText>
+                                    <HelperTextItem variant="error">{newNameError}</HelperTextItem>
+                                </HelperText>
+                            </FormHelperText>
+                        )}
                     </FormGroup>
                 </FlexItem>
                 <FlexItem>
                     <Button variant="secondary" icon={<PlusCircleIcon />} onClick={handleAdd}
-                        isDisabled={!newName.trim() || fields.some((f) => f.name === newName.trim())}
+                        isDisabled={!!validateFieldName(newName, fields, -1)}
                         style={{ marginBottom: "1px" }}>
                         Add
                     </Button>
@@ -76,8 +112,10 @@ export function ActionTypeFieldsTab({ kind, fields, onChange }: {
                 </EmptyState>
             ) : (
                 <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
-                    {fields.map((f, i) => (
-                        <Flex key={i} alignItems={{ default: "alignItemsCenter" }}
+                    {fields.map((f, i) => {
+                        const nameError = validateFieldName(f.name, fields, i);
+                        return (
+                        <Flex key={i} alignItems={{ default: "alignItemsFlexStart" }}
                             style={{
                                 padding: "8px 12px",
                                 backgroundColor: "var(--pf-t--global--background--color--secondary--default)",
@@ -85,7 +123,18 @@ export function ActionTypeFieldsTab({ kind, fields, onChange }: {
                                 gap: "8px",
                             }}>
                             <FlexItem style={{ minWidth: "160px" }}>
-                                <code style={{ fontSize: "13px", fontWeight: 600 }}>{f.name}</code>
+                                <TextInput value={f.name}
+                                    validated={nameError ? "error" : "default"}
+                                    onChange={(_e, v) => handleUpdate(i, { name: v })}
+                                    aria-label={`Name for ${f.name}`}
+                                    style={{ fontSize: "13px", fontWeight: 600 }} />
+                                {nameError && (
+                                    <FormHelperText>
+                                        <HelperText>
+                                            <HelperTextItem variant="error">{nameError}</HelperTextItem>
+                                        </HelperText>
+                                    </FormHelperText>
+                                )}
                             </FlexItem>
                             <FlexItem style={{ width: "130px" }}>
                                 <FormSelect value={f.type} aria-label={`Type for ${f.name}`}
@@ -114,7 +163,8 @@ export function ActionTypeFieldsTab({ kind, fields, onChange }: {
                                 </Button>
                             </FlexItem>
                         </Flex>
-                    ))}
+                        );
+                    })}
                 </div>
             )}
         </div>


### PR DESCRIPTION
## Summary

Improves the Inputs/Outputs field editor on the Action Type detail page (`ActionTypeFieldsTab`) so that:

- The field **name is now editable in place** via a `TextInput` (previously it was a read-only `<code>` label that could only be set at creation time).
- **Inline client-side validation** mirrors the server rule in `ActionTypeValidator.validateFields`:
  - non-blank
  - valid identifier pattern `^[a-zA-Z_][a-zA-Z0-9_]*$`
  - unique within the inputs/outputs list
- Invalid names surface an inline error (via `FormHelperText`/`HelperText`) on both the "Add" input and existing rows, and the **Add button is disabled** while the entered name is invalid — so users get feedback before the save round-trips a server error.

The uniqueness check excludes the row being edited (`selfIndex`) so a field can retain its own name while being edited.

This is a UX improvement; server-side validation already prevented bad data from persisting.

## Files changed

- `ui/src/components/ActionTypeFieldsTab.tsx`

Fixes #274