### PR TITLE
fix(deps): update softprops/action-gh-release to v3

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,7 +76,7 @@ jobs:
              app/target/apitomy-axiom-${{ steps.version.outputs.release-version }}.jar
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3
         with:
           tag_name: v${{ steps.version.outputs.release-version }}
           name: ${{ steps.version.outputs.release-version }}


### PR DESCRIPTION
## Summary
- Update `softprops/action-gh-release` from `v2` to `v3` in `.github/workflows/release.yaml`

## Context
This upgrade was split from Renovate PR #281 for easier review and testing.

## Test Plan
- [ ] Build passes
- [ ] Tests pass
- [ ] No breaking changes detected