### PR TITLE
Return 400 for missing/invalid workflow trigger request body

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/rest/ProjectsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/ProjectsResourceImpl.java
@@ -497,6 +497,10 @@ public class ProjectsResourceImpl implements ProjectsResource {
     @Override
     public io.apitomy.axiom.api.beans.WorkflowInstance triggerProjectWorkflow(
             long projectId, TriggerWorkflow data) {
+        if (data == null || data.getWorkflowDefinitionId() == null) {
+            throw new WebApplicationException(
+                    "Missing required 'workflowDefinitionId' field", 400);
+        }
         WorkflowRunEntity entity = workflowExecutionService
                 .triggerWorkflow(projectId, data.getWorkflowDefinitionId());
         return toWorkflowInstanceBean(entity);

--- a/app/src/test/java/io/apitomy/axiom/app/WorkflowInstanceResourceTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/WorkflowInstanceResourceTest.java
@@ -51,6 +51,37 @@ class WorkflowInstanceResourceTest {
     }
 
     @Test
+    void testTriggerWithMissingRequiredFieldReturns400() {
+        int projectId = createProject("WF Missing Field Project");
+
+        // Body present but missing the required workflowDefinitionId field.
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                    {
+                        "definitionId": 1
+                    }
+                    """)
+                .when()
+                    .post(PROJECTS_PATH + "/" + projectId + "/workflow")
+                .then()
+                    .statusCode(400);
+    }
+
+    @Test
+    void testTriggerWithEmptyBodyReturns400() {
+        int projectId = createProject("WF Empty Body Project");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{}")
+                .when()
+                    .post(PROJECTS_PATH + "/" + projectId + "/workflow")
+                .then()
+                    .statusCode(400);
+    }
+
+    @Test
     void testTriggerDuplicateReturns409() {
         int projectId = createProject("WF Dup Test Project");
         int definitionId = createAndPublishActionWorkflow(


### PR DESCRIPTION
## Summary

`POST /api/v1/projects/{projectId}/workflow` returned **HTTP 500** when the request body was missing the required `workflowDefinitionId` field (or was otherwise malformed). This happened because `TriggerWorkflow.getWorkflowDefinitionId()` returns a boxed `Long`, and passing a `null` value into `WorkflowExecutionService.triggerWorkflow(long projectId, long definitionId)` caused a `NullPointerException` during auto-unboxing, which surfaced as an unhandled 500.

## Change

- `ProjectsResourceImpl.triggerProjectWorkflow` now validates that the request body and its required `workflowDefinitionId` field are present, throwing `WebApplicationException` with **HTTP 400** and a descriptive message when they are not. This matches the existing `validateRequired` 400 pattern used elsewhere in the resource.
- Added REST tests covering a body missing the required field (`{"definitionId": 1}`) and an empty body (`{}`), both asserting a 400 response.

A well-formed body (`{"workflowDefinitionId": 1}`) continues to return 200.

## Files changed

- `app/src/main/java/io/apitomy/axiom/app/rest/ProjectsResourceImpl.java`
- `app/src/test/java/io/apitomy/axiom/app/WorkflowInstanceResourceTest.java`

Fixes #297