### PR TITLE
Best-effort I/O type coercion in ActionTypeIoValidator

### DIFF
--- a/core/src/main/java/io/apitomy/axiom/core/services/ActionTypeIoValidator.java
+++ b/core/src/main/java/io/apitomy/axiom/core/services/ActionTypeIoValidator.java
@@ -1,5 +1,6 @@
 package io.apitomy.axiom.core.services;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.apitomy.axiom.core.entities.ActionTypeField;
 
 import java.util.ArrayList;
@@ -11,9 +12,12 @@ import java.util.Map;
  *
  * <p>Used at execution time to enforce an action type's declared inputs (before the
  * action runs) and outputs (after it completes). Required fields must be present and
- * non-null; present values are best-effort type-checked; extra keys are permitted.</p>
+ * non-null; present values are best-effort coerced to their declared type before being
+ * validated; extra keys are permitted.</p>
  */
 public final class ActionTypeIoValidator {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private ActionTypeIoValidator() {
     }
@@ -48,16 +52,74 @@ public final class ActionTypeIoValidator {
         return errors;
     }
 
+    /**
+     * Determines whether the given value satisfies the declared type, applying best-effort
+     * coercion per the workflow I/O validation design. A value is accepted when it is already
+     * of the declared type <em>or</em> can be losslessly coerced into it.
+     */
     private static boolean matchesType(String type, Object value) {
         if (type == null) {
             return true;
         }
         return switch (type) {
-            case "string" -> value instanceof String;
-            case "number" -> value instanceof Number;
-            case "boolean" -> value instanceof Boolean;
-            case "object" -> value instanceof Map;
+            case "string" -> matchesString(value);
+            case "number" -> matchesNumber(value);
+            case "boolean" -> matchesBoolean(value);
+            case "object" -> matchesObject(value);
             default -> true;
         };
+    }
+
+    private static boolean matchesString(Object value) {
+        // Any scalar value can be losslessly rendered as a string via toString().
+        return value instanceof String || value instanceof Number || value instanceof Boolean;
+    }
+
+    private static boolean matchesNumber(Object value) {
+        if (value instanceof Number) {
+            return true;
+        }
+        if (value instanceof String s) {
+            String trimmed = s.trim();
+            if (trimmed.isEmpty()) {
+                return false;
+            }
+            try {
+                Double.parseDouble(trimmed);
+                return true;
+            } catch (NumberFormatException e) {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    private static boolean matchesBoolean(Object value) {
+        if (value instanceof Boolean) {
+            return true;
+        }
+        if (value instanceof String s) {
+            String trimmed = s.trim();
+            return "true".equalsIgnoreCase(trimmed) || "false".equalsIgnoreCase(trimmed);
+        }
+        return false;
+    }
+
+    private static boolean matchesObject(Object value) {
+        if (value instanceof Map) {
+            return true;
+        }
+        if (value instanceof String s) {
+            String trimmed = s.trim();
+            if (trimmed.isEmpty()) {
+                return false;
+            }
+            try {
+                return OBJECT_MAPPER.readValue(trimmed, Map.class) != null;
+            } catch (Exception e) {
+                return false;
+            }
+        }
+        return false;
     }
 }

--- a/core/src/test/java/io/apitomy/axiom/core/services/ActionTypeIoValidatorTest.java
+++ b/core/src/test/java/io/apitomy/axiom/core/services/ActionTypeIoValidatorTest.java
@@ -34,6 +34,44 @@ class ActionTypeIoValidatorTest {
     }
 
     @Test
+    void numericStringCoercedToNumber() {
+        List<ActionTypeField> declared = List.of(new ActionTypeField("count", "number", true, null));
+        assertEquals(List.of(), ActionTypeIoValidator.validate(declared, Map.of("count", "42")));
+        assertEquals(List.of(), ActionTypeIoValidator.validate(declared, Map.of("count", "3.14")));
+    }
+
+    @Test
+    void booleanStringCoercedToBoolean() {
+        List<ActionTypeField> declared = List.of(new ActionTypeField("flag", "boolean", true, null));
+        assertEquals(List.of(), ActionTypeIoValidator.validate(declared, Map.of("flag", "true")));
+        assertEquals(List.of(), ActionTypeIoValidator.validate(declared, Map.of("flag", "FALSE")));
+    }
+
+    @Test
+    void nonBooleanStringReportsError() {
+        List<ActionTypeField> declared = List.of(new ActionTypeField("flag", "boolean", true, null));
+        assertFalse(ActionTypeIoValidator.validate(declared, Map.of("flag", "yes")).isEmpty());
+    }
+
+    @Test
+    void numberCoercedToString() {
+        List<ActionTypeField> declared = List.of(new ActionTypeField("id", "string", true, null));
+        assertEquals(List.of(), ActionTypeIoValidator.validate(declared, Map.of("id", 42)));
+    }
+
+    @Test
+    void jsonStringCoercedToObject() {
+        List<ActionTypeField> declared = List.of(new ActionTypeField("cfg", "object", true, null));
+        assertEquals(List.of(), ActionTypeIoValidator.validate(declared, Map.of("cfg", "{\"a\":1}")));
+    }
+
+    @Test
+    void nonObjectStringReportsError() {
+        List<ActionTypeField> declared = List.of(new ActionTypeField("cfg", "object", true, null));
+        assertFalse(ActionTypeIoValidator.validate(declared, Map.of("cfg", "not-json")).isEmpty());
+    }
+
+    @Test
     void optionalMissingFieldIsOk() {
         List<ActionTypeField> declared = List.of(new ActionTypeField("note", "string", false, null));
         assertEquals(List.of(), ActionTypeIoValidator.validate(declared, Map.of()));


### PR DESCRIPTION
## Summary

`ActionTypeIoValidator.matchesType` performed a strict `instanceof` check with no coercion, so values that could reasonably satisfy the declared contract were rejected. Per the workflow I/O validation design (§3), present values should be *best-effort coerced* to their declared type before validation.

## Changes

Reworked `matchesType` to accept a value when it is already the declared type **or** can be losslessly coerced into it:

- **number** — accepts a `Number`, or a `String` that parses via `Double.parseDouble` (e.g. `"42"`, `"3.14"`).
- **boolean** — accepts a `Boolean`, or a `String` equal to `"true"`/`"false"` (case-insensitive).
- **string** — accepts a `String`, or a scalar (`Number`/`Boolean`) that renders losslessly via `toString()` (e.g. a numeric ID).
- **object** — accepts a `Map`, or a `String` that parses as a JSON object.

Non-coercible values (e.g. `"not-a-number"`, `"yes"` for boolean, `"not-json"` for object) still produce validation errors.

Added unit tests covering each coercion path and the remaining rejection cases.

### Files modified
- `core/src/main/java/io/apitomy/axiom/core/services/ActionTypeIoValidator.java`
- `core/src/test/java/io/apitomy/axiom/core/services/ActionTypeIoValidatorTest.java`

Fixes #271