### PR TITLE
Retry retention/cleanup jobs on H2 deadlocks and stagger their schedules

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/CleanupRetry.java
+++ b/app/src/main/java/io/apitomy/axiom/app/CleanupRetry.java
@@ -1,0 +1,71 @@
+package io.apitomy.axiom.app;
+
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import jakarta.persistence.PessimisticLockException;
+import org.hibernate.exception.LockAcquisitionException;
+import org.jboss.logging.Logger;
+
+/**
+ * Shared helper for the scheduled retention/cleanup jobs. Runs a unit of work in
+ * a new transaction and retries a bounded number of times when the database
+ * reports a deadlock ({@link LockAcquisitionException} /
+ * {@link PessimisticLockException}).
+ *
+ * <p>Deadlocks are expected under concurrent event ingestion (H2's MVStore uses
+ * row-level locking with deadlock detection) and are safely retryable. If all
+ * retries are exhausted the failure is logged at {@code WARN} rather than
+ * {@code ERROR}, because the next scheduled tick will recover the deferred work.
+ */
+final class CleanupRetry {
+
+    private static final int MAX_ATTEMPTS = 3;
+    private static final long BACKOFF_MILLIS = 200L;
+
+    private CleanupRetry() {
+    }
+
+    /**
+     * Executes {@code work} in a new transaction, retrying on database deadlocks.
+     *
+     * @param log     the logger of the calling cleanup job
+     * @param jobName a human-readable name for the job, used in log messages
+     * @param work    the cleanup work to run inside a transaction
+     */
+    static void runWithRetry(Logger log, String jobName, Runnable work) {
+        for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+            try {
+                QuarkusTransaction.requiringNew().run(work);
+                return;
+            } catch (RuntimeException e) {
+                if (!isDeadlock(e)) {
+                    throw e;
+                }
+                if (attempt == MAX_ATTEMPTS) {
+                    log.warnf("%s skipped after %d attempts due to a database deadlock; "
+                            + "retention is deferred to the next scheduled run", jobName, MAX_ATTEMPTS);
+                    return;
+                }
+                log.debugf("%s hit a database deadlock on attempt %d/%d; retrying",
+                        jobName, attempt, MAX_ATTEMPTS);
+                sleep(BACKOFF_MILLIS * attempt);
+            }
+        }
+    }
+
+    private static boolean isDeadlock(Throwable e) {
+        for (Throwable cause = e; cause != null; cause = cause.getCause()) {
+            if (cause instanceof LockAcquisitionException || cause instanceof PessimisticLockException) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/app/src/main/java/io/apitomy/axiom/app/CleanupRetry.java
+++ b/app/src/main/java/io/apitomy/axiom/app/CleanupRetry.java
@@ -3,69 +3,141 @@ package io.apitomy.axiom.app;
 import io.quarkus.narayana.jta.QuarkusTransaction;
 import jakarta.persistence.PessimisticLockException;
 import org.hibernate.exception.LockAcquisitionException;
+import org.hibernate.exception.LockTimeoutException;
 import org.jboss.logging.Logger;
+
+import java.sql.SQLException;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
 
 /**
  * Shared helper for the scheduled retention/cleanup jobs. Runs a unit of work in
  * a new transaction and retries a bounded number of times when the database
- * reports a deadlock ({@link LockAcquisitionException} /
- * {@link PessimisticLockException}).
+ * reports a retryable lock failure (a deadlock or a lock-acquisition timeout).
  *
- * <p>Deadlocks are expected under concurrent event ingestion (H2's MVStore uses
- * row-level locking with deadlock detection) and are safely retryable. If all
- * retries are exhausted the failure is logged at {@code WARN} rather than
- * {@code ERROR}, because the next scheduled tick will recover the deferred work.
+ * <p>Lock contention is expected under concurrent event ingestion (H2's MVStore
+ * uses row-level locking with deadlock detection and lock timeouts) and is
+ * safely retryable. Both true deadlocks ({@link LockAcquisitionException} /
+ * {@link PessimisticLockException}) and lock-acquisition timeouts
+ * ({@link LockTimeoutException} / {@link jakarta.persistence.LockTimeoutException})
+ * are treated as retryable; as a defensive fallback the underlying
+ * {@link SQLException} is also inspected for H2's deadlock (40001) and
+ * lock-timeout (50200) error codes in case a future Hibernate version maps them
+ * to a different exception type.
+ *
+ * <p>If all retries are exhausted the failure is logged at {@code WARN} rather
+ * than {@code ERROR}, because the next scheduled tick will recover the deferred
+ * work. Non-retryable exceptions are rethrown unchanged, preserving existing
+ * behavior.
  */
 final class CleanupRetry {
 
     private static final int MAX_ATTEMPTS = 3;
     private static final long BACKOFF_MILLIS = 200L;
 
+    /** H2 SQL error code for a detected deadlock (also surfaced as SQLState {@code 40001}). */
+    private static final int H2_DEADLOCK = 40001;
+    /** H2 SQL error code for a lock-acquisition timeout. */
+    private static final int H2_LOCK_TIMEOUT = 50200;
+
+    /** Default strategy: run the work in a fresh, independent transaction. */
+    private static final Consumer<Runnable> TX_RUNNER =
+            work -> QuarkusTransaction.requiringNew().run(work);
+
     private CleanupRetry() {
     }
 
     /**
-     * Executes {@code work} in a new transaction, retrying on database deadlocks.
+     * Executes {@code work} in a new transaction, retrying on database lock
+     * failures (deadlocks and lock-acquisition timeouts).
      *
-     * @param log     the logger of the calling cleanup job
-     * @param jobName a human-readable name for the job, used in log messages
-     * @param work    the cleanup work to run inside a transaction
+     * @param log          the logger of the calling cleanup job
+     * @param jobName      a human-readable name for the job, used in log messages
+     * @param shuttingDown supplies whether the application is shutting down; the
+     *                     loop aborts (without further database work) as soon as
+     *                     this returns {@code true}
+     * @param work         the cleanup work to run inside a transaction
      */
-    static void runWithRetry(Logger log, String jobName, Runnable work) {
+    static void runWithRetry(Logger log, String jobName, BooleanSupplier shuttingDown, Runnable work) {
+        runWithRetry(log, jobName, shuttingDown, work, TX_RUNNER);
+    }
+
+    /**
+     * Package-private overload allowing the transaction strategy to be supplied,
+     * so the retry/backoff/classification logic can be unit tested without a
+     * running Quarkus transaction manager.
+     */
+    static void runWithRetry(Logger log, String jobName, BooleanSupplier shuttingDown,
+                             Runnable work, Consumer<Runnable> txRunner) {
         for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+            // Re-check on every attempt so retries stop issuing DB work once
+            // shutdown has begun.
+            if (shuttingDown.getAsBoolean()) {
+                return;
+            }
             try {
-                QuarkusTransaction.requiringNew().run(work);
+                txRunner.accept(work);
                 return;
             } catch (RuntimeException e) {
-                if (!isDeadlock(e)) {
+                if (!isRetryableLockFailure(e)) {
                     throw e;
                 }
                 if (attempt == MAX_ATTEMPTS) {
-                    log.warnf("%s skipped after %d attempts due to a database deadlock; "
+                    log.warnf("%s skipped after %d attempts due to database lock contention; "
                             + "retention is deferred to the next scheduled run", jobName, MAX_ATTEMPTS);
                     return;
                 }
-                log.debugf("%s hit a database deadlock on attempt %d/%d; retrying",
+                log.debugf("%s hit database lock contention on attempt %d/%d; retrying",
                         jobName, attempt, MAX_ATTEMPTS);
-                sleep(BACKOFF_MILLIS * attempt);
+                if (!sleep(BACKOFF_MILLIS * attempt)) {
+                    // Interrupted (e.g. during shutdown) — stop retrying rather
+                    // than continue holding the worker and opening new transactions.
+                    return;
+                }
             }
         }
     }
 
-    private static boolean isDeadlock(Throwable e) {
+    /**
+     * Returns {@code true} if the given throwable (or any of its causes)
+     * represents a retryable database lock failure.
+     */
+    static boolean isRetryableLockFailure(Throwable e) {
         for (Throwable cause = e; cause != null; cause = cause.getCause()) {
-            if (cause instanceof LockAcquisitionException || cause instanceof PessimisticLockException) {
+            if (cause instanceof LockAcquisitionException
+                    || cause instanceof LockTimeoutException
+                    || cause instanceof PessimisticLockException
+                    || cause instanceof jakarta.persistence.LockTimeoutException) {
+                return true;
+            }
+            if (cause instanceof SQLException sqlEx && isRetryableSqlError(sqlEx)) {
                 return true;
             }
         }
         return false;
     }
 
-    private static void sleep(long millis) {
+    private static boolean isRetryableSqlError(SQLException e) {
+        int code = e.getErrorCode();
+        if (code == H2_DEADLOCK || code == H2_LOCK_TIMEOUT) {
+            return true;
+        }
+        return "40001".equals(e.getSQLState());
+    }
+
+    /**
+     * Sleeps for the given duration.
+     *
+     * @return {@code true} if the sleep completed, {@code false} if it was
+     *         interrupted (in which case the interrupt flag is restored)
+     */
+    private static boolean sleep(long millis) {
         try {
             Thread.sleep(millis);
+            return true;
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
+            return false;
         }
     }
 }

--- a/app/src/main/java/io/apitomy/axiom/app/EventCleanup.java
+++ b/app/src/main/java/io/apitomy/axiom/app/EventCleanup.java
@@ -9,7 +9,6 @@ import io.apitomy.axiom.core.entities.TraceEntity;
 import io.quarkus.scheduler.Scheduled;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.transaction.Transactional;
 import org.jboss.logging.Logger;
 
 import java.time.Instant;
@@ -36,12 +35,16 @@ public class EventCleanup {
     /**
      * Finds and deletes events older than the retention period.
      */
-    @Scheduled(every = "1h", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
-    @Transactional
+    @Scheduled(every = "1h", delayed = "4m",
+            concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
     void cleanup() {
         if (shuttingDown) {
             return;
         }
+        CleanupRetry.runWithRetry(LOG, "Event cleanup", this::doCleanup);
+    }
+
+    void doCleanup() {
         RetentionConfigEntity config = RetentionConfigEntity.<RetentionConfigEntity>findAll()
                 .firstResult();
         if (config == null) {

--- a/app/src/main/java/io/apitomy/axiom/app/EventCleanup.java
+++ b/app/src/main/java/io/apitomy/axiom/app/EventCleanup.java
@@ -41,7 +41,7 @@ public class EventCleanup {
         if (shuttingDown) {
             return;
         }
-        CleanupRetry.runWithRetry(LOG, "Event cleanup", this::doCleanup);
+        CleanupRetry.runWithRetry(LOG, "Event cleanup", () -> shuttingDown, this::doCleanup);
     }
 
     void doCleanup() {

--- a/app/src/main/java/io/apitomy/axiom/app/EventQueueCleanup.java
+++ b/app/src/main/java/io/apitomy/axiom/app/EventQueueCleanup.java
@@ -4,7 +4,6 @@ import io.apitomy.axiom.core.entities.EventQueueEntity;
 import io.quarkus.scheduler.Scheduled;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.transaction.Transactional;
 import org.jboss.logging.Logger;
 
 import java.time.Instant;
@@ -30,12 +29,16 @@ public class EventQueueCleanup {
     /**
      * Deletes processed event queue entries older than one day.
      */
-    @Scheduled(every = "1h", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
-    @Transactional
+    @Scheduled(every = "1h", delayed = "1m",
+            concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
     void cleanup() {
         if (shuttingDown) {
             return;
         }
+        CleanupRetry.runWithRetry(LOG, "Event queue cleanup", this::doCleanup);
+    }
+
+    void doCleanup() {
         Instant cutoff = Instant.now().minus(1, ChronoUnit.DAYS);
         long deleted = EventQueueEntity.delete(
                 "processedAt is not null and processedAt < ?1", cutoff);

--- a/app/src/main/java/io/apitomy/axiom/app/EventQueueCleanup.java
+++ b/app/src/main/java/io/apitomy/axiom/app/EventQueueCleanup.java
@@ -35,7 +35,7 @@ public class EventQueueCleanup {
         if (shuttingDown) {
             return;
         }
-        CleanupRetry.runWithRetry(LOG, "Event queue cleanup", this::doCleanup);
+        CleanupRetry.runWithRetry(LOG, "Event queue cleanup", () -> shuttingDown, this::doCleanup);
     }
 
     void doCleanup() {

--- a/app/src/main/java/io/apitomy/axiom/app/EventSourceLogCleanup.java
+++ b/app/src/main/java/io/apitomy/axiom/app/EventSourceLogCleanup.java
@@ -36,7 +36,7 @@ public class EventSourceLogCleanup {
         if (shuttingDown) {
             return;
         }
-        CleanupRetry.runWithRetry(LOG, "Event source log cleanup", this::doCleanup);
+        CleanupRetry.runWithRetry(LOG, "Event source log cleanup", () -> shuttingDown, this::doCleanup);
     }
 
     void doCleanup() {

--- a/app/src/main/java/io/apitomy/axiom/app/EventSourceLogCleanup.java
+++ b/app/src/main/java/io/apitomy/axiom/app/EventSourceLogCleanup.java
@@ -5,7 +5,6 @@ import io.apitomy.axiom.core.entities.RetentionConfigEntity;
 import io.quarkus.scheduler.Scheduled;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.transaction.Transactional;
 import org.jboss.logging.Logger;
 
 import java.time.Instant;
@@ -31,12 +30,16 @@ public class EventSourceLogCleanup {
     /**
      * Deletes event source log entries older than the retention period.
      */
-    @Scheduled(every = "1h", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
-    @Transactional
+    @Scheduled(every = "1h", delayed = "2m",
+            concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
     void cleanup() {
         if (shuttingDown) {
             return;
         }
+        CleanupRetry.runWithRetry(LOG, "Event source log cleanup", this::doCleanup);
+    }
+
+    void doCleanup() {
         RetentionConfigEntity config = RetentionConfigEntity.<RetentionConfigEntity>findAll()
                 .firstResult();
         if (config == null) {

--- a/app/src/main/java/io/apitomy/axiom/app/TraceCleanup.java
+++ b/app/src/main/java/io/apitomy/axiom/app/TraceCleanup.java
@@ -11,7 +11,6 @@ import io.apitomy.axiom.core.entities.TraceNodeEntity;
 import io.quarkus.scheduler.Scheduled;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.transaction.Transactional;
 import org.jboss.logging.Logger;
 
 import java.time.Instant;
@@ -39,12 +38,16 @@ public class TraceCleanup {
     /**
      * Finds and deletes traces older than the retention period.
      */
-    @Scheduled(every = "1h", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
-    @Transactional
+    @Scheduled(every = "1h", delayed = "3m",
+            concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
     void cleanup() {
         if (shuttingDown) {
             return;
         }
+        CleanupRetry.runWithRetry(LOG, "Trace cleanup", this::doCleanup);
+    }
+
+    void doCleanup() {
         RetentionConfigEntity config = RetentionConfigEntity.<RetentionConfigEntity>findAll()
                 .firstResult();
         if (config == null) {

--- a/app/src/main/java/io/apitomy/axiom/app/TraceCleanup.java
+++ b/app/src/main/java/io/apitomy/axiom/app/TraceCleanup.java
@@ -44,7 +44,7 @@ public class TraceCleanup {
         if (shuttingDown) {
             return;
         }
-        CleanupRetry.runWithRetry(LOG, "Trace cleanup", this::doCleanup);
+        CleanupRetry.runWithRetry(LOG, "Trace cleanup", () -> shuttingDown, this::doCleanup);
     }
 
     void doCleanup() {

--- a/app/src/test/java/io/apitomy/axiom/app/CleanupRetryTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/CleanupRetryTest.java
@@ -1,0 +1,192 @@
+package io.apitomy.axiom.app;
+
+import jakarta.persistence.PessimisticLockException;
+import org.hibernate.exception.LockAcquisitionException;
+import org.hibernate.exception.LockTimeoutException;
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link CleanupRetry}. Exercises the retry/backoff loop and the
+ * lock-failure classification directly, using an injected transaction-runner
+ * strategy so no Quarkus transaction manager is required.
+ */
+class CleanupRetryTest {
+
+    private static final Logger LOG = Logger.getLogger(CleanupRetryTest.class);
+    private static final BooleanSupplier NOT_SHUTTING_DOWN = () -> false;
+
+    // ---------------------------------------------------------------------
+    // Retry / backoff loop
+    // ---------------------------------------------------------------------
+
+    @Test
+    void runsWorkOnceOnSuccess() {
+        AtomicInteger runs = new AtomicInteger();
+        AtomicInteger txInvocations = new AtomicInteger();
+        Consumer<Runnable> txRunner = work -> {
+            txInvocations.incrementAndGet();
+            work.run();
+        };
+
+        CleanupRetry.runWithRetry(LOG, "test", NOT_SHUTTING_DOWN, runs::incrementAndGet, txRunner);
+
+        assertEquals(1, runs.get());
+        assertEquals(1, txInvocations.get());
+    }
+
+    @Test
+    void retriesOnLockFailureThenSucceeds() {
+        AtomicInteger txInvocations = new AtomicInteger();
+        Consumer<Runnable> txRunner = work -> {
+            if (txInvocations.incrementAndGet() == 1) {
+                throw deadlock();
+            }
+            work.run();
+        };
+        AtomicInteger runs = new AtomicInteger();
+
+        CleanupRetry.runWithRetry(LOG, "test", NOT_SHUTTING_DOWN, runs::incrementAndGet, txRunner);
+
+        assertEquals(2, txInvocations.get());
+        assertEquals(1, runs.get());
+    }
+
+    @Test
+    void exhaustsRetriesWithoutThrowing() {
+        AtomicInteger txInvocations = new AtomicInteger();
+        Consumer<Runnable> txRunner = work -> {
+            txInvocations.incrementAndGet();
+            throw deadlock();
+        };
+
+        // Should return normally (WARN-logged) rather than propagate.
+        CleanupRetry.runWithRetry(LOG, "test", NOT_SHUTTING_DOWN, () -> {
+        }, txRunner);
+
+        assertEquals(3, txInvocations.get());
+    }
+
+    @Test
+    void rethrowsNonRetryableException() {
+        AtomicInteger txInvocations = new AtomicInteger();
+        RuntimeException boom = new IllegalStateException("boom");
+        Consumer<Runnable> txRunner = work -> {
+            txInvocations.incrementAndGet();
+            throw boom;
+        };
+
+        RuntimeException thrown = assertThrows(IllegalStateException.class,
+                () -> CleanupRetry.runWithRetry(LOG, "test", NOT_SHUTTING_DOWN, () -> {
+                }, txRunner));
+
+        assertEquals(boom, thrown);
+        assertEquals(1, txInvocations.get());
+    }
+
+    @Test
+    void doesNotRunWorkWhenAlreadyShuttingDown() {
+        AtomicInteger txInvocations = new AtomicInteger();
+        Consumer<Runnable> txRunner = work -> {
+            txInvocations.incrementAndGet();
+            work.run();
+        };
+
+        CleanupRetry.runWithRetry(LOG, "test", () -> true, () -> {
+        }, txRunner);
+
+        assertEquals(0, txInvocations.get());
+    }
+
+    @Test
+    void stopsRetryingOnceShuttingDownMidLoop() {
+        AtomicBoolean shuttingDown = new AtomicBoolean(false);
+        AtomicInteger txInvocations = new AtomicInteger();
+        Consumer<Runnable> txRunner = work -> {
+            txInvocations.incrementAndGet();
+            // Trigger shutdown after the first (failed) attempt so the loop
+            // aborts on its next iteration instead of retrying.
+            shuttingDown.set(true);
+            throw deadlock();
+        };
+
+        CleanupRetry.runWithRetry(LOG, "test", shuttingDown::get, () -> {
+        }, txRunner);
+
+        assertEquals(1, txInvocations.get());
+    }
+
+    // ---------------------------------------------------------------------
+    // Lock-failure classification
+    // ---------------------------------------------------------------------
+
+    @Test
+    void classifiesHibernateDeadlock() {
+        assertTrue(CleanupRetry.isRetryableLockFailure(deadlock()));
+    }
+
+    @Test
+    void classifiesHibernateLockTimeout() {
+        assertTrue(CleanupRetry.isRetryableLockFailure(
+                new LockTimeoutException("lock timeout", new SQLException("timeout", null, 50200))));
+    }
+
+    @Test
+    void classifiesJakartaPessimisticLock() {
+        assertTrue(CleanupRetry.isRetryableLockFailure(new PessimisticLockException("locked")));
+    }
+
+    @Test
+    void classifiesJakartaLockTimeout() {
+        assertTrue(CleanupRetry.isRetryableLockFailure(
+                new jakarta.persistence.LockTimeoutException("timeout")));
+    }
+
+    @Test
+    void classifiesNestedCause() {
+        Throwable wrapped = new RuntimeException("wrapper",
+                new IllegalStateException("mid", deadlock()));
+        assertTrue(CleanupRetry.isRetryableLockFailure(wrapped));
+    }
+
+    @Test
+    void classifiesH2DeadlockByErrorCode() {
+        assertTrue(CleanupRetry.isRetryableLockFailure(
+                new RuntimeException(new SQLException("deadlock", "40001", 40001))));
+    }
+
+    @Test
+    void classifiesH2LockTimeoutByErrorCode() {
+        assertTrue(CleanupRetry.isRetryableLockFailure(
+                new RuntimeException(new SQLException("lock timeout", "HY000", 50200))));
+    }
+
+    @Test
+    void classifiesBySqlState40001() {
+        assertTrue(CleanupRetry.isRetryableLockFailure(
+                new RuntimeException(new SQLException("deadlock", "40001", 0))));
+    }
+
+    @Test
+    void nonLockFailureIsNotRetryable() {
+        assertFalse(CleanupRetry.isRetryableLockFailure(new IllegalStateException("boom")));
+        assertFalse(CleanupRetry.isRetryableLockFailure(
+                new RuntimeException(new SQLException("syntax error", "42000", 42000))));
+    }
+
+    private static LockAcquisitionException deadlock() {
+        return new LockAcquisitionException("deadlock detected",
+                new SQLException("deadlock", "40001", 40001));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the intermittent H2 lock contention (`LockAcquisitionException` / `PessimisticLockException` /
`LockTimeoutException`) that caused `EventCleanup.cleanup()` (and the other retention jobs) to fail at
`ERROR` level when running concurrently with the event-ingestion pipeline.

This applies the two complementary changes proposed in the issue:

### 1. Retry on lock contention (correctness)
Added a shared `CleanupRetry` helper that runs a cleanup body in a fresh transaction
(`QuarkusTransaction.requiringNew()` — the same pattern already used in `PipelineOrchestrator`) and retries a
bounded number of times (3 attempts) with a short escalating backoff when a retryable lock failure is
detected. Both true deadlocks (`LockAcquisitionException` / `PessimisticLockException`) **and
lock-acquisition timeouts** (`LockTimeoutException`, Hibernate and JPA variants) are treated as retryable,
checked through the full cause chain. As a defensive fallback the underlying `SQLException` is also inspected
for H2's deadlock (`40001`) and lock-timeout (`50200`) error codes, in case a future Hibernate version maps
them to a different exception type. Lock contention in H2 is expected and safely retryable. If all retries
are exhausted, the failure is logged at `WARN` (not `ERROR`) since the next scheduled tick recovers the
deferred work. Non-retryable exceptions are rethrown unchanged, preserving existing behavior.

Each cleanup job's transactional body was extracted into a `doCleanup()` method and the `@Transactional`
annotation on the scheduled method was removed (the transaction is now managed by `CleanupRetry`). The
retry logic is applied consistently to all four cleanup jobs.

The retry loop also re-checks each job's `shuttingDown` flag before every attempt and aborts if the backoff
sleep is interrupted, so retries stop issuing database work once application shutdown has begun.

### 2. Stagger the schedules (contention reduction)
Added distinct `delayed` offsets to the four cleanup jobs so they no longer all fire simultaneously at boot
alongside the poller's first ingest (the maximum-contention window):

- `EventQueueCleanup` → `delayed = "1m"`
- `EventSourceLogCleanup` → `delayed = "2m"`
- `TraceCleanup` → `delayed = "3m"`
- `EventCleanup` → `delayed = "4m"`

## Files changed
- `app/src/main/java/io/apitomy/axiom/app/CleanupRetry.java` (new) — shared lock-contention retry helper
- `app/src/main/java/io/apitomy/axiom/app/EventCleanup.java`
- `app/src/main/java/io/apitomy/axiom/app/EventQueueCleanup.java`
- `app/src/main/java/io/apitomy/axiom/app/TraceCleanup.java`
- `app/src/main/java/io/apitomy/axiom/app/EventSourceLogCleanup.java`
- `app/src/test/java/io/apitomy/axiom/app/CleanupRetryTest.java` (new) — unit tests for the retry loop,
  shutdown handling, and lock-failure classification

## Acceptance criteria
- [x] Cleanup jobs retry on retryable lock failures — deadlocks (`LockAcquisitionException` /
  `PessimisticLockException`) and lock-acquisition timeouts (`LockTimeoutException`) — with bounded retries
  and backoff.
- [x] Exhausted retries log at `WARN`, not `ERROR`.
- [x] The four cleanup jobs are staggered so they do not all fire simultaneously at startup.
- [x] Retry logic is applied consistently to the other cleanup jobs.

Fixes #263
