### PR TITLE
Extract shared input-binding/prompt-template resolution into InputBindingResolver

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/ScriptExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ScriptExecutionService.java
@@ -11,7 +11,7 @@ import io.apitomy.axiom.core.entities.ThreadEntryEntity;
 import io.apitomy.axiom.core.events.SseEvent;
 import io.apitomy.axiom.core.services.EncryptionService;
 import io.apitomy.axiom.core.services.EnvironmentResolver;
-import com.fasterxml.jackson.core.type.TypeReference;
+import io.apitomy.axiom.core.services.InputBindingResolver;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.arc.Arc;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -219,30 +218,9 @@ public class ScriptExecutionService {
         resolved = resolved.replace("{{workDir}}", workDir);
 
         // Bind named workflow inputs as {{inputs.NAME}} (workflow tasks only).
-        if (task.workflowRunId != null && task.input != null && !task.input.isBlank()) {
-            try {
-                Map<String, Object> inputs = objectMapper.readValue(
-                        task.input, new TypeReference<Map<String, Object>>() {});
-                for (Map.Entry<String, Object> e : inputs.entrySet()) {
-                    Object v = e.getValue();
-                    String rendered;
-                    if (v == null) {
-                        rendered = "";
-                    } else if (v instanceof String s) {
-                        rendered = s;
-                    } else {
-                        try {
-                            rendered = objectMapper.writeValueAsString(v);
-                        } catch (Exception ex) {
-                            LOG.debugf("Failed to serialize input '%s' to JSON, using toString()", e.getKey());
-                            rendered = String.valueOf(v);
-                        }
-                    }
-                    resolved = resolved.replace("{{inputs." + e.getKey() + "}}", rendered);
-                }
-            } catch (Exception ignored) {
-                // Non-object input — leave {{inputs.*}} placeholders untouched.
-            }
+        if (task.workflowRunId != null) {
+            resolved = InputBindingResolver.bindInputs(
+                    resolved, InputBindingResolver.parseInputs(task.input, objectMapper), objectMapper);
         }
 
         return resolved;

--- a/app/src/main/java/io/apitomy/axiom/app/TaskExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/TaskExecutionService.java
@@ -19,9 +19,9 @@ import io.apitomy.axiom.core.events.SseEvent;
 import io.apitomy.axiom.core.services.ActionTypeIoValidator;
 import io.apitomy.axiom.core.services.EncryptionService;
 import io.apitomy.axiom.core.services.EnvironmentResolver;
+import io.apitomy.axiom.core.services.InputBindingResolver;
 import io.apitomy.axiom.core.services.ToolsetResolver;
 import io.apitomy.axiom.core.services.WorkspaceService;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Event;
@@ -300,28 +300,11 @@ public class TaskExecutionService {
         resolved = resolved.replace("{{workDir}}", workspace != null ? workspace.toAbsolutePath().toString() : "");
 
         // Bind named workflow inputs as {{inputs.NAME}}.
-        Map<String, Object> resolvedInputs = parseResolvedInputs(task);
-        for (Map.Entry<String, Object> e : resolvedInputs.entrySet()) {
-            Object v = e.getValue();
-            String rendered;
-            if (v == null) {
-                rendered = "";
-            } else if (v instanceof String s) {
-                rendered = s;
-            } else {
-                try {
-                    rendered = objectMapper.writeValueAsString(v);
-                } catch (Exception ex) {
-                    LOG.debugf("Failed to serialize input '%s' to JSON, using toString()", e.getKey());
-                    rendered = String.valueOf(v);
-                }
-            }
-            resolved = resolved.replace("{{inputs." + e.getKey() + "}}", rendered);
-        }
+        resolved = InputBindingResolver.bindInputs(resolved, parseResolvedInputs(task), objectMapper);
 
         // Auto-append the output contract for workflow tasks that declare outputs.
         if (task.workflowRunId != null && actionType.outputs != null && !actionType.outputs.isEmpty()) {
-            resolved = resolved + "\n\n" + buildOutputContract(actionType.outputs);
+            resolved = resolved + "\n\n" + InputBindingResolver.buildOutputContract(actionType.outputs);
         }
         return resolved;
     }
@@ -331,36 +314,10 @@ public class TaskExecutionService {
      * Returns an empty map for non-workflow tasks or unparseable input.
      */
     private Map<String, Object> parseResolvedInputs(TaskEntity task) {
-        if (task.workflowRunId == null || task.input == null || task.input.isBlank()) {
+        if (task.workflowRunId == null) {
             return Map.of();
         }
-        try {
-            return objectMapper.readValue(task.input, new TypeReference<Map<String, Object>>() {});
-        } catch (Exception e) {
-            return Map.of();
-        }
-    }
-
-    /**
-     * Builds the instruction block appended to an agent prompt telling it to emit a
-     * JSON object keyed by the declared output names as its final result.
-     */
-    private String buildOutputContract(List<io.apitomy.axiom.core.entities.ActionTypeField> outputs) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("## Required output\n");
-        sb.append("When finished, output ONLY a single JSON object (no prose, no code fences) ");
-        sb.append("with exactly these keys:\n");
-        for (io.apitomy.axiom.core.entities.ActionTypeField f : outputs) {
-            sb.append("- \"").append(f.name).append("\" (").append(f.type).append(")");
-            if (f.required) {
-                sb.append(" [required]");
-            }
-            if (f.description != null && !f.description.isBlank()) {
-                sb.append(" — ").append(f.description);
-            }
-            sb.append("\n");
-        }
-        return sb.toString();
+        return InputBindingResolver.parseInputs(task.input, objectMapper);
     }
 
     private String buildSystemPrompt(TaskEntity task, ProjectEntity project) {

--- a/core/src/main/java/io/apitomy/axiom/core/services/InputBindingResolver.java
+++ b/core/src/main/java/io/apitomy/axiom/core/services/InputBindingResolver.java
@@ -1,0 +1,114 @@
+package io.apitomy.axiom.core.services;
+
+import io.apitomy.axiom.core.entities.ActionTypeField;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jboss.logging.Logger;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Shared input-binding and prompt/script template resolution logic.
+ *
+ * <p>Both the agent-task path ({@code TaskExecutionService}) and the script path
+ * ({@code ScriptExecutionService}) resolve named workflow inputs into
+ * {@code {{inputs.NAME}}} placeholders and (for agent tasks) append an output
+ * contract describing the declared outputs. Centralising that logic here keeps
+ * the two execution paths in lockstep and gives input-binding a single
+ * definition with a single set of tests.</p>
+ */
+public final class InputBindingResolver {
+
+    private static final Logger LOG = Logger.getLogger(InputBindingResolver.class);
+
+    private InputBindingResolver() {
+    }
+
+    /**
+     * Parses a workflow task's resolved inputs (a JSON object) into a map.
+     *
+     * @param inputJson the raw resolved-inputs JSON, or {@code null}/blank
+     * @param mapper    the JSON mapper to use
+     * @return the parsed map, or an empty map when the input is blank or not a JSON object
+     */
+    public static Map<String, Object> parseInputs(String inputJson, ObjectMapper mapper) {
+        if (inputJson == null || inputJson.isBlank()) {
+            return Map.of();
+        }
+        try {
+            return mapper.readValue(inputJson, new TypeReference<Map<String, Object>>() {});
+        } catch (Exception e) {
+            return Map.of();
+        }
+    }
+
+    /**
+     * Substitutes {@code {{inputs.NAME}}} placeholders in the given template with the
+     * corresponding rendered input values.
+     *
+     * @param template the template to resolve, or {@code null}
+     * @param inputs   the named inputs keyed by placeholder name (null/empty means "no binding")
+     * @param mapper   the JSON mapper used to render non-string values
+     * @return the template with {@code {{inputs.*}}} placeholders substituted
+     */
+    public static String bindInputs(String template, Map<String, Object> inputs, ObjectMapper mapper) {
+        if (template == null || inputs == null || inputs.isEmpty()) {
+            return template;
+        }
+        String resolved = template;
+        for (Map.Entry<String, Object> e : inputs.entrySet()) {
+            resolved = resolved.replace("{{inputs." + e.getKey() + "}}", renderValue(e.getValue(), mapper));
+        }
+        return resolved;
+    }
+
+    /**
+     * Renders a single input value to its placeholder string form: {@code null} becomes an
+     * empty string, strings are used verbatim, and everything else is serialized to JSON
+     * (falling back to {@code String.valueOf} if serialization fails).
+     *
+     * @param value  the value to render
+     * @param mapper the JSON mapper used for non-string values
+     * @return the rendered string
+     */
+    public static String renderValue(Object value, ObjectMapper mapper) {
+        if (value == null) {
+            return "";
+        }
+        if (value instanceof String s) {
+            return s;
+        }
+        try {
+            return mapper.writeValueAsString(value);
+        } catch (Exception ex) {
+            LOG.debug("Failed to serialize input value to JSON, using toString()");
+            return String.valueOf(value);
+        }
+    }
+
+    /**
+     * Builds the instruction block appended to an agent prompt telling it to emit a
+     * JSON object keyed by the declared output names as its final result.
+     *
+     * @param outputs the declared output fields
+     * @return the output-contract instruction block
+     */
+    public static String buildOutputContract(List<ActionTypeField> outputs) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("## Required output\n");
+        sb.append("When finished, output ONLY a single JSON object (no prose, no code fences) ");
+        sb.append("with exactly these keys:\n");
+        for (ActionTypeField f : outputs) {
+            sb.append("- \"").append(f.name).append("\" (").append(f.type).append(")");
+            if (f.required) {
+                sb.append(" [required]");
+            }
+            if (f.description != null && !f.description.isBlank()) {
+                sb.append(" — ").append(f.description);
+            }
+            sb.append("\n");
+        }
+        return sb.toString();
+    }
+}

--- a/core/src/test/java/io/apitomy/axiom/core/services/InputBindingResolverTest.java
+++ b/core/src/test/java/io/apitomy/axiom/core/services/InputBindingResolverTest.java
@@ -1,0 +1,73 @@
+package io.apitomy.axiom.core.services;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.apitomy.axiom.core.entities.ActionTypeField;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class InputBindingResolverTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void parseInputsReturnsEmptyForNullOrBlank() {
+        assertEquals(Map.of(), InputBindingResolver.parseInputs(null, mapper));
+        assertEquals(Map.of(), InputBindingResolver.parseInputs("   ", mapper));
+    }
+
+    @Test
+    void parseInputsReturnsEmptyForNonObjectJson() {
+        assertEquals(Map.of(), InputBindingResolver.parseInputs("not json", mapper));
+        assertEquals(Map.of(), InputBindingResolver.parseInputs("[1,2,3]", mapper));
+    }
+
+    @Test
+    void parseInputsParsesJsonObject() {
+        Map<String, Object> parsed = InputBindingResolver.parseInputs("{\"repo\":\"acme/app\",\"count\":3}", mapper);
+        assertEquals("acme/app", parsed.get("repo"));
+        assertEquals(3, parsed.get("count"));
+    }
+
+    @Test
+    void bindInputsSubstitutesStringPlaceholder() {
+        String result = InputBindingResolver.bindInputs(
+                "Repo is {{inputs.repo}}.", Map.of("repo", "acme/app"), mapper);
+        assertEquals("Repo is acme/app.", result);
+    }
+
+    @Test
+    void bindInputsRendersNonStringAsJson() {
+        String result = InputBindingResolver.bindInputs(
+                "count={{inputs.count}}", Map.of("count", 42), mapper);
+        assertEquals("count=42", result);
+    }
+
+    @Test
+    void bindInputsRendersNullAsEmptyString() {
+        // Map.of does not allow null values, so use a mutable map via renderValue directly.
+        assertEquals("", InputBindingResolver.renderValue(null, mapper));
+    }
+
+    @Test
+    void bindInputsIsNoopForNullOrEmptyInputs() {
+        assertEquals("template", InputBindingResolver.bindInputs("template", Map.of(), mapper));
+        assertEquals("template", InputBindingResolver.bindInputs("template", null, mapper));
+        assertEquals(null, InputBindingResolver.bindInputs(null, Map.of("a", "b"), mapper));
+    }
+
+    @Test
+    void buildOutputContractListsDeclaredOutputs() {
+        List<ActionTypeField> outputs = List.of(
+                new ActionTypeField("summary", "string", true, "A short summary"),
+                new ActionTypeField("count", "number", false, null));
+        String contract = InputBindingResolver.buildOutputContract(outputs);
+        assertTrue(contract.contains("## Required output"));
+        assertTrue(contract.contains("\"summary\" (string) [required] — A short summary"));
+        assertTrue(contract.contains("\"count\" (number)"));
+    }
+}


### PR DESCRIPTION
## Summary

The `{{inputs.NAME}}` binding loop and related template-resolution logic was duplicated between `TaskExecutionService` (agent tasks) and `ScriptExecutionService` (script tasks). The two copies had to be kept in lockstep, so a change to binding semantics in one path could silently diverge from the other.

This PR extracts that shared logic into a single reusable static utility, `io.apitomy.axiom.core.services.InputBindingResolver`, consumed by both execution services. Input-binding behavior now has one definition and one set of tests.

## Changes

- **New** `core/.../services/InputBindingResolver.java` — static helper with:
  - `parseInputs(String, ObjectMapper)` — parse resolved-inputs JSON into a map (empty for blank/non-object input)
  - `bindInputs(String, Map, ObjectMapper)` — substitute `{{inputs.NAME}}` placeholders
  - `renderValue(Object, ObjectMapper)` — render a single value (null → "", String verbatim, else JSON)
  - `buildOutputContract(List<ActionTypeField>)` — build the agent output-contract block
- **`TaskExecutionService`** — `resolvePromptTemplate`/`parseResolvedInputs` now delegate to `InputBindingResolver`; removed the local `buildOutputContract` copy and the now-unused `TypeReference` import.
- **`ScriptExecutionService`** — `substitutePlaceholders` now delegates the input-binding loop to `InputBindingResolver`; removed the now-unused `Map`/`TypeReference` imports.
- **New** `core/.../services/InputBindingResolverTest.java` — unit tests for the shared helper.

No behavior change intended — this is cleanup to remove duplication (follow-up from the code review of #266).

Fixes #273