### PR TITLE
fix(deps): update frontend-maven-plugin to 2.0.2

### DIFF
--- a/ui-bundle/pom.xml
+++ b/ui-bundle/pom.xml
@@ -20,7 +20,7 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.15.4</version>
+                <version>2.0.2</version>
                 <configuration>
                     <workingDirectory>${project.basedir}/../ui</workingDirectory>
                     <installDirectory>${project.build.directory}/node-install</installDirectory>


### PR DESCRIPTION
## Summary
- Update `com.github.eirslett:frontend-maven-plugin` from `1.15.4` to `2.0.2` (Maven, major)

## Context
This dependency upgrade was split from Renovate PR #281 for easier review and testing.

## Test Plan
- [ ] Build passes
- [ ] Tests pass
- [ ] No breaking changes detected