### PR TITLE
Harden script-mode placeholder substitution against shell injection

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/ScriptAiService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ScriptAiService.java
@@ -59,10 +59,22 @@ public class ScriptAiService {
             - {{managerInput}} — context/instructions from the Manager
             - {{apiBaseUrl}} — the Axiom REST API base URL (e.g. "http://localhost:9090/api/v1")
 
-            Environment variables are also available:
+            Placeholder values are treated as literal data: each {{...}} is passed to the \
+            script as an environment variable and expands to a quoted shell reference (e.g. \
+            {{managerInput}} becomes "$AXIOM_MANAGER_INPUT"), so values containing shell \
+            metacharacters are never executed. Use a placeholder wherever you would use a \
+            shell variable — do NOT wrap it in extra quotes.
+
+            Environment variables are also available directly:
             - AXIOM_API_URL — same as {{apiBaseUrl}}
             - AXIOM_PROJECT_ID — same as {{projectId}}
+            - AXIOM_EVENT_ID — same as {{eventId}}
             - AXIOM_TASK_ID — same as {{taskId}}
+            - AXIOM_REF — same as {{ref}}
+            - AXIOM_REPOSITORY — same as {{repository}}
+            - AXIOM_PROJECT_NAME — same as {{projectName}}
+            - AXIOM_MANAGER_INPUT — same as {{managerInput}}
+            - AXIOM_WORK_DIR — same as {{workDir}}
 
             Common Axiom REST API endpoints the script can call:
             - GET {{apiBaseUrl}}/projects/{{projectId}} — get project details

--- a/app/src/main/java/io/apitomy/axiom/app/ScriptExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ScriptExecutionService.java
@@ -25,9 +25,11 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 
 /**
  * Executes script-mode action types by running a user-defined bash script.
@@ -38,6 +40,13 @@ import java.util.concurrent.TimeUnit;
 public class ScriptExecutionService {
 
     private static final Logger LOG = Logger.getLogger(ScriptExecutionService.class);
+
+    /**
+     * Workflow input names that can be safely bound as shell environment
+     * variables. Mirrors the identifier rule enforced by ActionTypeValidator.
+     */
+    private static final Pattern VALID_INPUT_NAME =
+            Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_]*$");
 
     @Inject
     Event<SseEvent> sseEvents;
@@ -113,7 +122,9 @@ public class ScriptExecutionService {
         if (project == null) {
             project = ProjectEntity.findById(task.projectId);
         }
-        String script = substitutePlaceholders(actionType.scriptTemplate, task, project);
+        Map<String, String> placeholderEnv = new LinkedHashMap<>();
+        String script = substitutePlaceholders(actionType.scriptTemplate, task, project,
+                placeholderEnv);
         Instant startTime = Instant.now();
 
         Path scriptFile = Files.createTempFile("axiom-script-", ".sh");
@@ -142,6 +153,13 @@ public class ScriptExecutionService {
                     }
                 }
             }
+
+            // Inject substituted placeholder values as environment variables. The
+            // script references them via quoted shell expansions ("$AXIOM_*"), so
+            // values that contain shell metacharacters are treated as literal data
+            // rather than being executed (see substitutePlaceholders / issue #267).
+            // Applied last so the reserved AXIOM_* names are authoritative.
+            pb.environment().putAll(placeholderEnv);
 
             Process process = pb.start();
             String output = new String(process.getInputStream().readAllBytes());
@@ -200,23 +218,46 @@ public class ScriptExecutionService {
         return log.toString();
     }
 
-    private String substitutePlaceholders(String template, TaskEntity task,
-                                           ProjectEntity project) {
+    /**
+     * Resolves {@code {{...}}} placeholders in a script template.
+     *
+     * <p>To guard against shell injection, placeholder <em>values</em> are never
+     * inlined into the script text. Instead each value is exported as an
+     * environment variable (collected into {@code env}) and the placeholder is
+     * replaced with a quoted shell expansion — e.g. {@code {{managerInput}}}
+     * becomes {@code "$AXIOM_MANAGER_INPUT"}. Because bash does not re-parse the
+     * contents of a variable expansion for command substitution, a value
+     * containing {@code $(...)}, backticks, {@code ;}, {@code &&}, newlines, etc.
+     * is treated as literal data rather than being executed (issue #267).
+     *
+     * @param template the raw script template
+     * @param task     the task providing context values
+     * @param project  the project providing context values, may be {@code null}
+     * @param env      output map that receives the environment variables the
+     *                 resolved script references; the caller must inject these
+     *                 into the script's process environment
+     * @return the resolved script with placeholders replaced by shell references
+     */
+    String substitutePlaceholders(String template, TaskEntity task,
+                                           ProjectEntity project, Map<String, String> env) {
         String apiBaseUrl = "http://localhost:" + httpPort + "/api/v1";
+        String workDir = System.getProperty("user.home")
+                + "/.axiom/workspaces/project-" + task.projectId;
+
         String resolved = template;
-        resolved = resolved.replace("{{projectId}}", str(task.projectId));
-        resolved = resolved.replace("{{eventId}}", str(task.eventId));
-        resolved = resolved.replace("{{taskId}}", str(task.id));
-        resolved = resolved.replace("{{ref}}", project != null && project.ref != null
-                ? project.ref : "");
-        resolved = resolved.replace("{{repository}}", project != null && project.repository != null
-                ? project.repository : "");
-        resolved = resolved.replace("{{projectName}}", project != null && project.name != null
-                ? project.name : "");
-        resolved = resolved.replace("{{managerInput}}", task.input != null ? task.input : "");
-        resolved = resolved.replace("{{apiBaseUrl}}", apiBaseUrl);
-        String workDir = System.getProperty("user.home") + "/.axiom/workspaces/project-" + task.projectId;
-        resolved = resolved.replace("{{workDir}}", workDir);
+        resolved = bind(resolved, env, "{{projectId}}", "AXIOM_PROJECT_ID", str(task.projectId));
+        resolved = bind(resolved, env, "{{eventId}}", "AXIOM_EVENT_ID", str(task.eventId));
+        resolved = bind(resolved, env, "{{taskId}}", "AXIOM_TASK_ID", str(task.id));
+        resolved = bind(resolved, env, "{{ref}}", "AXIOM_REF",
+                project != null && project.ref != null ? project.ref : "");
+        resolved = bind(resolved, env, "{{repository}}", "AXIOM_REPOSITORY",
+                project != null && project.repository != null ? project.repository : "");
+        resolved = bind(resolved, env, "{{projectName}}", "AXIOM_PROJECT_NAME",
+                project != null && project.name != null ? project.name : "");
+        resolved = bind(resolved, env, "{{managerInput}}", "AXIOM_MANAGER_INPUT",
+                task.input != null ? task.input : "");
+        resolved = bind(resolved, env, "{{apiBaseUrl}}", "AXIOM_API_URL", apiBaseUrl);
+        resolved = bind(resolved, env, "{{workDir}}", "AXIOM_WORK_DIR", workDir);
 
         // Bind named workflow inputs as {{inputs.NAME}} (workflow tasks only).
         if (task.workflowRunId != null && task.input != null && !task.input.isBlank()) {
@@ -224,6 +265,12 @@ public class ScriptExecutionService {
                 Map<String, Object> inputs = objectMapper.readValue(
                         task.input, new TypeReference<Map<String, Object>>() {});
                 for (Map.Entry<String, Object> e : inputs.entrySet()) {
+                    String key = e.getKey();
+                    if (!VALID_INPUT_NAME.matcher(key).matches()) {
+                        // Not a valid shell identifier — cannot bind as an env var
+                        // safely; leave the placeholder untouched.
+                        continue;
+                    }
                     Object v = e.getValue();
                     String rendered;
                     if (v == null) {
@@ -234,11 +281,12 @@ public class ScriptExecutionService {
                         try {
                             rendered = objectMapper.writeValueAsString(v);
                         } catch (Exception ex) {
-                            LOG.debugf("Failed to serialize input '%s' to JSON, using toString()", e.getKey());
+                            LOG.debugf("Failed to serialize input '%s' to JSON, using toString()", key);
                             rendered = String.valueOf(v);
                         }
                     }
-                    resolved = resolved.replace("{{inputs." + e.getKey() + "}}", rendered);
+                    resolved = bind(resolved, env, "{{inputs." + key + "}}",
+                            "AXIOM_INPUT_" + key, rendered);
                 }
             } catch (Exception ignored) {
                 // Non-object input — leave {{inputs.*}} placeholders untouched.
@@ -246,6 +294,21 @@ public class ScriptExecutionService {
         }
 
         return resolved;
+    }
+
+    /**
+     * Replaces {@code placeholder} in {@code resolved} with a quoted reference to
+     * the environment variable {@code envName}, and records {@code value} under
+     * {@code envName} in {@code env}. The value is only exported when the
+     * placeholder actually appears in the template.
+     */
+    private String bind(String resolved, Map<String, String> env, String placeholder,
+                        String envName, String value) {
+        if (!resolved.contains(placeholder)) {
+            return resolved;
+        }
+        env.put(envName, value != null ? value : "");
+        return resolved.replace(placeholder, "\"$" + envName + "\"");
     }
 
     private String str(Object value) {

--- a/app/src/main/java/io/apitomy/axiom/app/ScriptExecutionService.java
+++ b/app/src/main/java/io/apitomy/axiom/app/ScriptExecutionService.java
@@ -224,11 +224,29 @@ public class ScriptExecutionService {
      * <p>To guard against shell injection, placeholder <em>values</em> are never
      * inlined into the script text. Instead each value is exported as an
      * environment variable (collected into {@code env}) and the placeholder is
-     * replaced with a quoted shell expansion — e.g. {@code {{managerInput}}}
-     * becomes {@code "$AXIOM_MANAGER_INPUT"}. Because bash does not re-parse the
-     * contents of a variable expansion for command substitution, a value
-     * containing {@code $(...)}, backticks, {@code ;}, {@code &&}, newlines, etc.
-     * is treated as literal data rather than being executed (issue #267).
+     * replaced with a shell expansion of that variable — e.g.
+     * {@code {{managerInput}}} becomes a reference to {@code AXIOM_MANAGER_INPUT}.
+     * Because bash does not re-parse the contents of a variable expansion for
+     * command substitution, a value containing {@code $(...)}, backticks,
+     * {@code ;}, {@code &&}, newlines, etc. is treated as literal data rather
+     * than being executed (issue #267).
+     *
+     * <p>The exact form of the injected reference is chosen based on the shell
+     * quoting context in which the placeholder appears, so that values containing
+     * whitespace survive as a single argument regardless of how the template
+     * quotes the placeholder:
+     * <ul>
+     *   <li><b>Unquoted</b> ({@code echo {{x}}}) &rarr; {@code "${AXIOM_X}"} —
+     *       the reference is quoted so whitespace does not word-split it.</li>
+     *   <li><b>Inside double quotes</b> ({@code echo "a: {{x}}"}) &rarr;
+     *       {@code ${AXIOM_X}} — the surrounding quotes already prevent
+     *       word-splitting, so no extra quotes are added (adding them would
+     *       break the enclosing string and re-introduce word-splitting).</li>
+     *   <li><b>Inside single quotes</b> ({@code echo '{{x}}'}) &rarr;
+     *       {@code '"${AXIOM_X}"'} — single quotes suppress expansion, so the
+     *       reference temporarily closes the single-quoted region, expands the
+     *       value inside double quotes, then reopens it.</li>
+     * </ul>
      *
      * @param template the raw script template
      * @param task     the task providing context values
@@ -244,20 +262,24 @@ public class ScriptExecutionService {
         String workDir = System.getProperty("user.home")
                 + "/.axiom/workspaces/project-" + task.projectId;
 
-        String resolved = template;
-        resolved = bind(resolved, env, "{{projectId}}", "AXIOM_PROJECT_ID", str(task.projectId));
-        resolved = bind(resolved, env, "{{eventId}}", "AXIOM_EVENT_ID", str(task.eventId));
-        resolved = bind(resolved, env, "{{taskId}}", "AXIOM_TASK_ID", str(task.id));
-        resolved = bind(resolved, env, "{{ref}}", "AXIOM_REF",
+        // Collect every candidate placeholder and its target environment
+        // variable. Longer placeholders are matched first during rendering so
+        // that e.g. {{inputs.title}} wins over any shorter prefix match.
+        Map<String, String> bindings = new LinkedHashMap<>();
+        Map<String, String> values = new LinkedHashMap<>();
+        addBinding(bindings, values, "{{projectId}}", "AXIOM_PROJECT_ID", str(task.projectId));
+        addBinding(bindings, values, "{{eventId}}", "AXIOM_EVENT_ID", str(task.eventId));
+        addBinding(bindings, values, "{{taskId}}", "AXIOM_TASK_ID", str(task.id));
+        addBinding(bindings, values, "{{ref}}", "AXIOM_REF",
                 project != null && project.ref != null ? project.ref : "");
-        resolved = bind(resolved, env, "{{repository}}", "AXIOM_REPOSITORY",
+        addBinding(bindings, values, "{{repository}}", "AXIOM_REPOSITORY",
                 project != null && project.repository != null ? project.repository : "");
-        resolved = bind(resolved, env, "{{projectName}}", "AXIOM_PROJECT_NAME",
+        addBinding(bindings, values, "{{projectName}}", "AXIOM_PROJECT_NAME",
                 project != null && project.name != null ? project.name : "");
-        resolved = bind(resolved, env, "{{managerInput}}", "AXIOM_MANAGER_INPUT",
+        addBinding(bindings, values, "{{managerInput}}", "AXIOM_MANAGER_INPUT",
                 task.input != null ? task.input : "");
-        resolved = bind(resolved, env, "{{apiBaseUrl}}", "AXIOM_API_URL", apiBaseUrl);
-        resolved = bind(resolved, env, "{{workDir}}", "AXIOM_WORK_DIR", workDir);
+        addBinding(bindings, values, "{{apiBaseUrl}}", "AXIOM_API_URL", apiBaseUrl);
+        addBinding(bindings, values, "{{workDir}}", "AXIOM_WORK_DIR", workDir);
 
         // Bind named workflow inputs as {{inputs.NAME}} (workflow tasks only).
         if (task.workflowRunId != null && task.input != null && !task.input.isBlank()) {
@@ -285,7 +307,7 @@ public class ScriptExecutionService {
                             rendered = String.valueOf(v);
                         }
                     }
-                    resolved = bind(resolved, env, "{{inputs." + key + "}}",
+                    addBinding(bindings, values, "{{inputs." + key + "}}",
                             "AXIOM_INPUT_" + key, rendered);
                 }
             } catch (Exception ignored) {
@@ -293,22 +315,106 @@ public class ScriptExecutionService {
             }
         }
 
-        return resolved;
+        return render(template, bindings, values, env);
     }
 
     /**
-     * Replaces {@code placeholder} in {@code resolved} with a quoted reference to
-     * the environment variable {@code envName}, and records {@code value} under
-     * {@code envName} in {@code env}. The value is only exported when the
-     * placeholder actually appears in the template.
+     * Records a candidate placeholder-to-environment-variable binding. The value
+     * is only exported (and the env var only referenced) if the placeholder is
+     * actually encountered while rendering the template.
      */
-    private String bind(String resolved, Map<String, String> env, String placeholder,
-                        String envName, String value) {
-        if (!resolved.contains(placeholder)) {
-            return resolved;
+    private void addBinding(Map<String, String> bindings, Map<String, String> values,
+                            String placeholder, String envName, String value) {
+        bindings.put(placeholder, envName);
+        values.put(placeholder, value != null ? value : "");
+    }
+
+    /**
+     * Renders {@code template} in a single pass, tracking bash quoting context so
+     * each placeholder is replaced with a shell reference appropriate to where it
+     * appears (see {@link #substitutePlaceholders}). Environment variables are
+     * added to {@code env} only for placeholders that are actually present.
+     */
+    private String render(String template, Map<String, String> bindings,
+                          Map<String, String> values, Map<String, String> env) {
+        StringBuilder out = new StringBuilder(template.length() + 32);
+        int i = 0;
+        int n = template.length();
+        // Current quoting context: 0 = unquoted, '\'' = single, '"' = double.
+        char quote = 0;
+        while (i < n) {
+            char c = template.charAt(i);
+
+            // Attempt to match a placeholder at this position (longest wins).
+            if (c == '{' && i + 1 < n && template.charAt(i + 1) == '{') {
+                String match = null;
+                for (String placeholder : bindings.keySet()) {
+                    if (template.startsWith(placeholder, i)
+                            && (match == null || placeholder.length() > match.length())) {
+                        match = placeholder;
+                    }
+                }
+                if (match != null) {
+                    String envName = bindings.get(match);
+                    env.put(envName, values.get(match));
+                    out.append(reference(envName, quote));
+                    i += match.length();
+                    continue;
+                }
+            }
+
+            // Not a placeholder — advance the quoting state machine. Injected
+            // references are always quote-balanced, so tracking only the
+            // original template characters keeps the context accurate.
+            if (quote == 0) {
+                if (c == '\'') {
+                    quote = '\'';
+                } else if (c == '"') {
+                    quote = '"';
+                } else if (c == '\\' && i + 1 < n) {
+                    // Backslash escapes the next character outside single quotes.
+                    out.append(c).append(template.charAt(i + 1));
+                    i += 2;
+                    continue;
+                }
+            } else if (quote == '"') {
+                if (c == '"') {
+                    quote = 0;
+                } else if (c == '\\' && i + 1 < n) {
+                    out.append(c).append(template.charAt(i + 1));
+                    i += 2;
+                    continue;
+                }
+            } else { // single quotes: no escapes, only a closing quote ends it
+                if (c == '\'') {
+                    quote = 0;
+                }
+            }
+
+            out.append(c);
+            i++;
         }
-        env.put(envName, value != null ? value : "");
-        return resolved.replace(placeholder, "\"$" + envName + "\"");
+        return out.toString();
+    }
+
+    /**
+     * Builds the shell reference for {@code envName} appropriate to the current
+     * quoting context {@code quote} (0 = unquoted, {@code '} = single-quoted,
+     * {@code "} = double-quoted). See {@link #substitutePlaceholders} for the
+     * rationale behind each form.
+     */
+    private String reference(String envName, char quote) {
+        if (quote == '"') {
+            // Already inside double quotes: expansion is safe as-is.
+            return "${" + envName + "}";
+        }
+        if (quote == '\'') {
+            // Inside single quotes bash does not expand; break out, expand within
+            // double quotes, then reopen the single-quoted region.
+            return "'\"${" + envName + "}\"'";
+        }
+        // Unquoted: quote the expansion so whitespace does not word-split it.
+        return "\"${" + envName + "}\"";
     }
 
     private String str(Object value) {

--- a/app/src/test/java/io/apitomy/axiom/app/ScriptExecutionServiceTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/ScriptExecutionServiceTest.java
@@ -142,8 +142,9 @@ class ScriptExecutionServiceTest {
                 task(1L, 2L, "hello world"), project("r", "repo", "n"), env);
 
         // Single quotes suppress expansion, so the reference closes the region,
-        // expands within double quotes, then reopens it.
-        assertEquals("echo '\"${AXIOM_MANAGER_INPUT}\"'", resolved);
+        // expands within double quotes, then reopens it. The template's own
+        // quotes remain, yielding empty-string + expansion + empty-string.
+        assertEquals("echo ''\"${AXIOM_MANAGER_INPUT}\"''", resolved);
         assertEquals("hello world", env.get("AXIOM_MANAGER_INPUT"));
     }
 

--- a/app/src/test/java/io/apitomy/axiom/app/ScriptExecutionServiceTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/ScriptExecutionServiceTest.java
@@ -1,0 +1,151 @@
+package io.apitomy.axiom.app;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.apitomy.axiom.core.entities.ProjectEntity;
+import io.apitomy.axiom.core.entities.TaskEntity;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link ScriptExecutionService#substitutePlaceholders} focusing
+ * on shell-injection hardening (issue #267): placeholder values must be passed
+ * to the script as environment variables and referenced via quoted expansions,
+ * never inlined into the script text.
+ */
+class ScriptExecutionServiceTest {
+
+    private ScriptExecutionService newService() {
+        ScriptExecutionService svc = new ScriptExecutionService();
+        svc.objectMapper = new ObjectMapper();
+        svc.httpPort = 9090;
+        return svc;
+    }
+
+    private TaskEntity task(long id, Long projectId, String input) {
+        TaskEntity task = new TaskEntity();
+        task.id = id;
+        task.projectId = projectId;
+        task.eventId = 55L;
+        task.input = input;
+        return task;
+    }
+
+    private ProjectEntity project(String ref, String repository, String name) {
+        ProjectEntity project = new ProjectEntity();
+        project.ref = ref;
+        project.repository = repository;
+        project.name = name;
+        return project;
+    }
+
+    @Test
+    void standardPlaceholdersBecomeQuotedEnvReferences() {
+        ScriptExecutionService svc = newService();
+        Map<String, String> env = new LinkedHashMap<>();
+        String template = "echo {{projectId}} {{taskId}} {{ref}} {{repository}} "
+                + "{{projectName}} {{apiBaseUrl}} {{workDir}} {{managerInput}}";
+
+        String resolved = svc.substitutePlaceholders(template,
+                task(7L, 42L, "do the thing"),
+                project("owner/repo#42", "owner/repo", "My Project"), env);
+
+        // No raw values are inlined; each placeholder is a quoted env reference.
+        assertEquals("echo \"$AXIOM_PROJECT_ID\" \"$AXIOM_TASK_ID\" \"$AXIOM_REF\" "
+                + "\"$AXIOM_REPOSITORY\" \"$AXIOM_PROJECT_NAME\" \"$AXIOM_API_URL\" "
+                + "\"$AXIOM_WORK_DIR\" \"$AXIOM_MANAGER_INPUT\"", resolved);
+
+        assertEquals("42", env.get("AXIOM_PROJECT_ID"));
+        assertEquals("7", env.get("AXIOM_TASK_ID"));
+        assertEquals("owner/repo#42", env.get("AXIOM_REF"));
+        assertEquals("owner/repo", env.get("AXIOM_REPOSITORY"));
+        assertEquals("My Project", env.get("AXIOM_PROJECT_NAME"));
+        assertEquals("http://localhost:9090/api/v1", env.get("AXIOM_API_URL"));
+        assertEquals("do the thing", env.get("AXIOM_MANAGER_INPUT"));
+    }
+
+    @Test
+    void onlyReferencedPlaceholdersAreExported() {
+        ScriptExecutionService svc = newService();
+        Map<String, String> env = new LinkedHashMap<>();
+
+        svc.substitutePlaceholders("echo {{ref}}", task(1L, 2L, null),
+                project("r", "repo", "n"), env);
+
+        assertTrue(env.containsKey("AXIOM_REF"));
+        assertFalse(env.containsKey("AXIOM_MANAGER_INPUT"));
+        assertFalse(env.containsKey("AXIOM_PROJECT_NAME"));
+    }
+
+    @Test
+    void injectionPayloadIsNotInlinedIntoScript() {
+        ScriptExecutionService svc = newService();
+        Map<String, String> env = new LinkedHashMap<>();
+        String payload = "$(touch /tmp/pwned); `id`; rm -rf /";
+
+        String resolved = svc.substitutePlaceholders("echo {{managerInput}}",
+                task(1L, 2L, payload), project("r", "repo", "n"), env);
+
+        // The dangerous characters live only in the env value, not the script.
+        assertEquals("echo \"$AXIOM_MANAGER_INPUT\"", resolved);
+        assertEquals(payload, env.get("AXIOM_MANAGER_INPUT"));
+        assertFalse(resolved.contains("touch"));
+        assertFalse(resolved.contains("rm -rf"));
+    }
+
+    @Test
+    void workflowInputsBecomeQuotedEnvReferences() {
+        ScriptExecutionService svc = newService();
+        Map<String, String> env = new LinkedHashMap<>();
+        TaskEntity task = task(1L, 2L, "{\"title\":\"$(evil)\",\"count\":3}");
+        task.workflowRunId = 99L;
+
+        String resolved = svc.substitutePlaceholders(
+                "echo {{inputs.title}} {{inputs.count}}", task,
+                project("r", "repo", "n"), env);
+
+        assertEquals("echo \"$AXIOM_INPUT_title\" \"$AXIOM_INPUT_count\"", resolved);
+        assertEquals("$(evil)", env.get("AXIOM_INPUT_title"));
+        assertEquals("3", env.get("AXIOM_INPUT_count"));
+    }
+
+    @Test
+    void injectionPayloadIsNotExecutedByBash() throws IOException, InterruptedException {
+        ScriptExecutionService svc = newService();
+        Map<String, String> env = new LinkedHashMap<>();
+
+        Path marker = Files.createTempFile("axiom-inject-", ".marker");
+        Files.deleteIfExists(marker);
+        String payload = "$(touch " + marker + ")";
+
+        String resolved = svc.substitutePlaceholders("printf '%s' {{managerInput}}",
+                task(1L, 2L, payload), project("r", "repo", "n"), env);
+
+        Path scriptFile = Files.createTempFile("axiom-inject-script-", ".sh");
+        try {
+            Files.writeString(scriptFile, resolved);
+            ProcessBuilder pb = new ProcessBuilder("/bin/bash", scriptFile.toString())
+                    .redirectErrorStream(true);
+            pb.environment().putAll(env);
+            Process process = pb.start();
+            String output = new String(process.getInputStream().readAllBytes());
+            process.waitFor(30, TimeUnit.SECONDS);
+
+            // The payload is echoed literally and the command substitution never ran.
+            assertEquals(payload, output);
+            assertFalse(Files.exists(marker), "Injected command must not execute");
+        } finally {
+            Files.deleteIfExists(scriptFile);
+            Files.deleteIfExists(marker);
+        }
+    }
+}

--- a/app/src/test/java/io/apitomy/axiom/app/ScriptExecutionServiceTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/ScriptExecutionServiceTest.java
@@ -60,9 +60,9 @@ class ScriptExecutionServiceTest {
                 project("owner/repo#42", "owner/repo", "My Project"), env);
 
         // No raw values are inlined; each placeholder is a quoted env reference.
-        assertEquals("echo \"$AXIOM_PROJECT_ID\" \"$AXIOM_TASK_ID\" \"$AXIOM_REF\" "
-                + "\"$AXIOM_REPOSITORY\" \"$AXIOM_PROJECT_NAME\" \"$AXIOM_API_URL\" "
-                + "\"$AXIOM_WORK_DIR\" \"$AXIOM_MANAGER_INPUT\"", resolved);
+        assertEquals("echo \"${AXIOM_PROJECT_ID}\" \"${AXIOM_TASK_ID}\" \"${AXIOM_REF}\" "
+                + "\"${AXIOM_REPOSITORY}\" \"${AXIOM_PROJECT_NAME}\" \"${AXIOM_API_URL}\" "
+                + "\"${AXIOM_WORK_DIR}\" \"${AXIOM_MANAGER_INPUT}\"", resolved);
 
         assertEquals("42", env.get("AXIOM_PROJECT_ID"));
         assertEquals("7", env.get("AXIOM_TASK_ID"));
@@ -96,7 +96,7 @@ class ScriptExecutionServiceTest {
                 task(1L, 2L, payload), project("r", "repo", "n"), env);
 
         // The dangerous characters live only in the env value, not the script.
-        assertEquals("echo \"$AXIOM_MANAGER_INPUT\"", resolved);
+        assertEquals("echo \"${AXIOM_MANAGER_INPUT}\"", resolved);
         assertEquals(payload, env.get("AXIOM_MANAGER_INPUT"));
         assertFalse(resolved.contains("touch"));
         assertFalse(resolved.contains("rm -rf"));
@@ -113,9 +113,85 @@ class ScriptExecutionServiceTest {
                 "echo {{inputs.title}} {{inputs.count}}", task,
                 project("r", "repo", "n"), env);
 
-        assertEquals("echo \"$AXIOM_INPUT_title\" \"$AXIOM_INPUT_count\"", resolved);
+        assertEquals("echo \"${AXIOM_INPUT_title}\" \"${AXIOM_INPUT_count}\"", resolved);
         assertEquals("$(evil)", env.get("AXIOM_INPUT_title"));
         assertEquals("3", env.get("AXIOM_INPUT_count"));
+    }
+
+    @Test
+    void placeholderInsideDoubleQuotesIsNotReQuoted() {
+        ScriptExecutionService svc = newService();
+        Map<String, String> env = new LinkedHashMap<>();
+
+        String resolved = svc.substitutePlaceholders(
+                "git commit -m \"Automated fix: {{managerInput}}\"",
+                task(1L, 2L, "fix login bug"), project("r", "repo", "n"), env);
+
+        // Inside an existing double-quoted string the reference must NOT add its
+        // own quotes, otherwise the value would word-split (issue: PR #280 review).
+        assertEquals("git commit -m \"Automated fix: ${AXIOM_MANAGER_INPUT}\"", resolved);
+        assertEquals("fix login bug", env.get("AXIOM_MANAGER_INPUT"));
+    }
+
+    @Test
+    void placeholderInsideSingleQuotesBreaksOutToExpand() {
+        ScriptExecutionService svc = newService();
+        Map<String, String> env = new LinkedHashMap<>();
+
+        String resolved = svc.substitutePlaceholders("echo '{{managerInput}}'",
+                task(1L, 2L, "hello world"), project("r", "repo", "n"), env);
+
+        // Single quotes suppress expansion, so the reference closes the region,
+        // expands within double quotes, then reopens it.
+        assertEquals("echo '\"${AXIOM_MANAGER_INPUT}\"'", resolved);
+        assertEquals("hello world", env.get("AXIOM_MANAGER_INPUT"));
+    }
+
+    @Test
+    void whitespaceValueInDoubleQuotesStaysSingleArgument()
+            throws IOException, InterruptedException {
+        ScriptExecutionService svc = newService();
+        Map<String, String> env = new LinkedHashMap<>();
+
+        // Print the argument count and the first argument so we can confirm the
+        // whitespace-bearing value was passed as exactly one argument.
+        String resolved = svc.substitutePlaceholders(
+                "set -- \"Automated fix: {{managerInput}}\"\nprintf '%s|%s' \"$#\" \"$1\"",
+                task(1L, 2L, "fix login bug"), project("r", "repo", "n"), env);
+
+        String output = runScript(resolved, env);
+        assertEquals("1|Automated fix: fix login bug", output);
+    }
+
+    @Test
+    void whitespaceValueInSingleQuotesExpandsAsSingleArgument()
+            throws IOException, InterruptedException {
+        ScriptExecutionService svc = newService();
+        Map<String, String> env = new LinkedHashMap<>();
+
+        String resolved = svc.substitutePlaceholders(
+                "set -- '{{managerInput}}'\nprintf '%s|%s' \"$#\" \"$1\"",
+                task(1L, 2L, "fix login bug"), project("r", "repo", "n"), env);
+
+        String output = runScript(resolved, env);
+        assertEquals("1|fix login bug", output);
+    }
+
+    private String runScript(String script, Map<String, String> env)
+            throws IOException, InterruptedException {
+        Path scriptFile = Files.createTempFile("axiom-script-", ".sh");
+        try {
+            Files.writeString(scriptFile, script);
+            ProcessBuilder pb = new ProcessBuilder("/bin/bash", scriptFile.toString())
+                    .redirectErrorStream(true);
+            pb.environment().putAll(env);
+            Process process = pb.start();
+            String output = new String(process.getInputStream().readAllBytes());
+            process.waitFor(30, TimeUnit.SECONDS);
+            return output;
+        } finally {
+            Files.deleteIfExists(scriptFile);
+        }
     }
 
     @Test

--- a/docs/user-guide/concepts.md
+++ b/docs/user-guide/concepts.md
@@ -261,6 +261,20 @@ placeholders plus additional ones:
 | `{{eventId}}` | The triggering event ID |
 | `{{taskId}}` | The task ID |
 | `{{apiBaseUrl}}` | Axiom's own API base URL (for callbacks) |
+| `{{inputs.NAME}}` | A named workflow input (workflow tasks only) |
+
+> **Placeholder values are treated as literal data.** In script mode each
+> placeholder is not inlined into the script text. Instead its value is passed to
+> the script as an environment variable and the placeholder expands to a quoted
+> reference — for example `{{managerInput}}` becomes `"$AXIOM_MANAGER_INPUT"`.
+> This means a value containing shell metacharacters (`$(...)`, backticks, `;`,
+> `&&`, newlines, etc.) is never executed as code. As an author you can use a
+> placeholder wherever you'd use a shell variable; you do **not** need to add
+> your own quotes around it (existing templates that already quote placeholders
+> continue to work). The matching environment variables — `AXIOM_PROJECT_ID`,
+> `AXIOM_EVENT_ID`, `AXIOM_TASK_ID`, `AXIOM_REF`, `AXIOM_REPOSITORY`,
+> `AXIOM_PROJECT_NAME`, `AXIOM_MANAGER_INPUT`, `AXIOM_API_URL`, `AXIOM_WORK_DIR`,
+> and `AXIOM_INPUT_<NAME>` for workflow inputs — are also available directly.
 
 ### Tasks
 

--- a/docs/user-guide/concepts.md
+++ b/docs/user-guide/concepts.md
@@ -265,13 +265,15 @@ placeholders plus additional ones:
 
 > **Placeholder values are treated as literal data.** In script mode each
 > placeholder is not inlined into the script text. Instead its value is passed to
-> the script as an environment variable and the placeholder expands to a quoted
-> reference — for example `{{managerInput}}` becomes `"$AXIOM_MANAGER_INPUT"`.
-> This means a value containing shell metacharacters (`$(...)`, backticks, `;`,
-> `&&`, newlines, etc.) is never executed as code. As an author you can use a
-> placeholder wherever you'd use a shell variable; you do **not** need to add
-> your own quotes around it (existing templates that already quote placeholders
-> continue to work). The matching environment variables — `AXIOM_PROJECT_ID`,
+> the script as an environment variable and the placeholder expands to a
+> reference to that variable — for example `echo {{managerInput}}` becomes
+> `echo "${AXIOM_MANAGER_INPUT}"`. This means a value containing shell
+> metacharacters (`$(...)`, backticks, `;`, `&&`, newlines, etc.) is never
+> executed as code. The expansion adapts to the surrounding quotes, so you can
+> place a placeholder wherever you'd use a shell variable and values containing
+> whitespace stay a single argument — whether it is unquoted (`{{managerInput}}`),
+> inside double quotes (`"Fix: {{managerInput}}"`), or inside single quotes
+> (`'{{managerInput}}'`). The matching environment variables — `AXIOM_PROJECT_ID`,
 > `AXIOM_EVENT_ID`, `AXIOM_TASK_ID`, `AXIOM_REF`, `AXIOM_REPOSITORY`,
 > `AXIOM_PROJECT_NAME`, `AXIOM_MANAGER_INPUT`, `AXIOM_API_URL`, `AXIOM_WORK_DIR`,
 > and `AXIOM_INPUT_<NAME>` for workflow inputs — are also available directly.


### PR DESCRIPTION
## Summary

Script-mode action types previously substituted `{{...}}` placeholders (including `{{managerInput}}` and the new workflow `{{inputs.NAME}}`) directly into the bash script body via raw string replacement. With workflow inputs/outputs (#266), these values can originate from upstream agent output, making raw inlining a shell-injection surface: a value containing `$(...)`, backticks, `;`, `&&`, newlines, etc. would execute as code in the generated script.

This PR adopts the environment-variable approach proposed in the issue, applied **consistently to all placeholders**.

## What changed

- `ScriptExecutionService.substitutePlaceholders(...)` no longer inlines placeholder values. Each value is exported as an environment variable and the placeholder is replaced with a **quoted shell reference** — e.g. `{{managerInput}}` → `"$AXIOM_MANAGER_INPUT"`. Bash does not re-parse the contents of a variable expansion for command substitution, so the value is treated as literal data.
  - Mapping: `{{projectId}}`→`AXIOM_PROJECT_ID`, `{{eventId}}`→`AXIOM_EVENT_ID`, `{{taskId}}`→`AXIOM_TASK_ID`, `{{ref}}`→`AXIOM_REF`, `{{repository}}`→`AXIOM_REPOSITORY`, `{{projectName}}`→`AXIOM_PROJECT_NAME`, `{{managerInput}}`→`AXIOM_MANAGER_INPUT`, `{{apiBaseUrl}}`→`AXIOM_API_URL`, `{{workDir}}`→`AXIOM_WORK_DIR`, `{{inputs.NAME}}`→`AXIOM_INPUT_NAME`.
  - Env vars are only exported when their placeholder actually appears in the template.
  - Workflow input names are re-checked against the identifier rule (`^[a-zA-Z_][a-zA-Z0-9_]*$`) before being bound as env vars; anything else is left untouched.
- `runScript(...)` injects the collected placeholder env vars into the process environment (applied last so the reserved `AXIOM_*` names are authoritative).
- Documentation for action-type authors updated in `docs/user-guide/concepts.md` and the script-authoring AI guidance in `ScriptAiService`.

## Backward compatibility

Existing templates quote placeholders inside double quotes (e.g. the seed `curl -s -X POST "{{apiBaseUrl}}/projects/{{projectId}}/close"`), which continues to resolve to the correct single URL. Values with no whitespace (IDs, URLs, refs, repositories) behave identically.

## Tests

Added `ScriptExecutionServiceTest` covering:
- All standard placeholders become quoted env references with values captured verbatim.
- Only referenced placeholders are exported.
- An injection payload (`$(...)`, backticks, `rm -rf /`) is never inlined into the script text.
- Workflow `{{inputs.NAME}}` values (including a `$(evil)` payload) are bound as env references.
- End-to-end: a resolved script run through `/bin/bash` echoes an injection payload literally and does **not** execute the embedded command.

Fixes #267