### PR TITLE
fix(deps): update actions/* GitHub Actions (major)

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout apitomy-axiom
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.14.7'
 
@@ -32,7 +32,7 @@ jobs:
         run: mkdocs build --strict
 
       - name: Checkout website repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: Apitomy/apitomy.github.io
           token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,18 +16,18 @@ jobs:
     steps:
       # ── Setup ────────────────────────────────────────────────────────
       - name: Checkout code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           token: ${{ secrets.ACCESS_TOKEN }}
 
       - name: Set up Java 25
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6
         with:
           distribution: oracle
           java-version: '25'
 
       - name: Set up Node.js 22
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '22.23.2'
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Java 25
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6
         with:
           distribution: oracle
           java-version: '25'
@@ -34,10 +34,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Node.js 22
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '22.23.2'
           cache: 'npm'


### PR DESCRIPTION
## Summary
Update the `actions/*` GitHub Actions to their latest major versions:
- `actions/checkout` `v6` → `v7`
- `actions/setup-java` `v5` → `v6`
- `actions/setup-node` `v6` → `v7`
- `actions/setup-python` `v5` → `v7`

## Context
These upgrades were split from Renovate PR #281 for easier review and testing. The `node-version`
bump and `softprops/action-gh-release` upgrade from the same Renovate PR are handled in separate PRs.

## Test Plan
- [ ] Build passes
- [ ] Tests pass
- [ ] No breaking changes detected