### PR TITLE
fix(deps): update CI node version to 24.20.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Node.js 22
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: '22.23.2'
+          node-version: '24.20.0'
 
       - name: Configure Git
         run: |

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Node.js 22
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: '22.23.2'
+          node-version: '24.20.0'
           cache: 'npm'
           cache-dependency-path: ui/package-lock.json
 


### PR DESCRIPTION
## Summary
- Update the `node-version` used by CI workflows from `22.23.2` to `24.20.0`
  (in `.github/workflows/release.yaml` and `.github/workflows/verify.yaml`)

## Context
This upgrade was split from Renovate PR #281 for easier review and testing.

## Test Plan
- [ ] Build passes
- [ ] Tests pass
- [ ] No breaking changes detected