### PR TITLE
Workflow tab: allow running a new workflow when current run is terminal

### DIFF
--- a/ui/src/components/WorkflowTab.tsx
+++ b/ui/src/components/WorkflowTab.tsx
@@ -183,6 +183,65 @@ export function WorkflowTab({
             return items;
         }, [instance, navigate]);
 
+    const triggerModal = (
+        <Modal isOpen={isTriggerOpen}
+            onClose={() => { setIsTriggerOpen(false); setTriggerError(null); }}
+            variant="medium">
+            <ModalHeader title="Run Workflow" />
+            <ModalBody>
+                {triggerError && (
+                    <Alert variant="danger" isInline
+                        title="Failed to run workflow"
+                        style={{ marginBottom: "16px" }}>
+                        {triggerError}
+                    </Alert>
+                )}
+                {definitions.length === 0 ? (
+                    <EmptyState>
+                        <EmptyStateBody>
+                            No published workflow definitions
+                            available.
+                        </EmptyStateBody>
+                    </EmptyState>
+                ) : (
+                    <Form>
+                        <FormGroup label="Workflow Definition"
+                            isRequired fieldId="wf-def">
+                            <FormSelect id="wf-def"
+                                value={selectedDefId}
+                                onChange={(_e, v) =>
+                                    setSelectedDefId(v)}>
+                                {definitions.map((d) => (
+                                    <FormSelectOption
+                                        key={d.id}
+                                        value={String(d.id)}
+                                        label={`${d.name} (v${d.currentVersion})`}
+                                    />
+                                ))}
+                            </FormSelect>
+                        </FormGroup>
+                    </Form>
+                )}
+            </ModalBody>
+            <ModalFooter>
+                <Button variant="primary"
+                    onClick={handleTrigger}
+                    isDisabled={
+                        !selectedDefId
+                        || definitions.length === 0
+                        || submitting}
+                    isLoading={submitting}>
+                    Run Workflow
+                </Button>
+                <Button variant="link"
+                    onClick={
+                        () => { setIsTriggerOpen(false); setTriggerError(null); }}>
+                    Cancel
+                </Button>
+            </ModalFooter>
+        </Modal>
+    );
+
     if (loading) {
         return <EmptyState><EmptyStateBody>
             Loading...
@@ -202,68 +261,16 @@ export function WorkflowTab({
                     </Button>
                 </EmptyState>
 
-                <Modal isOpen={isTriggerOpen}
-                    onClose={() => { setIsTriggerOpen(false); setTriggerError(null); }}
-                    variant="medium">
-                    <ModalHeader title="Run Workflow" />
-                    <ModalBody>
-                        {triggerError && (
-                            <Alert variant="danger" isInline
-                                title="Failed to run workflow"
-                                style={{ marginBottom: "16px" }}>
-                                {triggerError}
-                            </Alert>
-                        )}
-                        {definitions.length === 0 ? (
-                            <EmptyState>
-                                <EmptyStateBody>
-                                    No published workflow definitions
-                                    available.
-                                </EmptyStateBody>
-                            </EmptyState>
-                        ) : (
-                            <Form>
-                                <FormGroup label="Workflow Definition"
-                                    isRequired fieldId="wf-def">
-                                    <FormSelect id="wf-def"
-                                        value={selectedDefId}
-                                        onChange={(_e, v) =>
-                                            setSelectedDefId(v)}>
-                                        {definitions.map((d) => (
-                                            <FormSelectOption
-                                                key={d.id}
-                                                value={String(d.id)}
-                                                label={`${d.name} (v${d.currentVersion})`}
-                                            />
-                                        ))}
-                                    </FormSelect>
-                                </FormGroup>
-                            </Form>
-                        )}
-                    </ModalBody>
-                    <ModalFooter>
-                        <Button variant="primary"
-                            onClick={handleTrigger}
-                            isDisabled={
-                                !selectedDefId
-                                || definitions.length === 0
-                                || submitting}
-                            isLoading={submitting}>
-                            Run Workflow
-                        </Button>
-                        <Button variant="link"
-                            onClick={
-                                () => { setIsTriggerOpen(false); setTriggerError(null); }}>
-                            Cancel
-                        </Button>
-                    </ModalFooter>
-                </Modal>
+                {triggerModal}
             </>
         );
     }
 
     const isActive = instance.status === "running"
         || instance.status === "waiting";
+    const isTerminal = instance.status === "completed"
+        || instance.status === "failed"
+        || instance.status === "cancelled";
 
     return (
         <div style={{
@@ -316,6 +323,14 @@ export function WorkflowTab({
                         </Button>
                     </FlexItem>
                 )}
+                {isTerminal && (
+                    <FlexItem>
+                        <Button variant="primary"
+                            onClick={openTriggerModal}>
+                            Run Workflow
+                        </Button>
+                    </FlexItem>
+                )}
                 <FlexItem>
                     <Link to={`/logs/workflow-runs/${instance.id}`}>
                         View run details →
@@ -365,6 +380,8 @@ export function WorkflowTab({
                 taskId={logTaskId}
                 onClose={() => setIsLogOpen(false)}
             />
+
+            {triggerModal}
         </div>
     );
 }


### PR DESCRIPTION
## Summary

On a project's **Workflow** tab, the "Run Workflow" button previously only appeared in the empty-state branch (when the project had never run a workflow). Once any run existed — including a finished one (`completed`, `failed`, or `cancelled`) — the tab switched to the run viewer, which offered no way to start a new run.

This PR adds a **Run Workflow** button to the viewer branch of `WorkflowTab.tsx` that appears when the current instance is in a terminal state.

## Changes

- Extracted the existing trigger (workflow-definition picker) modal into a reusable `triggerModal` JSX variable so it can be rendered from both the empty-state and viewer branches.
- Added an `isTerminal` check (`completed`/`failed`/`cancelled`) and a primary **Run Workflow** button in the viewer's header row. It reuses the existing `openTriggerModal` / `handleTrigger` flow and refreshes on success (SSE `workflow-updated` also reloads).
- The button is mutually exclusive with the existing **Cancel Workflow** button, which only shows while a run is active (`running`/`waiting`), consistent with the backend's 409 guard.

## Files modified

- `ui/src/components/WorkflowTab.tsx`

Fixes #311