### PR TITLE
fix: POST /projects missing required fields returns 400 instead of 500

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/rest/ProjectsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/ProjectsResourceImpl.java
@@ -154,6 +154,10 @@ public class ProjectsResourceImpl implements ProjectsResource {
     @Override
     @Transactional
     public Project createProject(NewProject data) {
+        validateRequired(data.getName(), "name");
+        validateRequired(data.getType(), "type");
+        validateRequired(data.getRef(), "ref");
+
         ProjectEntity entity = new ProjectEntity();
         entity.name = data.getName();
         entity.body = data.getBody();
@@ -542,6 +546,12 @@ public class ProjectsResourceImpl implements ProjectsResource {
     private io.apitomy.axiom.api.beans.WorkflowInstance toWorkflowInstanceBean(
             WorkflowRunEntity entity) {
         return runBeanMapper.toBean(entity);
+    }
+
+    private void validateRequired(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new WebApplicationException("Missing required '" + fieldName + "' field", 400);
+        }
     }
 
     private ProjectEntity findProjectOrThrow(long id) {

--- a/app/src/test/java/io/apitomy/axiom/app/ProjectsResourceTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/ProjectsResourceTest.java
@@ -113,6 +113,54 @@ class ProjectsResourceTest {
     }
 
     @Test
+    void testCreateProjectMissingType() {
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                    "name": "No Type Project",
+                    "ref": "owner/repo#missing-type"
+                }
+                """)
+            .when()
+                .post(PROJECTS_PATH)
+            .then()
+                .statusCode(400);
+    }
+
+    @Test
+    void testCreateProjectMissingName() {
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                    "type": "bug-fix",
+                    "ref": "owner/repo#missing-name"
+                }
+                """)
+            .when()
+                .post(PROJECTS_PATH)
+            .then()
+                .statusCode(400);
+    }
+
+    @Test
+    void testCreateProjectMissingRef() {
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                    "name": "No Ref Project",
+                    "type": "bug-fix"
+                }
+                """)
+            .when()
+                .post(PROJECTS_PATH)
+            .then()
+                .statusCode(400);
+    }
+
+    @Test
     void testGetProjectNotFound() {
         given()
             .when()


### PR DESCRIPTION
## Summary

Adds input validation for the required `name`, `type`, and `ref` fields in `POST /api/v1/projects`. Previously, omitting any of these fields caused an unhandled database constraint violation resulting in an HTTP 500. Now the endpoint returns HTTP 400 with a clear error message indicating which field is missing.

## Changes

- **`ProjectsResourceImpl.createProject()`**: Added validation calls before entity creation for the three required fields (`name`, `type`, `ref`).
- **`validateRequired()` helper**: New private method following the existing validation pattern used in `AssistantResourceImpl` (`"Missing required '<field>' field"`, HTTP 400).
- **`ProjectsResourceTest`**: Added three test cases covering each missing required field scenario.

## Files Modified

- `app/src/main/java/io/apitomy/axiom/app/rest/ProjectsResourceImpl.java`
- `app/src/test/java/io/apitomy/axiom/app/ProjectsResourceTest.java`

Fixes #270