### PR TITLE
feat: cascade delete workflow definition versions, runs, and tasks

### DIFF
--- a/app/src/main/java/io/apitomy/axiom/app/rest/WorkflowDefinitionsResourceImpl.java
+++ b/app/src/main/java/io/apitomy/axiom/app/rest/WorkflowDefinitionsResourceImpl.java
@@ -10,6 +10,7 @@ import io.apitomy.axiom.api.beans.WorkflowDefinition;
 import io.apitomy.axiom.api.beans.WorkflowDefinitionSearchResults;
 import io.apitomy.axiom.api.beans.WorkflowDefinitionVersion;
 import io.apitomy.axiom.app.WorkflowRunBeanMapper;
+import io.apitomy.axiom.core.entities.TaskEntity;
 import io.apitomy.axiom.core.entities.WorkflowDefinitionEntity;
 import io.apitomy.axiom.core.entities.WorkflowDefinitionVersionEntity;
 import io.apitomy.axiom.core.entities.WorkflowRunEntity;
@@ -154,6 +155,27 @@ public class WorkflowDefinitionsResourceImpl implements WorkflowResource {
     @Transactional
     public void deleteWorkflowDefinition(long workflowDefinitionId) {
         WorkflowDefinitionEntity entity = findOrThrow(workflowDefinitionId);
+
+        // Cascade delete everything that references this workflow definition. Deletes are
+        // performed explicitly (rather than relying on database ON DELETE CASCADE) so the
+        // behavior is deterministic across database engines.
+        List<Long> runIds = WorkflowRunEntity
+                .<WorkflowRunEntity>list("definitionId", workflowDefinitionId)
+                .stream()
+                .map(run -> run.id)
+                .toList();
+
+        if (!runIds.isEmpty()) {
+            // Delete human tasks belonging to the runs first (task.workflow_run_id FK).
+            TaskEntity.delete("workflowRunId in ?1", runIds);
+            // Then delete the runs themselves.
+            WorkflowRunEntity.delete("definitionId", workflowDefinitionId);
+        }
+
+        // Delete the published versions of the definition.
+        WorkflowDefinitionVersionEntity.delete("definitionId", workflowDefinitionId);
+
+        // Finally delete the definition itself.
         entity.delete();
     }
 

--- a/app/src/test/java/io/apitomy/axiom/app/WorkflowRunsResourceTest.java
+++ b/app/src/test/java/io/apitomy/axiom/app/WorkflowRunsResourceTest.java
@@ -4,6 +4,7 @@ import io.apitomy.axiom.agents.spi.AgentResult;
 import io.apitomy.axiom.core.entities.TaskEntity;
 import io.apitomy.axiom.core.entities.TraceEntity;
 import io.apitomy.axiom.core.entities.TraceNodeEntity;
+import io.apitomy.axiom.core.entities.WorkflowDefinitionVersionEntity;
 import io.apitomy.axiom.core.entities.WorkflowRunEntity;
 import io.quarkus.narayana.jta.QuarkusTransaction;
 import io.quarkus.test.junit.QuarkusTest;
@@ -488,5 +489,56 @@ class WorkflowRunsResourceTest {
         given()
                 .when().get(WORKFLOWS_PATH + "/999999/runs")
                 .then().statusCode(404);
+    }
+
+    /**
+     * Verifies that deleting a workflow definition cascades to its published
+     * versions, its runs, and the tasks belonging to those runs.
+     */
+    @Test
+    void deletingDefinitionCascadesVersionsRunsAndTasks() {
+        int projectId = createProject("WF Cascade Delete Project");
+        int definitionId = createAndPublishActionWorkflow("Cascade Delete WF");
+
+        // Trigger the action workflow so it stops at the action node, creating a
+        // run (and a task) that reference the definition.
+        Integer runId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"workflowDefinitionId\": %d}".formatted(definitionId))
+                .when().post(PROJECTS_PATH + "/" + projectId + "/workflow")
+                .then().statusCode(200).body("status", equalTo("waiting"))
+                .extract().path("runId");
+
+        // Sanity check: the version, run, and task all exist before deletion.
+        long runId_ = runId.longValue();
+        long definitionId_ = definitionId;
+        long[] before = QuarkusTransaction.requiringNew().call(() -> new long[] {
+                WorkflowDefinitionVersionEntity.count("definitionId", definitionId_),
+                WorkflowRunEntity.count("definitionId", definitionId_),
+                TaskEntity.count("workflowRunId", runId_)
+        });
+        assertEquals(1, before[0], "Version should exist before delete");
+        assertEquals(1, before[1], "Run should exist before delete");
+        assertEquals(1, before[2], "Task should exist before delete");
+
+        // Delete the definition.
+        given()
+                .when().delete(WORKFLOWS_PATH + "/" + definitionId)
+                .then().statusCode(204);
+
+        // The definition is gone.
+        given()
+                .when().get(WORKFLOWS_PATH + "/" + definitionId)
+                .then().statusCode(404);
+
+        // Versions, runs, and tasks are all cascaded away.
+        long[] after = QuarkusTransaction.requiringNew().call(() -> new long[] {
+                WorkflowDefinitionVersionEntity.count("definitionId", definitionId_),
+                WorkflowRunEntity.count("definitionId", definitionId_),
+                TaskEntity.count("workflowRunId", runId_)
+        });
+        assertEquals(0, after[0], "Versions should be deleted");
+        assertEquals(0, after[1], "Runs should be deleted");
+        assertEquals(0, after[2], "Tasks should be deleted");
     }
 }

--- a/ui/src/pages/WorkflowDefinitionDetailPage.tsx
+++ b/ui/src/pages/WorkflowDefinitionDetailPage.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useEffectiveTheme } from "../hooks/useTheme";
 import { useParams, Link, useNavigate } from "react-router-dom";
 import {
+    Alert,
+    AlertActionCloseButton,
     Breadcrumb,
     BreadcrumbItem,
     Button,
@@ -96,6 +98,7 @@ export function WorkflowDefinitionDetailPage() {
     const [editMetadataOpen, setEditMetadataOpen] = useState(false);
     const [metadataForm, setMetadataForm] = useState({ name: "", description: "" });
     const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+    const [deleteError, setDeleteError] = useState<string | null>(null);
 
     // EditorSpi for action types — memoized to avoid re-renders
     const spi: EditorSpi = useMemo(() => ({
@@ -243,12 +246,15 @@ export function WorkflowDefinitionDetailPage() {
     };
 
     const handleDelete = () => {
+        setDeleteError(null);
         deleteWorkflowDefinition(id)
             .then(() => {
+                setDeleteConfirmOpen(false);
                 navigate("/components/workflows");
             })
             .catch((err) => {
                 console.error("Failed to delete workflow definition:", err);
+                setDeleteError("Failed to delete this workflow. Please try again.");
             });
     };
 
@@ -585,9 +591,20 @@ export function WorkflowDefinitionDetailPage() {
                 isOpen={deleteConfirmOpen}
                 title="Delete Workflow Definition"
                 onConfirm={handleDelete}
-                onCancel={() => setDeleteConfirmOpen(false)}
+                onCancel={() => { setDeleteConfirmOpen(false); setDeleteError(null); }}
             >
-                Delete workflow definition &quot;{definition.name}&quot;? This action cannot be undone.
+                {deleteError && (
+                    <Alert
+                        variant="danger"
+                        isInline
+                        title={deleteError}
+                        actionClose={<AlertActionCloseButton onClose={() => setDeleteError(null)} />}
+                        style={{ marginBottom: "16px" }}
+                    />
+                )}
+                Delete workflow definition &quot;{definition.name}&quot;? This will permanently
+                delete the workflow, all of its versions, and all of its runs and their
+                tasks. This action cannot be undone.
             </ConfirmDeleteModal>
         </PageSection>
     );

--- a/ui/src/pages/WorkflowDefinitionsPage.tsx
+++ b/ui/src/pages/WorkflowDefinitionsPage.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import {
+    Alert,
+    AlertActionCloseButton,
     Button,
     EmptyState,
     EmptyStateBody,
@@ -52,6 +54,7 @@ export function WorkflowDefinitionsPage() {
     const [loading, setLoading] = useState(true);
     const [isCreateOpen, setIsCreateOpen] = useState(false);
     const [deleteTarget, setDeleteTarget] = useState<number | null>(null);
+    const [deleteError, setDeleteError] = useState<string | null>(null);
     const [newName, setNewName] = useState("");
     const [newDescription, setNewDescription] = useState("");
 
@@ -118,14 +121,24 @@ export function WorkflowDefinitionsPage() {
 
     const handleDelete = (e: React.MouseEvent, id: number) => {
         e.stopPropagation();
+        setDeleteError(null);
         setDeleteTarget(id);
     };
 
     const confirmDelete = () => {
-        if (deleteTarget !== null) {
-            deleteWorkflowDefinition(deleteTarget).then(load).catch(console.error);
-            setDeleteTarget(null);
+        if (deleteTarget === null) {
+            return;
         }
+        setDeleteError(null);
+        deleteWorkflowDefinition(deleteTarget)
+            .then(() => {
+                setDeleteTarget(null);
+                load();
+            })
+            .catch((err) => {
+                console.error("Failed to delete workflow definition:", err);
+                setDeleteError("Failed to delete this workflow. Please try again.");
+            });
     };
 
     const formatDate = (dateString: string) => {
@@ -252,8 +265,20 @@ export function WorkflowDefinitionsPage() {
             </div>
 
             <ConfirmDeleteModal isOpen={deleteTarget !== null} title="Delete Workflow Definition"
-                onConfirm={confirmDelete} onCancel={() => setDeleteTarget(null)}>
-                Delete this workflow definition?
+                onConfirm={confirmDelete}
+                onCancel={() => { setDeleteTarget(null); setDeleteError(null); }}>
+                {deleteError && (
+                    <Alert
+                        variant="danger"
+                        isInline
+                        title={deleteError}
+                        actionClose={<AlertActionCloseButton onClose={() => setDeleteError(null)} />}
+                        style={{ marginBottom: "16px" }}
+                    />
+                )}
+                Delete this workflow definition? This will permanently delete the workflow,
+                all of its versions, and all of its runs and their tasks. This action cannot
+                be undone.
             </ConfirmDeleteModal>
 
             <Modal isOpen={isCreateOpen} onClose={() => setIsCreateOpen(false)} variant="small">


### PR DESCRIPTION
## Summary

Deleting a workflow definition failed when it had a non-zero number of runs, because
`workflow_run.definition_id` has no `ON DELETE CASCADE` and nothing cleaned up the dependent rows.
This change makes deletion cascade to everything that references the definition, and improves the UI
so the user knows what will be removed and sees an error if the delete fails.

## Backend

`WorkflowDefinitionsResourceImpl.deleteWorkflowDefinition` now removes all dependent data within its
existing transaction, in order:

1. Human tasks belonging to the definition's runs (`task.workflow_run_id`)
2. The runs themselves (`workflow_run.definition_id`)
3. The published versions (`workflow_definition_version.definition_id`)
4. The definition itself

Deletes are performed explicitly in Java rather than relying on database-level `ON DELETE CASCADE`.
This was necessary because H2 did not actually cascade the version rows (caught by the new test), and
it makes the behavior deterministic across database engines. Traces are only value-linked (no DB FK)
and are intentionally left in place.

## UI

- The delete confirmation on both the workflow list and detail pages now warns that all versions,
  runs, and tasks will be permanently deleted.
- Delete failures now surface a dismissible inline danger alert (matching the existing PatternFly
  pattern used elsewhere) instead of only logging to the console. The confirmation modal stays open on
  failure so the user keeps context.

## Testing

- Added `WorkflowRunsResourceTest.deletingDefinitionCascadesVersionsRunsAndTasks`, an end-to-end test
  that triggers an action workflow (creating a version, run, and task), deletes the definition, and
  asserts the definition 404s and the version, run, and task rows are all gone.
- `./build.sh` — `BUILD SUCCESS`, 402 tests, 0 failures.
- `npm run build` (ui) — clean.