### PR TITLE
Validate {{inputs.*}} placeholders against declared inputs

### DIFF
--- a/app/src/test/java/io/apitomy/axiom/core/services/ActionTypeValidatorTest.java
+++ b/app/src/test/java/io/apitomy/axiom/core/services/ActionTypeValidatorTest.java
@@ -150,11 +150,45 @@ class ActionTypeValidatorTest {
     }
 
     @Test
-    void actorPromptWithInputsDottedPlaceholderIsValid() {
+    void actorPromptWithDeclaredInputsDottedPlaceholderIsValid() {
         NewActionType at = makeActor("test", "desc",
                 "Process {{inputs.repository}} and {{inputs.branch}}");
+        at.setInputs(List.of(
+                field("repository", ActionTypeField.Type.STRING),
+                field("branch", ActionTypeField.Type.STRING)));
 
         assertFalse(ActionTypeValidator.validate(at).hasErrors());
+    }
+
+    @Test
+    void actorPromptWithUndeclaredInputPlaceholderIsError() {
+        NewActionType at = makeActor("test", "desc", "Process {{inputs.foo}}");
+
+        ValidationResult result = ActionTypeValidator.validate(at);
+
+        assertTrue(result.hasErrors());
+        assertTrue(result.errors().stream().anyMatch(
+                m -> m.field().equals("promptTemplate") && m.message().contains("{{inputs.foo}}")));
+    }
+
+    @Test
+    void scriptWithDeclaredInputsDottedPlaceholderIsValid() {
+        NewActionType at = makeScript("test", "desc",
+                "echo {{inputs.repository}} {{projectId}}");
+        at.setInputs(List.of(field("repository", ActionTypeField.Type.STRING)));
+
+        assertFalse(ActionTypeValidator.validate(at).hasErrors());
+    }
+
+    @Test
+    void scriptWithUndeclaredInputPlaceholderIsError() {
+        NewActionType at = makeScript("test", "desc", "echo {{inputs.foo}}");
+
+        ValidationResult result = ActionTypeValidator.validate(at);
+
+        assertTrue(result.hasErrors());
+        assertTrue(result.errors().stream().anyMatch(
+                m -> m.field().equals("scriptTemplate") && m.message().contains("{{inputs.foo}}")));
     }
 
     @Test

--- a/core/src/main/java/io/apitomy/axiom/core/services/ActionTypeValidator.java
+++ b/core/src/main/java/io/apitomy/axiom/core/services/ActionTypeValidator.java
@@ -21,6 +21,10 @@ public final class ActionTypeValidator {
 
     private static final Pattern PLACEHOLDER_PATTERN =
             Pattern.compile("\\{\\{([a-zA-Z_][a-zA-Z0-9_]*)\\}\\}");
+    private static final Pattern INPUT_PLACEHOLDER_PATTERN =
+            Pattern.compile("\\{\\{inputs\\.([a-zA-Z_][a-zA-Z0-9_]*)\\}\\}");
+    private static final Pattern VALID_SHELL_IDENTIFIER_PATTERN =
+            Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_]*$");
     private static final Pattern MALFORMED_PLACEHOLDER_PATTERN =
             Pattern.compile("\\{\\{\\s+|\\s+\\}\\}|\\{\\{[^}]*$");
     private static final Set<String> RECOGNIZED_PROMPT_PLACEHOLDERS = Set.of(
@@ -131,6 +135,8 @@ public final class ActionTypeValidator {
                                 + RECOGNIZED_PROMPT_PLACEHOLDERS + "."));
             }
         }
+
+        checkInputPlaceholders(prompt, "promptTemplate", def, messages);
     }
 
     private static void validateScriptTemplate(NewActionType def, List<ValidationMessage> messages) {
@@ -153,6 +159,23 @@ public final class ActionTypeValidator {
                 messages.add(error("scriptTemplate",
                         "Unrecognized placeholder '{{" + name + "}}'. Supported: "
                                 + RECOGNIZED_SCRIPT_PLACEHOLDERS + "."));
+            }
+        }
+
+        checkInputPlaceholders(script, "scriptTemplate", def, messages);
+
+        // Script binding only substitutes inputs whose names are valid shell
+        // identifiers; any other declared input is silently skipped at runtime.
+        if (def.getInputs() != null) {
+            for (io.apitomy.axiom.api.beans.ActionTypeField f : def.getInputs()) {
+                String name = f.getName();
+                if (name != null && !name.isBlank()
+                        && !VALID_SHELL_IDENTIFIER_PATTERN.matcher(name).matches()) {
+                    messages.add(warning("scriptTemplate",
+                            "Declared input '" + name + "' is not a valid shell identifier "
+                                    + "and will be skipped by the script binding path. "
+                                    + "Use letters, digits, and underscores; must not start with a digit."));
+                }
             }
         }
     }
@@ -280,6 +303,33 @@ public final class ActionTypeValidator {
                 messages.add(error(field, "Field type is required."));
             }
         }
+    }
+
+    private static void checkInputPlaceholders(String text, String field, NewActionType def,
+                                               List<ValidationMessage> messages) {
+        Set<String> declared = declaredInputNames(def);
+        Matcher matcher = INPUT_PLACEHOLDER_PATTERN.matcher(text);
+        while (matcher.find()) {
+            String name = matcher.group(1);
+            if (!declared.contains(name)) {
+                messages.add(error(field,
+                        "References undeclared input '{{inputs." + name + "}}'. "
+                                + "Declare '" + name + "' in the action type's inputs "
+                                + "or fix the placeholder name."));
+            }
+        }
+    }
+
+    private static Set<String> declaredInputNames(NewActionType def) {
+        Set<String> names = new HashSet<>();
+        if (def.getInputs() != null) {
+            for (io.apitomy.axiom.api.beans.ActionTypeField f : def.getInputs()) {
+                if (f.getName() != null && !f.getName().isBlank()) {
+                    names.add(f.getName());
+                }
+            }
+        }
+        return names;
     }
 
     private static void checkMalformedPlaceholders(String text, String field,


### PR DESCRIPTION
## Summary

`ActionTypeValidator` previously ignored dotted `{{inputs.NAME}}` placeholders because the placeholder scan only matched a simple identifier (no dot). As a result, referencing an undeclared or misspelled input (e.g. `{{inputs.foo}}`) produced no validation error and failed silently at runtime.

## Changes

- Added `INPUT_PLACEHOLDER_PATTERN` to capture dotted `{{inputs.NAME}}` references.
- Added `checkInputPlaceholders(...)` which cross-references each referenced input name against the action type's declared `inputs` and emits an **error** when the referenced input is not declared. This is wired into both `validatePromptTemplate` (agent mode) and `validateScriptTemplate` (script mode).
- For script-mode action types, added a **warning** when a declared input name is not a valid shell identifier, since such inputs are silently skipped by the script binding path.
- Updated the existing `{{inputs.*}}` test to declare the referenced inputs, and added unit tests covering the undeclared-input error case (prompt and script) and the declared happy-path (prompt and script).

## Acceptance criteria

- ✅ Validating an action type whose template references `{{inputs.foo}}` while `foo` is not declared yields a validation error identifying the offending placeholder.
- ✅ Declared-and-referenced inputs continue to validate cleanly.
- ✅ `ActionTypeValidatorTest` covers the undeclared-input and happy-path cases.

## Files modified

- `core/src/main/java/io/apitomy/axiom/core/services/ActionTypeValidator.java`
- `app/src/test/java/io/apitomy/axiom/core/services/ActionTypeValidatorTest.java`

Fixes #310