### PR TITLE
Return informative 400 body for invalid action type field type

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/rest/EnumDeserializationCustomizer.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/EnumDeserializationCustomizer.java
@@ -1,0 +1,50 @@
+package io.apitomy.axiom.app.rest;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import io.quarkus.jackson.ObjectMapperCustomizer;
+import jakarta.inject.Singleton;
+
+import java.io.IOException;
+
+/**
+ * Normalizes generated-enum deserialization failures so they can be reported with an
+ * informative HTTP 400 body.
+ *
+ * <p>The generated API beans read enum values through a {@code @JsonCreator fromValue(...)}
+ * factory that throws {@link IllegalArgumentException} for out-of-range input. Jackson wraps
+ * that in a {@code ValueInstantiationException}, which Quarkus REST (RESTEasy Reactive)
+ * converts into a bodyless {@code 400} <em>before</em> any {@code ExceptionMapper} runs —
+ * only {@code MismatchedInputException}s survive to the mapper layer. This customizer installs
+ * a {@link DeserializationProblemHandler} that rethrows enum instantiation failures as an
+ * {@link InvalidFormatException} (a {@code MismatchedInputException}), allowing
+ * {@link InvalidFormatExceptionMapper} to produce an explanatory response.</p>
+ */
+@Singleton
+public class EnumDeserializationCustomizer implements ObjectMapperCustomizer {
+
+    /**
+     * Registers the enum-normalizing {@link DeserializationProblemHandler} on the mapper.
+     *
+     * @param objectMapper the application {@link ObjectMapper} being configured
+     */
+    @Override
+    public void customize(ObjectMapper objectMapper) {
+        objectMapper.addHandler(new DeserializationProblemHandler() {
+            @Override
+            public Object handleInstantiationProblem(DeserializationContext ctxt, Class<?> instClass,
+                    Object argument, Throwable t) throws IOException {
+                if (instClass != null && instClass.isEnum() && t instanceof IllegalArgumentException) {
+                    JsonParser parser = ctxt.getParser();
+                    throw InvalidFormatException.from(parser,
+                            "Value '" + argument + "' is not a valid " + instClass.getSimpleName(),
+                            argument, instClass);
+                }
+                return super.handleInstantiationProblem(ctxt, instClass, argument, t);
+            }
+        });
+    }
+}

--- a/app/src/main/java/io/apitomy/axiom/app/rest/InvalidFormatExceptionMapper.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/InvalidFormatExceptionMapper.java
@@ -21,10 +21,25 @@ import java.util.stream.Collectors;
  * the allowed set — for example an action type field {@code type} of
  * {@code "integer"} when only {@code string|number|boolean|object} are permitted.
  * Without this mapper the client receives a bare 400 with no explanation.</p>
+ *
+ * <p>Enum values in the generated beans are read through a {@code @JsonCreator}
+ * factory that throws {@link IllegalArgumentException}, which Jackson would otherwise
+ * wrap as a {@code ValueInstantiationException} — a type Quarkus REST converts into a
+ * bodyless 400 before any {@code ExceptionMapper} runs. {@link EnumDeserializationCustomizer}
+ * normalizes those failures into an {@link InvalidFormatException} so that this mapper
+ * can handle them uniformly.</p>
  */
 @Provider
 public class InvalidFormatExceptionMapper implements ExceptionMapper<InvalidFormatException> {
 
+    /**
+     * Builds a {@code 400 Bad Request} response whose JSON body carries a human-readable
+     * {@code message} describing the offending value, the field it was bound to, and (for
+     * enum targets) the set of allowed values.
+     *
+     * @param exception the format failure raised while reading the request body
+     * @return a {@code 400 Bad Request} response with an explanatory JSON body
+     */
     @Override
     public Response toResponse(InvalidFormatException exception) {
         String field = pathOf(exception);
@@ -52,6 +67,9 @@ public class InvalidFormatExceptionMapper implements ExceptionMapper<InvalidForm
     /**
      * Builds a dotted JSON path (e.g. {@code inputs[0].type}) from the exception's
      * path references, or {@code null} if none are available.
+     *
+     * @param exception the format failure
+     * @return the dotted path to the offending property, or {@code null}
      */
     private static String pathOf(InvalidFormatException exception) {
         List<JsonMappingException.Reference> path = exception.getPath();
@@ -73,9 +91,12 @@ public class InvalidFormatExceptionMapper implements ExceptionMapper<InvalidForm
     }
 
     /**
-     * Returns the JSON values allowed for an enum target type, using the generated
-     * {@code value()} accessor when present and falling back to the constant name.
+     * Returns the JSON values allowed for an enum target type, using the constant's
+     * {@code toString()} (which the generated enums override to return the JSON value).
      * Returns an empty list for non-enum types.
+     *
+     * @param targetType the type the value was being bound to
+     * @return the allowed JSON values, or an empty list when {@code targetType} is not an enum
      */
     private static List<String> allowedEnumValues(Class<?> targetType) {
         if (targetType == null || !targetType.isEnum()) {
@@ -83,21 +104,8 @@ public class InvalidFormatExceptionMapper implements ExceptionMapper<InvalidForm
         }
         List<String> values = new ArrayList<>();
         for (Object constant : targetType.getEnumConstants()) {
-            values.add(jsonValueOf(constant));
+            values.add(String.valueOf(constant));
         }
         return values.stream().filter(v -> v != null && !v.isBlank()).collect(Collectors.toList());
-    }
-
-    private static String jsonValueOf(Object constant) {
-        try {
-            var valueMethod = constant.getClass().getMethod("value");
-            Object result = valueMethod.invoke(constant);
-            if (result != null) {
-                return result.toString();
-            }
-        } catch (ReflectiveOperationException ignored) {
-            // Fall through to the enum constant name.
-        }
-        return constant.toString();
     }
 }

--- a/app/src/main/java/io/apitomy/axiom/app/rest/InvalidFormatExceptionMapper.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/InvalidFormatExceptionMapper.java
@@ -1,0 +1,103 @@
+package io.apitomy.axiom.app.rest;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Translates Jackson {@link InvalidFormatException}s (raised while deserializing a
+ * request body) into an informative HTTP 400 response instead of the empty body
+ * produced by the default handler.
+ *
+ * <p>The most common trigger is an enum-typed property receiving a value outside
+ * the allowed set — for example an action type field {@code type} of
+ * {@code "integer"} when only {@code string|number|boolean|object} are permitted.
+ * Without this mapper the client receives a bare 400 with no explanation.</p>
+ */
+@Provider
+public class InvalidFormatExceptionMapper implements ExceptionMapper<InvalidFormatException> {
+
+    @Override
+    public Response toResponse(InvalidFormatException exception) {
+        String field = pathOf(exception);
+        Object value = exception.getValue();
+        Class<?> targetType = exception.getTargetType();
+
+        StringBuilder message = new StringBuilder("Invalid value ");
+        message.append("'").append(value).append("'");
+        if (field != null && !field.isBlank()) {
+            message.append(" for field '").append(field).append("'");
+        }
+        message.append(".");
+
+        List<String> allowed = allowedEnumValues(targetType);
+        if (!allowed.isEmpty()) {
+            message.append(" Allowed values: ").append(String.join(", ", allowed)).append(".");
+        }
+
+        return Response.status(Response.Status.BAD_REQUEST)
+                .type(MediaType.APPLICATION_JSON)
+                .entity(Map.of("message", message.toString()))
+                .build();
+    }
+
+    /**
+     * Builds a dotted JSON path (e.g. {@code inputs[0].type}) from the exception's
+     * path references, or {@code null} if none are available.
+     */
+    private static String pathOf(InvalidFormatException exception) {
+        List<JsonMappingException.Reference> path = exception.getPath();
+        if (path == null || path.isEmpty()) {
+            return null;
+        }
+        StringBuilder sb = new StringBuilder();
+        for (JsonMappingException.Reference ref : path) {
+            if (ref.getFieldName() != null) {
+                if (sb.length() > 0) {
+                    sb.append(".");
+                }
+                sb.append(ref.getFieldName());
+            } else if (ref.getIndex() >= 0) {
+                sb.append("[").append(ref.getIndex()).append("]");
+            }
+        }
+        return sb.length() > 0 ? sb.toString() : null;
+    }
+
+    /**
+     * Returns the JSON values allowed for an enum target type, using the generated
+     * {@code value()} accessor when present and falling back to the constant name.
+     * Returns an empty list for non-enum types.
+     */
+    private static List<String> allowedEnumValues(Class<?> targetType) {
+        if (targetType == null || !targetType.isEnum()) {
+            return List.of();
+        }
+        List<String> values = new ArrayList<>();
+        for (Object constant : targetType.getEnumConstants()) {
+            values.add(jsonValueOf(constant));
+        }
+        return values.stream().filter(v -> v != null && !v.isBlank()).collect(Collectors.toList());
+    }
+
+    private static String jsonValueOf(Object constant) {
+        try {
+            var valueMethod = constant.getClass().getMethod("value");
+            Object result = valueMethod.invoke(constant);
+            if (result != null) {
+                return result.toString();
+            }
+        } catch (ReflectiveOperationException ignored) {
+            // Fall through to the enum constant name.
+        }
+        return constant.toString();
+    }
+}

--- a/app/src/test/java/io/apitomy/axiom/app/ActionResourceTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/ActionResourceTest.java
@@ -141,6 +141,29 @@ class ActionResourceTest {
     }
 
     @Test
+    void testCreateActionTypeInvalidFieldTypeRejected() {
+        // A field whose type is outside the allowed enum must be rejected with a
+        // 400 that explains the problem, rather than an empty-bodied 400.
+        given()
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                    "name": "invalid-field-type-action",
+                    "executionMode": "agent",
+                    "promptTemplate": "Do: {{input}}",
+                    "workflowEnabled": true,
+                    "inputs": [{ "name": "issueNumber", "type": "integer", "required": true }]
+                }
+                """)
+            .when()
+                .post(ACTION_TYPES_PATH)
+            .then()
+                .statusCode(400)
+                .body("message", containsString("integer"))
+                .body("message", containsString("string"));
+    }
+
+    @Test
     void testUpdateActionType() {
         int id = createActionType("update-test-action");
 


### PR DESCRIPTION
## Summary

Submitting an Action Type with an `inputs`/`outputs` field whose `type` is outside the allowed enum (`string|number|boolean|object`) via a raw REST call returned an **HTTP 400 with an empty body**, giving the client no indication of what was wrong.

## Root cause

The `type` property is a strict enum in the generated API bean. When a client sends an invalid value such as `"integer"`, Jackson fails to deserialize the request body (throwing `InvalidFormatException`) **before** the action-type validation logic runs. Quarkus REST's default handling for that exception returns a 400 with an empty body, so the `ActionTypeValidator` never gets a chance to produce a helpful message.

## Fix

Added `InvalidFormatExceptionMapper`, a JAX-RS `ExceptionMapper` that translates Jackson `InvalidFormatException`s into an informative `400` JSON response, e.g.:

```json
{ "message": "Invalid value 'integer' for field 'inputs[0].type'. Allowed values: string, number, boolean, object." }
```

For enum target types the mapper lists the allowed values (using the generated `value()` accessor), and it builds a dotted JSON path (e.g. `inputs[0].type`) from the exception's path references. Non-enum invalid-format errors also now get a descriptive body instead of an empty one.

## Testing

Added `testCreateActionTypeInvalidFieldTypeRejected` to `ActionResourceTest`, which posts an action type with a field `type` of `integer` and asserts a `400` whose body explains the invalid value and lists the allowed types.

## Files changed

- `app/src/main/java/io/apitomy/axiom/app/rest/InvalidFormatExceptionMapper.java` (new)
- `app/src/test/java/io/apitomy/axiom/app/ActionResourceTest.java` (new test)

Fixes #268