### PR TITLE
Render muted placeholder for blank human-task detail rows

### DIFF
--- a/ui/src/pages/InboxPage.tsx
+++ b/ui/src/pages/InboxPage.tsx
@@ -275,7 +275,10 @@ export function InboxPage() {
                             <div style={{ marginBottom: "16px" }}>
                                 {selectedItem.humanContext.details.map((d) => (
                                     <div key={d.label} style={{ marginBottom: "4px" }}>
-                                        <strong>{d.label}:</strong> {d.value}
+                                        <strong>{d.label}:</strong>{" "}
+                                        {d.value?.trim()
+                                            ? d.value
+                                            : <span className="axiom-text-subtle">&mdash;</span>}
                                     </div>
                                 ))}
                             </div>

--- a/ui/src/pages/ProjectDetailPage.tsx
+++ b/ui/src/pages/ProjectDetailPage.tsx
@@ -723,7 +723,10 @@ function TasksTab({ tasks, projectId, agentNames, onRefresh }: {
                         </Title>
                         {respondItem?.humanContext?.details?.map((d) => (
                             <div key={d.label} style={{ marginTop: "8px" }}>
-                                <strong>{d.label}:</strong> {d.value}
+                                <strong>{d.label}:</strong>{" "}
+                                {d.value?.trim()
+                                    ? d.value
+                                    : <span className="axiom-text-subtle">&mdash;</span>}
                             </div>
                         ))}
                         <div style={{ marginTop: "8px" }}>


### PR DESCRIPTION
## Summary

When a `human-task` node declares an `inputs` mapping to a workflow-context key that has no value at run time, the resulting inbox task rendered the detail row with an empty value (e.g. `Requested By :` with nothing after it), which reads as a rendering glitch.

This change renders a muted em-dash placeholder (`—`) for detail rows whose resolved value is `null`/blank, so rows no longer look unfinished. It reuses the existing `axiom-text-subtle` styling class for the muted appearance.

## Changes

- `ui/src/pages/InboxPage.tsx` — details section now shows a muted `—` when a detail value is empty/blank.
- `ui/src/pages/ProjectDetailPage.tsx` — same treatment in the task response details section.

Fixes #296
