### PR TITLE
fix(deps): update echarts to 6.1.0

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -18,7 +18,7 @@
                 "@types/react-grid-layout": "1.3.6",
                 "@types/react-syntax-highlighter": "15.5.13",
                 "@xyflow/react": "12.11.6",
-                "echarts": "5.6.0",
+                "echarts": "6.1.0",
                 "elkjs": "0.12.0",
                 "mermaid": "11.17.2",
                 "monaco-editor": "0.56.0",
@@ -3141,13 +3141,13 @@
             }
         },
         "node_modules/echarts": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.6.0.tgz",
-            "integrity": "sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.1.0.tgz",
+            "integrity": "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "2.3.0",
-                "zrender": "5.6.1"
+                "zrender": "6.1.0"
             }
         },
         "node_modules/echarts/node_modules/tslib": {
@@ -6101,9 +6101,9 @@
             "license": "ISC"
         },
         "node_modules/zrender": {
-            "version": "5.6.1",
-            "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.1.tgz",
-            "integrity": "sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.1.0.tgz",
+            "integrity": "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "tslib": "2.3.0"

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,7 +13,7 @@
         "@apitomy/common-ui-components": "4.1.2",
         "@apitomy/flow-ui": "1.0.2",
         "@patternfly/react-charts": "8.6.1",
-        "echarts": "5.6.0",
+        "echarts": "6.1.0",
         "victory-area": "37.3.6",
         "victory-axis": "37.3.6",
         "victory-bar": "37.3.6",


### PR DESCRIPTION
## Summary
- Update `echarts` from `5.6.0` to `6.1.0` (major)

## Context
This dependency upgrade was split from Renovate PR #281 for easier review and testing.
`ui/package-lock.json` was regenerated for this single dependency.

## Test Plan
- [ ] Build passes
- [ ] Tests pass
- [ ] No breaking changes detected