### PR TITLE
Fix POST /system/packs/export to return 400 when required 'name' is missing

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/rest/SystemResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/SystemResourceImpl.java
@@ -145,6 +145,10 @@ public class SystemResourceImpl implements SystemResource {
      */
     @Override
     public Response exportPack(PackExportRequest data) {
+        if (data == null || data.getName() == null || data.getName().isBlank()) {
+            throw new jakarta.ws.rs.WebApplicationException(
+                    "Missing required 'name' field", 400);
+        }
         JsonNode pack = importExportService.exportPack(data);
         String filename = data.getName().replaceAll("[^a-zA-Z0-9_-]", "_") + ".json";
         return Response.ok(pack)

--- a/app/src/test/java/io/apitomy/axiom/app/SystemResourceTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/SystemResourceTest.java
@@ -1,6 +1,7 @@
 package io.apitomy.axiom.app;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
@@ -63,5 +64,16 @@ class SystemResourceTest {
             .then()
                 .statusCode(200)
                 .body("version", equalTo(healthVersion));
+    }
+
+    @Test
+    void testExportPackMissingNameReturnsBadRequest() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("{}")
+            .when()
+                .post("/api/v1/system/packs/export")
+            .then()
+                .statusCode(400);
     }
 }


### PR DESCRIPTION
## Summary

`POST /api/v1/system/packs/export` with a request body missing the required `name` field previously returned **HTTP 500** instead of a client error. This happened because `exportPack` dereferenced `data.getName()` (e.g. `data.getName().replaceAll(...)`) without validating that `name` was present, resulting in a `NullPointerException` that surfaced as a 500.

## Changes

- `SystemResourceImpl.exportPack` now validates the request up front and throws a `WebApplicationException` with status **400** and the message `Missing required 'name' field` when the body is missing, or `name` is null/blank. This matches the existing validation pattern used elsewhere (e.g. `AssistantResourceImpl`).
- Added a test (`SystemResourceTest.testExportPackMissingNameReturnsBadRequest`) that posts an empty body `{}` and asserts a `400` response.

## Files modified

- `app/src/main/java/io/apitomy/axiom/app/rest/SystemResourceImpl.java`
- `app/src/test/java/io/apitomy/axiom/app/SystemResourceTest.java`

Fixes #269