### PR TITLE
fix(ui): migrate DashboardViewPage to react-grid-layout v2 API

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -15,7 +15,6 @@
                 "@patternfly/react-core": "6.6.1",
                 "@patternfly/react-icons": "6.6.1",
                 "@patternfly/react-table": "6.6.1",
-                "@types/react-grid-layout": "2.1.0",
                 "@types/react-syntax-highlighter": "15.5.13",
                 "@xyflow/react": "12.11.6",
                 "echarts": "6.1.0",
@@ -969,16 +968,6 @@
             "license": "MIT",
             "peerDependencies": {
                 "@types/react": "^19.2.0"
-            }
-        },
-        "node_modules/@types/react-grid-layout": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@types/react-grid-layout/-/react-grid-layout-2.1.0.tgz",
-            "integrity": "sha512-pHEjVg9ert6BDFHFQ1IEdLUkd2gasJvyti5lV2kE46N/R07ZiaSZpAXeXJAA1MXy/Qby23fZmiuEgZkITxPXug==",
-            "deprecated": "This is a stub types definition. react-grid-layout provides its own type definitions, so you do not need this installed.",
-            "license": "MIT",
-            "dependencies": {
-                "react-grid-layout": "*"
             }
         },
         "node_modules/@types/react-syntax-highlighter": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -35,7 +35,6 @@
         "@patternfly/react-core": "6.6.1",
         "@patternfly/react-icons": "6.6.1",
         "@patternfly/react-table": "6.6.1",
-        "@types/react-grid-layout": "2.1.0",
         "@types/react-syntax-highlighter": "15.5.13",
         "@xyflow/react": "12.11.6",
         "elkjs": "0.12.0",

--- a/ui/src/pages/DashboardViewPage.tsx
+++ b/ui/src/pages/DashboardViewPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
-import { Responsive, WidthProvider } from "react-grid-layout/legacy";
-import type { Layout, LayoutItem } from "react-grid-layout/legacy";
+import { Responsive, useContainerWidth } from "react-grid-layout";
+import type { Layout, LayoutItem } from "react-grid-layout";
 import {
     Breadcrumb,
     BreadcrumbItem,
@@ -50,11 +50,14 @@ import "react-grid-layout/css/styles.css";
 import "react-resizable/css/styles.css";
 import "./DashboardViewPage.css";
 
-const ResponsiveGridLayout = WidthProvider(Responsive);
-
 export function DashboardViewPage() {
     const { dashboardId } = useParams<{ dashboardId: string }>();
     const navigate = useNavigate();
+
+    // v2 react-grid-layout: WidthProvider is replaced by the useContainerWidth
+    // hook, which measures the container via ResizeObserver and supplies the
+    // `width` prop the Responsive grid now requires.
+    const { width, containerRef, mounted } = useContainerWidth();
 
     const [dashboard, setDashboard] = useState<Dashboard | null>(null);
     const [loading, setLoading] = useState(true);
@@ -504,34 +507,41 @@ export function DashboardViewPage() {
                     </EmptyStateBody>
                 </EmptyState>
             ) : (
-                <ResponsiveGridLayout
-                    key={activeTabId}
-                    className="layout"
-                    layouts={{ lg: gridItems }}
-                    breakpoints={{ lg: 1200, md: 996, sm: 768 }}
-                    cols={{ lg: 12, md: 8, sm: 4 }}
-                    rowHeight={80}
-                    isDraggable={isEditing}
-                    isResizable={isEditing}
-                    onLayoutChange={isEditing ? onGridLayoutChange : undefined}
-                    draggableHandle=".pf-v6-c-card__header"
-                    draggableCancel=".pf-v6-c-button"
-                >
-                    {activeWidgets.map(w => (
-                        <div key={w.id}>
-                            <WidgetCard
-                                key={refreshKey}
-                                widgetType={w.type}
-                                config={w.config}
-                                labels={activeLabels}
-                                isEditing={isEditing}
-                                onConfigChange={(config) =>
-                                    handleWidgetConfigChange(w.id, config)}
-                                onRemove={() => handleRemoveWidget(w.id)}
-                            />
-                        </div>
-                    ))}
-                </ResponsiveGridLayout>
+                <div ref={containerRef}>
+                    {mounted && (
+                        <Responsive
+                            key={activeTabId}
+                            className="layout"
+                            width={width}
+                            layouts={{ lg: gridItems }}
+                            breakpoints={{ lg: 1200, md: 996, sm: 768 }}
+                            cols={{ lg: 12, md: 8, sm: 4 }}
+                            rowHeight={80}
+                            dragConfig={{
+                                enabled: isEditing,
+                                handle: ".pf-v6-c-card__header",
+                                cancel: ".pf-v6-c-button",
+                            }}
+                            resizeConfig={{ enabled: isEditing }}
+                            onLayoutChange={isEditing ? onGridLayoutChange : undefined}
+                        >
+                            {activeWidgets.map(w => (
+                                <div key={w.id}>
+                                    <WidgetCard
+                                        key={refreshKey}
+                                        widgetType={w.type}
+                                        config={w.config}
+                                        labels={activeLabels}
+                                        isEditing={isEditing}
+                                        onConfigChange={(config) =>
+                                            handleWidgetConfigChange(w.id, config)}
+                                        onRemove={() => handleRemoveWidget(w.id)}
+                                    />
+                                </div>
+                            ))}
+                        </Responsive>
+                    )}
+                </div>
             )}
 
             <AddWidgetModal


### PR DESCRIPTION
## Summary

`DashboardViewPage` was written against the **legacy** react-grid-layout API (imported via
`react-grid-layout/legacy`). This migrates it to the **v2** API (`react-grid-layout`), which is
not drop-in compatible.

## Changes

- **Width handling** — replace the `WidthProvider` HOC (removed in v2) with the `useContainerWidth`
  hook, and pass the now-required `width` prop to `Responsive` explicitly. Rendering is gated on
  `mounted` to avoid a first-paint layout flash before the container width is measured.
- **Drag/resize props** — move `isDraggable` / `draggableHandle` / `draggableCancel` into
  `dragConfig`, and `isResizable` into `resizeConfig` (v2 groups these into config objects).
- **Dependencies** — drop the v1-era `@types/react-grid-layout`; v2 ships its own bundled type
  definitions, and the stale `@types` package could shadow them.

`layouts` / `breakpoints` / `cols` / `rowHeight` / `onLayoutChange` and the `Layout` / `LayoutItem`
type usage were already v2-compatible and are unchanged.

## Testing

- [ ] Verify drag and resize behavior in dashboard edit mode.